### PR TITLE
Add DNS record forwarding to email via new API and UI component

### DIFF
--- a/apps/backend/domain/src/routes/domain/verify-dns/verify-dns.controllers.ts
+++ b/apps/backend/domain/src/routes/domain/verify-dns/verify-dns.controllers.ts
@@ -1,3 +1,4 @@
+import { BusEvent, bus } from "@reloop/bus";
 import { DOMAIN_VERIFY_WEBHOOK_EVENT } from "@reloop/webhook-events";
 
 import { useLogger } from "evlog/elysia";
@@ -39,6 +40,45 @@ export async function verifyDNSRecordController({
 		};
 	} catch (error) {
 		log.error("Error verifying DNS records");
+		throw error;
+	}
+}
+
+export async function forwardDNSController({
+	domainId,
+	email,
+	organizationId,
+}: {
+	domainId: string;
+	email: string;
+	organizationId: string;
+}) {
+	const log = useLogger();
+	try {
+		const { domainWithRecords } = await fetchDomain_step1({
+			domainId,
+			organizationId,
+		});
+
+		const records = (domainWithRecords.dnsRecords || []).map((r) => ({
+			type: r.recordType,
+			name: r.name,
+			value: r.value,
+			priority: r.priority ?? undefined,
+		}));
+
+		await bus.publish(BusEvent.DNS_CONFIG_REQUESTED, {
+			email,
+			domain: domainWithRecords.domain,
+			records,
+		});
+
+		log.info(
+			`Forwarded DNS configuration for ${domainWithRecords.domain} to ${email}`,
+		);
+		return { success: true };
+	} catch (error) {
+		log.error("Error forwarding DNS configuration");
 		throw error;
 	}
 }

--- a/apps/backend/domain/src/routes/domain/verify-dns/verify-dns.route.ts
+++ b/apps/backend/domain/src/routes/domain/verify-dns/verify-dns.route.ts
@@ -76,5 +76,6 @@ export const verifyDNSRecordRoute = new Elysia()
 				description:
 					"Forwards DNS configuration records of a domain to an email address",
 			},
+			afterResponse: auditLogHook({ action: "forwarded", successStatus: 200 }),
 		},
 	);

--- a/apps/backend/domain/src/routes/domain/verify-dns/verify-dns.route.ts
+++ b/apps/backend/domain/src/routes/domain/verify-dns/verify-dns.route.ts
@@ -1,9 +1,13 @@
+import { ErrorResponseSchema } from "@reloop/domain/error/domain.error-response";
 import { authMiddleware } from "@reloop/domain/middleware/auth";
 import { rateLimitPlugin } from "@reloop/domain/middleware/rate-limit";
 import { DomainModel } from "@reloop/domain/model/domain.model";
 import { auditLogHook } from "@reloop/domain/utils/audit-log";
 import { Elysia, t } from "elysia";
-import { verifyDNSRecordController } from "./verify-dns.controllers";
+import {
+	forwardDNSController,
+	verifyDNSRecordController,
+} from "./verify-dns.controllers";
 import { verifyDNSXCodeSamples } from "./verify-dns.x-codeSamples";
 
 export const verifyDNSRecordRoute = new Elysia()
@@ -38,5 +42,39 @@ export const verifyDNSRecordRoute = new Elysia()
 				"x-codeSamples": verifyDNSXCodeSamples,
 			},
 			afterResponse: auditLogHook({ action: "verified", successStatus: 200 }),
+		},
+	)
+	.post(
+		"/verify/:domain_id/forward-dns",
+		async ({ params: { domain_id }, body: { email }, organizationId }) => {
+			return await forwardDNSController({
+				domainId: domain_id,
+				email,
+				organizationId,
+			});
+		},
+		{
+			auth: true,
+			rateLimit: true,
+			params: t.Object({
+				domain_id: t.String(),
+			}),
+			body: t.Object({
+				email: t.String({ format: "email" }),
+			}),
+			response: {
+				200: t.Object({
+					success: t.Boolean(),
+				}),
+				400: ErrorResponseSchema,
+				404: ErrorResponseSchema,
+				403: ErrorResponseSchema,
+			},
+			detail: {
+				tags: ["Domains"],
+				summary: "Forward DNS Records",
+				description:
+					"Forwards DNS configuration records of a domain to an email address",
+			},
 		},
 	);

--- a/apps/frontend/dashboard/src/app/(protected)/(layout)/domain/add/[domainId]/components/forward-dns-records.tsx
+++ b/apps/frontend/dashboard/src/app/(protected)/(layout)/domain/add/[domainId]/components/forward-dns-records.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import * as Button from "@reloop/ui/button";
+import { cn } from "@reloop/ui/cn";
+import { Icon } from "@reloop/ui/icon";
+import * as Input from "@reloop/ui/input";
+import * as Popover from "@reloop/ui/popover";
+import Spinner from "@reloop/ui/spinner";
+import axios from "axios";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+
+interface ForwardDNSRecordsButtonProps {
+	domainId: string;
+}
+
+export const ForwardDNSRecordsButton = ({
+	domainId,
+}: ForwardDNSRecordsButtonProps) => {
+	const [isOpen, setIsOpen] = useState(false);
+	const [email, setEmail] = useState("");
+	const [isSending, setIsSending] = useState(false);
+
+	useEffect(() => {
+		if (!isOpen) {
+			setEmail("");
+			setIsSending(false);
+		}
+	}, [isOpen]);
+
+	const handleForward = async (e: React.FormEvent) => {
+		e.preventDefault();
+		if (!email.trim() || !domainId) return;
+
+		setIsSending(true);
+		try {
+			await axios.post(
+				`/api/domain/v1/verify/${domainId}/forward-dns`,
+				{ email },
+				{ headers: { credentials: "include" } },
+			);
+			toast.success("DNS records forwarded successfully");
+			setIsOpen(false);
+		} catch (error) {
+			const errorMessage = axios.isAxiosError(error)
+				? error.response?.data?.message || "Failed to forward DNS records"
+				: "Failed to forward DNS records";
+			toast.error(errorMessage);
+		} finally {
+			setIsSending(false);
+		}
+	};
+
+	return (
+		<Popover.Root open={isOpen} onOpenChange={setIsOpen}>
+			<Popover.Trigger asChild>
+				<Button.Root
+					variant="neutral"
+					mode="stroke"
+					size="xsmall"
+					className={cn("gap-1.5", isOpen && "bg-bg-weak-50")}
+				>
+					<Icon name="mail-single" className="h-4 w-4" />
+					Forward records
+				</Button.Root>
+			</Popover.Trigger>
+			<Popover.Content
+				align="end"
+				sideOffset={8}
+				showArrow={false}
+				className="w-[280px] p-4"
+			>
+				<form onSubmit={handleForward} className="flex flex-col gap-2">
+					<div className="space-y-1">
+						<h3 className="font-semibold text-sm text-text-strong-950">
+							Forward DNS records
+						</h3>
+					</div>
+					<Input.Root size="small" className="w-full">
+						<Input.Wrapper>
+							<Input.Icon
+								as={Icon}
+								name="mail-single"
+								className="text-text-soft-400"
+							/>
+							<Input.Input
+								type="email"
+								placeholder="Enter email"
+								value={email}
+								onChange={(e) => setEmail(e.target.value)}
+								required
+								disabled={isSending}
+							/>
+							<button
+								type="submit"
+								disabled={isSending || !email.trim()}
+								className="flex items-center justify-center rounded p-1 text-text-sub-600 outline-none transition duration-150 hover:bg-neutral-alpha-10 disabled:text-text-disabled-300"
+							>
+								{isSending ? (
+									<Spinner size={14} color="currentColor" />
+								) : (
+									<Icon name="send-1" className="h-4 w-4" />
+								)}
+							</button>
+						</Input.Wrapper>
+					</Input.Root>
+				</form>
+			</Popover.Content>
+		</Popover.Root>
+	);
+};

--- a/apps/frontend/dashboard/src/app/(protected)/(layout)/domain/add/[domainId]/components/forward-dns-records.tsx
+++ b/apps/frontend/dashboard/src/app/(protected)/(layout)/domain/add/[domainId]/components/forward-dns-records.tsx
@@ -2,6 +2,7 @@
 
 import * as Button from "@reloop/ui/button";
 import { cn } from "@reloop/ui/cn";
+import * as CompactButton from "@reloop/ui/compact-button";
 import { Icon } from "@reloop/ui/icon";
 import * as Input from "@reloop/ui/input";
 import * as Popover from "@reloop/ui/popover";
@@ -91,17 +92,19 @@ export const ForwardDNSRecordsButton = ({
 								required
 								disabled={isSending}
 							/>
-							<button
+							<CompactButton.Root
 								type="submit"
+								variant="ghost"
+								size="medium"
 								disabled={isSending || !email.trim()}
-								className="flex items-center justify-center rounded p-1 text-text-sub-600 outline-none transition duration-150 hover:bg-neutral-alpha-10 disabled:text-text-disabled-300"
+								className="text-text-sub-600 transition duration-150 disabled:text-text-disabled-300"
 							>
 								{isSending ? (
 									<Spinner size={14} color="currentColor" />
 								) : (
 									<Icon name="send-1" className="h-4 w-4" />
 								)}
-							</button>
+							</CompactButton.Root>
 						</Input.Wrapper>
 					</Input.Root>
 				</form>

--- a/apps/frontend/dashboard/src/app/(protected)/(layout)/domain/add/[domainId]/page.tsx
+++ b/apps/frontend/dashboard/src/app/(protected)/(layout)/domain/add/[domainId]/page.tsx
@@ -19,6 +19,7 @@ import { groupDomainDnsRecords } from "../../[domainId]/components/dns-record-gr
 import { useDomainActions } from "../../[domainId]/hooks/use-domain-actions";
 import { DomainNotFound } from "../../components/domain-not-found";
 import { DNSRecordSection } from "./components/dns-record-section";
+import { ForwardDNSRecordsButton } from "./components/forward-dns-records";
 
 const NewDomainPage = () => {
 	const [isVerifying, setIsVerifying] = React.useState(false);
@@ -102,6 +103,11 @@ const NewDomainPage = () => {
 						Successfully added and ready for DNS configuration
 					</p>
 				</div>
+				{domainId && (
+					<div className="flex items-center gap-2">
+						<ForwardDNSRecordsButton domainId={domainId as string} />
+					</div>
+				)}
 			</div>
 
 			<div className="relative mb-10 flex flex-col">

--- a/apps/frontend/dashboard/src/app/(protected)/templates/[templateId]/components/use-editor-hooks.tsx
+++ b/apps/frontend/dashboard/src/app/(protected)/templates/[templateId]/components/use-editor-hooks.tsx
@@ -92,7 +92,7 @@ export const useEditorHook = (collab: CollabOptions) => {
 				StarterKit.configure({ UndoRedo: false }),
 				...baseExtensions,
 				Variable,
-				VariableSuggestion,
+				VariableSuggestion as any,
 				imageExtension,
 				...collabExtensions,
 			],

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "reloop",


### PR DESCRIPTION
<img width="1177" height="513" alt="image" src="https://github.com/user-attachments/assets/858ce3c2-1740-44e9-b5c6-d6930b3f72ef" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a "Forward DNS Records" feature that lets users email their domain's DNS configuration to any address. It introduces a new backend API endpoint (`POST /verify/:domain_id/forward-dns`), a new React popover component, and a minor unrelated TypeScript workaround in the editor hooks.

- **Backend**: `forwardDNSController` fetches the domain's DNS records (scoped to the authenticated org), then publishes a `DNS_CONFIG_REQUESTED` bus event with the email and records. The route is auth-guarded, rate-limited, and includes the audit log hook.
- **Frontend**: `ForwardDNSRecordsButton` renders a popover with an email input that POSTs to the new endpoint. State resets on popover close.
- **Unrelated**: `VariableSuggestion` is cast to `any` in the email editor hook to suppress a TypeScript type error.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge. The new DNS-forwarding endpoint is properly auth-guarded, org-scoped, rate-limited, and audit-logged, and the frontend component handles errors and state cleanly.

The backend changes are well-structured: org scoping via fetchDomain_step1 prevents cross-tenant access, the email format is validated at the Elysia layer, and the audit log hook is present. The frontend component resets state correctly on close and surfaces errors via toasts. The only notable issue is an unrelated as-any cast in the editor hooks that suppresses a TypeScript type error rather than fixing it, which does not affect the DNS forwarding functionality.

The as-any cast in use-editor-hooks.tsx is worth a follow-up to resolve the actual type mismatch, but it is unrelated to the DNS forwarding feature and does not block merging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/backend/domain/src/routes/domain/verify-dns/verify-dns.controllers.ts | Adds forwardDNSController: fetches org-scoped domain, maps DNS records, publishes bus event. Auth-scoped and error-handled correctly; previously flagged PII log remains. |
| apps/backend/domain/src/routes/domain/verify-dns/verify-dns.route.ts | Adds new POST route with auth, rate-limit, email format validation, and audit log hook. All required middleware is present. |
| apps/frontend/dashboard/src/app/(protected)/(layout)/domain/add/[domainId]/components/forward-dns-records.tsx | New React popover component with email input, loading state, and error handling via sonner toasts. State resets correctly on popover close. |
| apps/frontend/dashboard/src/app/(protected)/(layout)/domain/add/[domainId]/page.tsx | Integrates ForwardDNSRecordsButton into the domain setup page header, guarded by a domainId check. |
| apps/frontend/dashboard/src/app/(protected)/templates/[templateId]/components/use-editor-hooks.tsx | Adds as-any cast to VariableSuggestion to suppress a TypeScript error; the underlying type mismatch is hidden rather than resolved. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ForwardDNSRecordsButton
    participant Backend as /verify/:domain_id/forward-dns
    participant DB as fetchDomain_step1
    participant Bus as Event Bus

    User->>ForwardDNSRecordsButton: "Enter email & submit form"
    ForwardDNSRecordsButton->>Backend: "POST { email }"
    Backend->>Backend: authMiddleware (org scope)
    Backend->>Backend: rateLimitPlugin
    Backend->>DB: fetchDomain_step1(domainId, orgId)
    DB-->>Backend: domainWithRecords
    Backend->>Bus: "publish(DNS_CONFIG_REQUESTED, { email, domain, records })"
    Bus-->>Backend: ack
    Backend-->>ForwardDNSRecordsButton: "{ success: true }"
    Backend->>Backend: auditLogHook(forwarded)
    ForwardDNSRecordsButton-->>User: toast.success / toast.error
```

<sub>Reviews (2): Last reviewed commit: ["feat: implement automated global style e..."](https://github.com/reloop-labs/reloop/commit/5da3eebf034d455a6cb1f938441533c1083afa6b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34962935)</sub>

<!-- /greptile_comment -->