### PR TITLE
feat: integrate Chatwoot live chat widget with user session synchroni…

### DIFF
--- a/apps/frontend/dashboard/README.md
+++ b/apps/frontend/dashboard/README.md
@@ -11,6 +11,22 @@
 
 For detailed setup and development instructions, please refer to the [Setup Guide](https://reloop.sh/docs/setup/frontend/dashboard).
 
+## Chatwoot widget
+
+To enable the Chatwoot live chat widget in the dashboard, set (no spaces around `=`):
+
+- `NEXT_PUBLIC_CHATWOOT_BASE_URL` (example: `https://chatwoot.reloop.sh`)
+- `NEXT_PUBLIC_CHATWOOT_WEBSITE_TOKEN` (from Chatwoot → Settings → Inboxes → Website inbox)
+
+Restart the dev server after changing env vars.
+
+In Chatwoot → Inbox → **Settings**, set **Website domain** to the exact origin you use:
+
+- Local dev: `https://local.reloop.sh`
+- Production: `https://reloop.sh`
+
+If the domain does not match, the chat bubble will not appear.
+
 ---
 
 ## 🔗 Resources & Community

--- a/apps/frontend/dashboard/src/app/(protected)/(layout)/layout.tsx
+++ b/apps/frontend/dashboard/src/app/(protected)/(layout)/layout.tsx
@@ -2,6 +2,7 @@ import { PageHeader } from "@fe/dashboard/components/layout/page-header";
 import { MainSidebar } from "@fe/dashboard/components/layout/sidebar";
 import { SidebarToggle } from "@fe/dashboard/components/layout/sidebar-toggel";
 import { UserOrganizationProvider } from "@fe/dashboard/providers/org-provider";
+import { ChatwootUserSync } from "@fe/dashboard/components/chatwoot-widget";
 
 const OrgLayout = ({ children }: { children: React.ReactNode }) => {
 	return (
@@ -14,6 +15,7 @@ const OrgLayout = ({ children }: { children: React.ReactNode }) => {
 					<div className="flex-1 overflow-y-auto">{children}</div>
 				</main>
 			</div>
+			<ChatwootUserSync />
 		</UserOrganizationProvider>
 	);
 };

--- a/apps/frontend/dashboard/src/app/(protected)/templates/[templateId]/layout.tsx
+++ b/apps/frontend/dashboard/src/app/(protected)/templates/[templateId]/layout.tsx
@@ -1,9 +1,11 @@
+import { ChatwootUserSync } from "@fe/dashboard/components/chatwoot-widget";
 import { UserOrganizationProvider } from "@fe/dashboard/providers/org-provider";
 
 const TemplateEditorLayout = ({ children }: { children: React.ReactNode }) => {
 	return (
 		<UserOrganizationProvider>
 			<div className="min-h-screen">{children}</div>
+			<ChatwootUserSync />
 		</UserOrganizationProvider>
 	);
 };

--- a/apps/frontend/dashboard/src/app/layout.tsx
+++ b/apps/frontend/dashboard/src/app/layout.tsx
@@ -8,6 +8,7 @@ import * as Tooltip from "@reloop/ui/tooltip";
 import localFont from "next/font/local";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
 import { Suspense } from "react";
+import { ChatwootLoader } from "@reloop/ui/chatwoot-loader";
 import { CommandMenuGlobal } from "../components/command-menu";
 
 const openRunde = localFont({
@@ -64,6 +65,7 @@ export default function RootLayout({
 							<IconsSprite />
 							<Toaster />
 							<CommandMenuGlobal />
+							<ChatwootLoader />
 						</SWRProvider>
 					</ThemeProvider>
 				</NuqsAdapter>

--- a/apps/frontend/dashboard/src/components/chatwoot-widget.tsx
+++ b/apps/frontend/dashboard/src/components/chatwoot-widget.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect } from "react";
+
+import { useUserOrganization } from "@fe/dashboard/providers/org-provider";
+import { ChatwootLoader } from "@reloop/ui/chatwoot-loader";
+
+/** Identifies the logged-in Reloop user in Chatwoot (requires UserOrganizationProvider). */
+export function ChatwootUserSync() {
+	const { user, activeOrganization } = useUserOrganization();
+
+	const baseUrl = process.env.NEXT_PUBLIC_CHATWOOT_BASE_URL?.replace(/\/+$/, "");
+	const websiteToken = process.env.NEXT_PUBLIC_CHATWOOT_WEBSITE_TOKEN?.trim();
+	const isConfigured = Boolean(baseUrl && websiteToken);
+
+	useEffect(() => {
+		if (!isConfigured || !user?.email) return;
+		if (!window.$chatwoot?.setUser) return;
+
+		const identifier =
+			(user as { id?: string | null }).id?.toString() || user.email;
+
+		window.$chatwoot.setUser(identifier, {
+			email: user.email,
+			name: (user as { name?: string | null }).name ?? undefined,
+			custom_attributes: {
+				activeOrganizationId:
+					(activeOrganization as { id?: string | null })?.id ?? undefined,
+				activeOrganizationSlug:
+					(activeOrganization as { slug?: string | null })?.slug ?? undefined,
+				activeOrganizationName:
+					(activeOrganization as { name?: string | null })?.name ?? undefined,
+			},
+		});
+	}, [isConfigured, user, activeOrganization]);
+
+	return null;
+}
+
+export { ChatwootLoader };
+
+/** @deprecated Use ChatwootLoader + ChatwootUserSync instead */
+export function ChatwootWidget() {
+	return (
+		<>
+			<ChatwootLoader />
+			<ChatwootUserSync />
+		</>
+	);
+}

--- a/apps/frontend/dashboard/src/components/chatwoot-widget.tsx
+++ b/apps/frontend/dashboard/src/components/chatwoot-widget.tsx
@@ -14,24 +14,26 @@ export function ChatwootUserSync() {
 	const isConfigured = Boolean(baseUrl && websiteToken);
 
 	useEffect(() => {
-		if (!isConfigured || !user?.email) return;
+		if (!isConfigured) return;
+
+		// Reset Chatwoot session when user logs out
+		if (!user?.email) {
+			window.$chatwoot?.reset();
+			return;
+		}
 
 		const identify = () => {
 			if (!window.$chatwoot?.setUser) return;
 
-			const identifier =
-				(user as { id?: string | null }).id?.toString() || user.email;
+			const identifier = user.id?.toString() || user.email;
 
 			window.$chatwoot.setUser(identifier, {
 				email: user.email,
-				name: (user as { name?: string | null }).name ?? undefined,
+				name: user.name ?? undefined,
 				custom_attributes: {
-					activeOrganizationId:
-						(activeOrganization as { id?: string | null })?.id ?? undefined,
-					activeOrganizationSlug:
-						(activeOrganization as { slug?: string | null })?.slug ?? undefined,
-					activeOrganizationName:
-						(activeOrganization as { name?: string | null })?.name ?? undefined,
+					activeOrganizationId: activeOrganization?.id ?? undefined,
+					activeOrganizationSlug: activeOrganization?.slug ?? undefined,
+					activeOrganizationName: activeOrganization?.name ?? undefined,
 				},
 			});
 		};

--- a/apps/frontend/dashboard/src/components/chatwoot-widget.tsx
+++ b/apps/frontend/dashboard/src/components/chatwoot-widget.tsx
@@ -15,23 +15,36 @@ export function ChatwootUserSync() {
 
 	useEffect(() => {
 		if (!isConfigured || !user?.email) return;
-		if (!window.$chatwoot?.setUser) return;
 
-		const identifier =
-			(user as { id?: string | null }).id?.toString() || user.email;
+		const identify = () => {
+			if (!window.$chatwoot?.setUser) return;
 
-		window.$chatwoot.setUser(identifier, {
-			email: user.email,
-			name: (user as { name?: string | null }).name ?? undefined,
-			custom_attributes: {
-				activeOrganizationId:
-					(activeOrganization as { id?: string | null })?.id ?? undefined,
-				activeOrganizationSlug:
-					(activeOrganization as { slug?: string | null })?.slug ?? undefined,
-				activeOrganizationName:
-					(activeOrganization as { name?: string | null })?.name ?? undefined,
-			},
-		});
+			const identifier =
+				(user as { id?: string | null }).id?.toString() || user.email;
+
+			window.$chatwoot.setUser(identifier, {
+				email: user.email,
+				name: (user as { name?: string | null }).name ?? undefined,
+				custom_attributes: {
+					activeOrganizationId:
+						(activeOrganization as { id?: string | null })?.id ?? undefined,
+					activeOrganizationSlug:
+						(activeOrganization as { slug?: string | null })?.slug ?? undefined,
+					activeOrganizationName:
+						(activeOrganization as { name?: string | null })?.name ?? undefined,
+				},
+			});
+		};
+
+		// Try immediately in case the SDK is already ready
+		identify();
+
+		// Also listen for the SDK ready event in case it loads later
+		window.addEventListener("chatwoot:ready", identify);
+
+		return () => {
+			window.removeEventListener("chatwoot:ready", identify);
+		};
 	}, [isConfigured, user, activeOrganization]);
 
 	return null;

--- a/apps/frontend/web/README.md
+++ b/apps/frontend/web/README.md
@@ -11,6 +11,15 @@
 
 For detailed setup and development instructions, please refer to the [Setup Guide](https://reloop.sh/docs/setup/frontend/web).
 
+## Chatwoot widget
+
+Set in `apps/frontend/web/.env` (same values as the dashboard):
+
+- `NEXT_PUBLIC_CHATWOOT_BASE_URL`
+- `NEXT_PUBLIC_CHATWOOT_WEBSITE_TOKEN`
+
+In Chatwoot inbox settings, **Website domain** must match where the site is served (e.g. `https://local.reloop.sh` for local dev).
+
 ---
 
 ## 🔗 Resources & Community

--- a/apps/frontend/web/src/app/layout.tsx
+++ b/apps/frontend/web/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import { ChatwootLoader } from "@reloop/ui/chatwoot-loader";
 import { IconsSprite } from "@reloop/ui/icon";
 import { ThemeProvider } from "@reloop/web/providers/theme-provider";
 import {
@@ -74,6 +75,7 @@ export default function RootLayout({
 				>
 					{children}
 					<IconsSprite />
+					<ChatwootLoader />
 				</ThemeProvider>
 			</body>
 		</html>

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -90,7 +90,8 @@
 		"./divider": "./src/components/divider.tsx",
 		"./use-loading": "./src/hooks/use-loading.ts",
 		"./horizontal-stepper": "./src/components/horizontal-stepper.tsx",
-		"./digit-input": "./src/components/digit-input.tsx"
+		"./digit-input": "./src/components/digit-input.tsx",
+		"./chatwoot-loader": "./src/components/chatwoot-loader.tsx"
 	},
 	"dependencies": {
 		"@radix-ui/react-accordion": "catalog:ui",
@@ -131,6 +132,7 @@
 		"@tailwindcss/postcss": "catalog:ui"
 	},
 	"peerDependencies": {
+		"next": "catalog:ui",
 		"react": "catalog:ui",
 		"react-dom": "catalog:ui",
 		"@types/react": "catalog:ui",

--- a/packages/ui/src/components/chatwoot-loader.tsx
+++ b/packages/ui/src/components/chatwoot-loader.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import Script from "next/script";
+import { useEffect, useMemo, useRef } from "react";
+
+declare global {
+	interface Window {
+		chatwootSDK?: {
+			run: (config: { websiteToken: string; baseUrl: string }) => void;
+		};
+		$chatwoot?: {
+			setUser: (
+				identifier: string,
+				user: {
+					email?: string;
+					name?: string;
+					avatar_url?: string;
+					custom_attributes?: Record<string, unknown>;
+				},
+			) => void;
+		};
+	}
+}
+
+function useChatwootConfig() {
+	const baseUrlRaw = process.env.NEXT_PUBLIC_CHATWOOT_BASE_URL;
+	const websiteTokenRaw = process.env.NEXT_PUBLIC_CHATWOOT_WEBSITE_TOKEN;
+
+	const baseUrl = useMemo(() => baseUrlRaw?.replace(/\/+$/, ""), [baseUrlRaw]);
+	const websiteToken = useMemo(
+		() => websiteTokenRaw?.trim(),
+		[websiteTokenRaw],
+	);
+
+	return { baseUrl, websiteToken, isConfigured: Boolean(baseUrl && websiteToken) };
+}
+
+export function ChatwootLoader() {
+	const { baseUrl, websiteToken, isConfigured } = useChatwootConfig();
+	const didInit = useRef(false);
+
+	useEffect(() => {
+		if (process.env.NODE_ENV !== "development" || isConfigured) return;
+		console.warn(
+			"[Chatwoot] Widget disabled: set NEXT_PUBLIC_CHATWOOT_BASE_URL and NEXT_PUBLIC_CHATWOOT_WEBSITE_TOKEN, then restart the dev server.",
+		);
+	}, [isConfigured]);
+
+	if (!isConfigured || !baseUrl || !websiteToken) return null;
+
+	return (
+		<Script
+			id="chatwoot-sdk"
+			src={`${baseUrl}/packs/js/sdk.js`}
+			strategy="afterInteractive"
+			onLoad={() => {
+				if (didInit.current) return;
+				didInit.current = true;
+				window.chatwootSDK?.run({ websiteToken, baseUrl });
+			}}
+		/>
+	);
+}

--- a/packages/ui/src/components/chatwoot-loader.tsx
+++ b/packages/ui/src/components/chatwoot-loader.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Script from "next/script";
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useRef } from "react";
 
 declare global {
 	interface Window {
@@ -18,19 +18,14 @@ declare global {
 					custom_attributes?: Record<string, unknown>;
 				},
 			) => void;
+			reset: () => void;
 		};
 	}
 }
 
 function useChatwootConfig() {
-	const baseUrlRaw = process.env.NEXT_PUBLIC_CHATWOOT_BASE_URL;
-	const websiteTokenRaw = process.env.NEXT_PUBLIC_CHATWOOT_WEBSITE_TOKEN;
-
-	const baseUrl = useMemo(() => baseUrlRaw?.replace(/\/+$/, ""), [baseUrlRaw]);
-	const websiteToken = useMemo(
-		() => websiteTokenRaw?.trim(),
-		[websiteTokenRaw],
-	);
+	const baseUrl = process.env.NEXT_PUBLIC_CHATWOOT_BASE_URL?.replace(/\/+$/, "");
+	const websiteToken = process.env.NEXT_PUBLIC_CHATWOOT_WEBSITE_TOKEN?.trim();
 
 	return { baseUrl, websiteToken, isConfigured: Boolean(baseUrl && websiteToken) };
 }


### PR DESCRIPTION
<img width="1435" height="742" alt="image" src="https://github.com/user-attachments/assets/9a51e6a6-8e4a-4b18-9162-e2543aee0f72" />

<img width="698" height="871" alt="image" src="https://github.com/user-attachments/assets/956d9cf0-30bf-4b7d-8f5d-ba50582aaa04" />

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Review completed and submitted via submit_review tool.

<h3>Confidence Score: 5/5</h3>

The change is additive and entirely opt-in via env vars — missing vars cause the widget to be silently disabled, so no breakage on existing deployments.

All SDK interaction is guarded by optional chaining, the async race condition is handled via chatwoot:ready, and logout correctly resets the session. The only findings are minor style concerns around naming and code duplication that do not affect runtime behaviour.

No files require special attention.

<sub>Reviews (2): Last reviewed commit: ["fix: implement Chatwoot session reset on..."](https://github.com/reloop-labs/reloop/commit/1c582d980f14648d4d6287ff66f3fe30c01c9736) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35316833)</sub>

<!-- /greptile_comment -->