### PR TITLE
refactor(auth): absorb api-key package into @reloop/auth (expand) (#46)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -832,11 +832,9 @@
       "name": "@reloop/apikey",
       "version": "0.1.0",
       "dependencies": {
-        "@reloop/db": "workspace:*",
-        "drizzle-orm": "catalog:db",
+        "@reloop/auth": "workspace:*",
       },
       "devDependencies": {
-        "@reloop/cache": "workspace:*",
         "@reloop/tsconfig": "workspace:*",
         "@types/node": "catalog:",
         "typescript": "catalog:",

--- a/packages/apikey/package.json
+++ b/packages/apikey/package.json
@@ -14,11 +14,9 @@
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {
-		"@reloop/db": "workspace:*",
-		"drizzle-orm": "catalog:db"
+		"@reloop/auth": "workspace:*"
 	},
 	"devDependencies": {
-		"@reloop/cache": "workspace:*",
 		"@reloop/tsconfig": "workspace:*",
 		"@types/node": "catalog:",
 		"typescript": "catalog:"

--- a/packages/apikey/src/index.ts
+++ b/packages/apikey/src/index.ts
@@ -1,102 +1,17 @@
-import { createHash, randomBytes } from "node:crypto";
-import type { RedisCache } from "@reloop/cache/redis-client";
-import { db as defaultDb } from "@reloop/db/client";
-import { apikey } from "@reloop/db/schema";
-import { eq, sql } from "drizzle-orm";
-
-export const API_KEY_PREFIX = "rl_prod";
-export const API_KEY_LENGTH = 20;
-
-export function hashApiKey(key: string): string {
-	return createHash("sha256").update(key).digest("hex");
-}
-
-export function generateApiKey(): string {
-	const randomPart = randomBytes(API_KEY_LENGTH).toString("base64url");
-	return `${API_KEY_PREFIX}_${randomPart}`;
-}
-
-export function getKeyStart(key: string): string {
-	return key.substring(0, 17);
-}
-
-export function getApiKeyCacheKey(apiKey: string): string {
-	return `apikey:v1:${apiKey}`;
-}
-
-export interface ApiKeyValidationResult {
-	userId: string;
-	organizationId: string;
-	apiKeyId: string;
-	authType: "apikey";
-}
-
-export async function validateApiKey(
-	apiKey: string | null | undefined,
-	redis: RedisCache,
-	db = defaultDb,
-): Promise<ApiKeyValidationResult | null> {
-	if (!apiKey || typeof apiKey !== "string") return null;
-
-	// Basic format check
-	if (!apiKey.includes("_") || !/^[a-zA-Z0-9_-]+$/.test(apiKey)) {
-		return null;
-	}
-
-	const hashedKey = hashApiKey(apiKey);
-	const cacheKey = getApiKeyCacheKey(hashedKey);
-
-	const cached = await redis.get<{
-		userId: string;
-		organizationId: string;
-		apiKeyId: string;
-	}>(cacheKey);
-
-	if (cached) {
-		// Update request stats in database asynchronously
-		db.update(apikey)
-			.set({
-				requestCount: sql`${apikey.requestCount} + 1`,
-				lastRequest: new Date(),
-			})
-			.where(eq(apikey.id, cached.apiKeyId))
-			.catch((err) => console.error("Failed to update API key stats:", err));
-
-		return {
-			userId: cached.userId,
-			organizationId: cached.organizationId,
-			apiKeyId: cached.apiKeyId,
-			authType: "apikey",
-		};
-	}
-
-	const apiKeyRecord = await db.query.apikey.findFirst({
-		where: (apikeys, { eq, and }) =>
-			and(eq(apikeys.key, hashedKey), eq(apikeys.enabled, true)),
-	});
-
-	if (apiKeyRecord) {
-		const result = {
-			userId: apiKeyRecord.userId,
-			organizationId: apiKeyRecord.organizationId,
-			apiKeyId: apiKeyRecord.id,
-		};
-		await redis.set(cacheKey, result, 30 * 24 * 60 * 60);
-
-		// Update request stats in database asynchronously
-		db.update(apikey)
-			.set({
-				requestCount: sql`${apikey.requestCount} + 1`,
-				lastRequest: new Date(),
-			})
-			.where(eq(apikey.id, apiKeyRecord.id))
-			.catch((err) => console.error("Failed to update API key stats:", err));
-
-		return {
-			...result,
-			authType: "apikey",
-		};
-	}
-
-	return null;
-}
+/**
+ * Thin re-export shim. Logic lives in `@reloop/auth` (expand step of the auth
+ * refactor). This package stays so existing importers keep working; deletion
+ * lands in the contract ticket that repoints generation consumers.
+ */
+export {
+	API_KEY_LENGTH,
+	API_KEY_PREFIX,
+	generateApiKey,
+	getApiKeyCacheKey,
+	getKeyStart,
+	hashApiKey,
+} from "@reloop/auth/apikey";
+export {
+	type ApiKeyValidationResult,
+	validateApiKey,
+} from "@reloop/auth/apikey/validate";

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -6,6 +6,8 @@
 		"./client": "./src/client.ts",
 		"./server": "./src/server.ts",
 		"./types": "./src/types.ts",
+		"./apikey": "./src/apikey/index.ts",
+		"./apikey/validate": "./src/apikey/validate.ts",
 		"./roles": "./src/roles.ts",
 		"./permissions": "./src/permissions.ts",
 		"./platform-permissions": "./src/platform-permissions.ts"

--- a/packages/auth/src/apikey/helpers.ts
+++ b/packages/auth/src/apikey/helpers.ts
@@ -1,0 +1,26 @@
+import { createHash, randomBytes } from "node:crypto";
+
+/**
+ * Dependency-light API-key helpers (no Elysia, Redis, or DB).
+ * Used by the api-key service and absorbed into `@reloop/auth/apikey`.
+ */
+
+export const API_KEY_PREFIX = "rl_prod";
+export const API_KEY_LENGTH = 20;
+
+export function hashApiKey(key: string): string {
+	return createHash("sha256").update(key).digest("hex");
+}
+
+export function generateApiKey(): string {
+	const randomPart = randomBytes(API_KEY_LENGTH).toString("base64url");
+	return `${API_KEY_PREFIX}_${randomPart}`;
+}
+
+export function getKeyStart(key: string): string {
+	return key.substring(0, 17);
+}
+
+export function getApiKeyCacheKey(apiKey: string): string {
+	return `apikey:v1:${apiKey}`;
+}

--- a/packages/auth/src/apikey/index.ts
+++ b/packages/auth/src/apikey/index.ts
@@ -1,0 +1,12 @@
+/**
+ * `@reloop/auth/apikey` — dependency-light generation/hashing helpers only.
+ * Validation (Redis/DB) lives at `@reloop/auth/apikey/validate`.
+ */
+export {
+	API_KEY_LENGTH,
+	API_KEY_PREFIX,
+	generateApiKey,
+	getApiKeyCacheKey,
+	getKeyStart,
+	hashApiKey,
+} from "./helpers";

--- a/packages/auth/src/apikey/validate.ts
+++ b/packages/auth/src/apikey/validate.ts
@@ -1,0 +1,85 @@
+import type { RedisCache } from "@reloop/cache/redis-client";
+import { db as defaultDb } from "@reloop/db/client";
+import { apikey } from "@reloop/db/schema";
+import { and, eq, sql } from "drizzle-orm";
+import { getApiKeyCacheKey, hashApiKey } from "./helpers";
+
+export interface ApiKeyValidationResult {
+	userId: string;
+	organizationId: string;
+	apiKeyId: string;
+	authType: "apikey";
+}
+
+/**
+ * Validate a raw API key against Redis cache + Postgres.
+ * Consumed by service middleware today and by the shared auth plugin later.
+ */
+export async function validateApiKey(
+	apiKey: string | null | undefined,
+	redis: RedisCache,
+	db = defaultDb,
+): Promise<ApiKeyValidationResult | null> {
+	if (!apiKey || typeof apiKey !== "string") return null;
+
+	// Basic format check
+	if (!apiKey.includes("_") || !/^[a-zA-Z0-9_-]+$/.test(apiKey)) {
+		return null;
+	}
+
+	const hashedKey = hashApiKey(apiKey);
+	const cacheKey = getApiKeyCacheKey(hashedKey);
+
+	const cached = await redis.get<{
+		userId: string;
+		organizationId: string;
+		apiKeyId: string;
+	}>(cacheKey);
+
+	if (cached) {
+		// Update request stats in database asynchronously
+		db.update(apikey)
+			.set({
+				requestCount: sql`${apikey.requestCount} + 1`,
+				lastRequest: new Date(),
+			})
+			.where(eq(apikey.id, cached.apiKeyId))
+			.catch((err) => console.error("Failed to update API key stats:", err));
+
+		return {
+			userId: cached.userId,
+			organizationId: cached.organizationId,
+			apiKeyId: cached.apiKeyId,
+			authType: "apikey",
+		};
+	}
+
+	const apiKeyRecord = await db.query.apikey.findFirst({
+		where: and(eq(apikey.key, hashedKey), eq(apikey.enabled, true)),
+	});
+
+	if (apiKeyRecord) {
+		const result = {
+			userId: apiKeyRecord.userId,
+			organizationId: apiKeyRecord.organizationId,
+			apiKeyId: apiKeyRecord.id,
+		};
+		await redis.set(cacheKey, result, 30 * 24 * 60 * 60);
+
+		// Update request stats in database asynchronously
+		db.update(apikey)
+			.set({
+				requestCount: sql`${apikey.requestCount} + 1`,
+				lastRequest: new Date(),
+			})
+			.where(eq(apikey.id, apiKeyRecord.id))
+			.catch((err) => console.error("Failed to update API key stats:", err));
+
+		return {
+			...result,
+			authType: "apikey",
+		};
+	}
+
+	return null;
+}

--- a/packages/auth/test/apikey-helpers.test.ts
+++ b/packages/auth/test/apikey-helpers.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import {
+	API_KEY_LENGTH,
+	API_KEY_PREFIX,
+	generateApiKey,
+	getApiKeyCacheKey,
+	getKeyStart,
+	hashApiKey,
+} from "../src/apikey/helpers";
+
+describe("API key generation / hashing helpers", () => {
+	test("generateApiKey uses the production prefix and a long enough secret", () => {
+		const key = generateApiKey();
+		expect(key.startsWith(`${API_KEY_PREFIX}_`)).toBe(true);
+		const secret = key.slice(API_KEY_PREFIX.length + 1);
+		// base64url of API_KEY_LENGTH random bytes is longer than the byte count
+		expect(secret.length).toBeGreaterThanOrEqual(API_KEY_LENGTH);
+		expect(key).toMatch(/^[a-zA-Z0-9_-]+$/);
+	});
+
+	test("generateApiKey produces unique keys", () => {
+		const a = generateApiKey();
+		const b = generateApiKey();
+		expect(a).not.toBe(b);
+	});
+
+	test("hashApiKey is stable SHA-256 hex", () => {
+		// Worked example: sha256("hello") known digest
+		expect(hashApiKey("hello")).toBe(
+			"2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+		);
+		expect(hashApiKey("hello")).toBe(hashApiKey("hello"));
+		expect(hashApiKey("hello")).not.toBe(hashApiKey("world"));
+	});
+
+	test("getKeyStart returns the first 17 characters", () => {
+		const key = `${API_KEY_PREFIX}_abcdefghijklmnopqrstuvwxyz`;
+		expect(getKeyStart(key)).toBe(key.slice(0, 17));
+		expect(getKeyStart(key).length).toBe(17);
+	});
+
+	test("getApiKeyCacheKey namespaces under apikey:v1", () => {
+		expect(getApiKeyCacheKey("abc")).toBe("apikey:v1:abc");
+	});
+});

--- a/packages/auth/test/export-isolation.test.ts
+++ b/packages/auth/test/export-isolation.test.ts
@@ -7,6 +7,9 @@ const PKG_SRC = join(import.meta.dir, "..", "src");
 /** Relative paths under `src/` that form the client + types surface. */
 const CLIENT_SURFACE_ENTRYPOINTS = ["client.ts", "types.ts"] as const;
 
+/** Dependency-light API-key helpers — must not pull Redis/DB/Elysia. */
+const APIKEY_HELPERS_ENTRYPOINT = "apikey/index.ts";
+
 /**
  * Modules that may appear on the client/types import graph.
  * Anything under `server/` (or the old monoloithic server.ts re-export tree
@@ -19,6 +22,7 @@ const FORBIDDEN_VALUE_IMPORT_SUBSTRINGS = [
 	"drizzle-orm",
 	"better-auth/adapters",
 	"evlog",
+	"elysia",
 ] as const;
 
 function resolveLocal(fromFile: string, spec: string): string | null {
@@ -158,5 +162,27 @@ describe("export isolation (client / types)", () => {
 		}
 		walk(PKG_SRC);
 		expect(betterAuthCalls).toEqual(["server/auth.ts"]);
+	});
+
+	test("apikey helpers value-import graph excludes Redis/DB/Elysia", () => {
+		const { localFiles, packageSpecs } = collectValueImports(
+			APIKEY_HELPERS_ENTRYPOINT,
+		);
+		const localRels = [...localFiles].map((f) => relative(PKG_SRC, f));
+
+		const heavyLocals = localRels.filter(
+			(r) =>
+				r.includes("validate") ||
+				r.startsWith(`server${"/"}`) ||
+				r === "server.ts",
+		);
+		expect(heavyLocals).toEqual([]);
+
+		const forbidden = [...packageSpecs].filter((spec) =>
+			FORBIDDEN_VALUE_IMPORT_SUBSTRINGS.some(
+				(frag) => spec === frag || spec.startsWith(`${frag}/`),
+			),
+		);
+		expect(forbidden).toEqual([]);
 	});
 });


### PR DESCRIPTION
## Summary

- Absorbs standalone `@reloop/apikey` into the shared auth package (expand step).
- `@reloop/auth/apikey` — pure generate / hash / key-start / prefix helpers (no Redis/DB/Elysia).
- `@reloop/auth/apikey/validate` — hashed lookup + cache for the middleware plugin to consume next.
- `@reloop/apikey` becomes a thin re-export shim; **no importer changes** in this PR.

Stacked on #54 (#45). Closes #46.

## Test plan

- [x] `bun test` in `packages/auth` (helpers + isolation — 8 pass)
- [x] `bun run test` in `apps/backend/auth` (tripwire via shim — 6 pass)
- [x] `tsc --noEmit` for `@reloop/auth`, `@reloop/apikey`, `be-api-key`
- [ ] CI green once stacked base merges

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR folds API-key code into the shared auth package. The main changes are:

- New `@reloop/auth/apikey` helper entrypoint.
- New `@reloop/auth/apikey/validate` Redis and DB validation entrypoint.
- `@reloop/apikey` changed into a compatibility re-export shim.
- Auth export-isolation and helper tests added.

<h3>Confidence Score: 4/5</h3>

The changed shim is mostly safe, but its new runtime package hop can break stricter service installs.

- The helper behavior appears preserved.
- The validation query shape matches existing repository usage.
- The re-export shim changes dependency resolution for existing `@reloop/apikey` consumers.

packages/apikey/src/index.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/apikey/src/index.ts | Replaces the standalone implementation with re-exports from `@reloop/auth` subpaths. |
| packages/auth/src/apikey/helpers.ts | Adds dependency-light API-key generation, hashing, key-start, and cache-key helpers. |
| packages/auth/src/apikey/validate.ts | Adds the Redis and database-backed API-key validation implementation under auth. |
| packages/auth/package.json | Adds subpath exports for API-key helpers and validation. |
| packages/auth/test/export-isolation.test.ts | Adds coverage that the helper entrypoint does not pull heavy server dependencies. |

<sub>Reviews (1): Last reviewed commit: ["refactor(auth): absorb api-key package i..."](https://github.com/reloop-labs/reloop/commit/07fc5a67057eb6a50d52de259b4e7730d501d3c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43725689)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->