### PR TITLE
feat(auth): centralize session-cache eviction on auth lifecycle (#48)

### DIFF
--- a/packages/auth/src/middleware/eviction.ts
+++ b/packages/auth/src/middleware/eviction.ts
@@ -1,0 +1,125 @@
+import {
+	extractSessionToken,
+	sessionTokenCacheKey,
+	sessionUserIndexKey,
+} from "./keys";
+import type { AuthRedis } from "./types";
+
+/**
+ * Shared RedisCache prefix for the short-TTL session validation cache.
+ * Every service that mounts `createAuthPlugin` must inject a Redis client
+ * constructed with this prefix so central eviction hits the same keys.
+ */
+export const SESSION_CACHE_REDIS_PREFIX = "reloop-session";
+
+/** Lifecycle events that require session-cache eviction. */
+export type SessionEvictionEvent =
+	| { type: "logout"; sessionToken: string; userId?: string | null }
+	| { type: "password-change"; userId: string }
+	| { type: "organization-switch"; userId: string };
+
+/**
+ * Apply one eviction event against the shared session-validation cache.
+ *
+ * - logout → delete that session-token entry (+ prune user index if userId known)
+ * - password-change / organization-switch → delete every token in the user index
+ */
+export async function applySessionCacheEviction(
+	redis: AuthRedis,
+	event: SessionEvictionEvent,
+): Promise<void> {
+	if (event.type === "logout") {
+		await evictSessionByToken(redis, event.sessionToken, event.userId);
+		return;
+	}
+	await evictAllSessionsForUser(redis, event.userId);
+}
+
+/** Delete one cached session and optionally remove it from the user index. */
+export async function evictSessionByToken(
+	redis: AuthRedis,
+	sessionToken: string,
+	userId?: string | null,
+): Promise<void> {
+	await redis.delete(sessionTokenCacheKey(sessionToken));
+
+	if (!userId) return;
+
+	const indexKey = sessionUserIndexKey(userId);
+	const tokens = (await redis.get<string[]>(indexKey)) ?? [];
+	const next = tokens.filter((t) => t !== sessionToken);
+	if (next.length === 0) {
+		await redis.delete(indexKey);
+	} else {
+		await redis.set(indexKey, next);
+	}
+}
+
+/** Read the per-user index and delete every session-token entry + the index. */
+export async function evictAllSessionsForUser(
+	redis: AuthRedis,
+	userId: string,
+): Promise<void> {
+	const indexKey = sessionUserIndexKey(userId);
+	const tokens = (await redis.get<string[]>(indexKey)) ?? [];
+	for (const token of tokens) {
+		await redis.delete(sessionTokenCacheKey(token));
+	}
+	await redis.delete(indexKey);
+}
+
+/**
+ * Map a Better Auth request path (+ cookie / user) onto an eviction event.
+ * Returns null when the path is not a lifecycle event we care about.
+ */
+export function evictionEventFromAuthPath(opts: {
+	path: string;
+	cookieHeader?: string | null;
+	userId?: string | null;
+}): SessionEvictionEvent | null {
+	const path = opts.path;
+
+	if (path === "/sign-out") {
+		const token = extractSessionToken(opts.cookieHeader ?? null);
+		if (!token) return null;
+		return {
+			type: "logout",
+			sessionToken: token,
+			userId: opts.userId ?? null,
+		};
+	}
+
+	if (path === "/change-password" || path === "/reset-password") {
+		if (!opts.userId) return null;
+		return { type: "password-change", userId: opts.userId };
+	}
+
+	if (path === "/organization/set-active") {
+		if (!opts.userId) return null;
+		return { type: "organization-switch", userId: opts.userId };
+	}
+
+	return null;
+}
+
+/**
+ * Best-effort hook entrypoint: resolve an event from the path and apply it.
+ * Never throws — eviction must not break the auth response.
+ */
+export async function handleAuthLifecycleEviction(
+	redis: AuthRedis,
+	opts: {
+		path: string;
+		cookieHeader?: string | null;
+		userId?: string | null;
+	},
+): Promise<SessionEvictionEvent | null> {
+	const event = evictionEventFromAuthPath(opts);
+	if (!event) return null;
+	try {
+		await applySessionCacheEviction(redis, event);
+	} catch {
+		// ignore — auth path must succeed even if cache is down
+	}
+	return event;
+}

--- a/packages/auth/src/middleware/index.ts
+++ b/packages/auth/src/middleware/index.ts
@@ -4,6 +4,15 @@
  */
 
 export {
+	applySessionCacheEviction,
+	evictAllSessionsForUser,
+	evictionEventFromAuthPath,
+	evictSessionByToken,
+	handleAuthLifecycleEviction,
+	SESSION_CACHE_REDIS_PREFIX,
+	type SessionEvictionEvent,
+} from "./eviction";
+export {
 	extractSessionToken,
 	sessionTokenCacheKey,
 	sessionUserIndexKey,

--- a/packages/auth/src/middleware/types.ts
+++ b/packages/auth/src/middleware/types.ts
@@ -19,7 +19,12 @@ export type AuthRedis = {
 export type AuthMiddlewareConfig = {
 	/** Base URL of the auth service (e.g. https://local.reloop.sh). */
 	baseUrl: string;
-	/** Shared Redis used for short-TTL session cache + API-key cache. */
+	/**
+	 * Shared Redis used for short-TTL session cache + API-key cache.
+	 * Session keys use a package-owned convention; construct RedisCache with
+	 * `SESSION_CACHE_REDIS_PREFIX` so central eviction in the auth service
+	 * hits the same keys.
+	 */
 	redis: AuthRedis;
 	/** Session-cache TTL in seconds. Default 5. */
 	ttl?: number;

--- a/packages/auth/src/server/auth.ts
+++ b/packages/auth/src/server/auth.ts
@@ -16,11 +16,13 @@ import {
 } from "better-auth/plugins";
 import { eq } from "drizzle-orm";
 import { log } from "evlog";
+import { handleAuthLifecycleEviction } from "../middleware/eviction";
 import { ac, orgRoles } from "../permissions";
 import { platformAc, platformRoles } from "../platform-permissions";
 import { DEFAULT_USER_ROLE, PLATFORM_ADMIN_ROLE } from "../roles";
 import { authServerConfig } from "./config";
 import { redis } from "./redis";
+import { sessionCacheRedis } from "./session-cache-redis";
 import {
 	canCreateAccount,
 	findValidSignupInvite,
@@ -126,6 +128,31 @@ export const auth = betterAuth({
 		after: createAuthMiddleware(async (ctx) => {
 			const { path, context } = ctx;
 			log.info({ message: String(ctx.path) });
+
+			// Near-instant session-validation cache eviction (shared Redis).
+			// Logout → that token; password-change / org-switch → all user tokens.
+			try {
+				const cookieHeader =
+					typeof ctx.headers?.get === "function"
+						? ctx.headers.get("cookie")
+						: null;
+				const sessionUser =
+					// biome-ignore lint/suspicious/noExplicitAny: Better Auth context shape
+					(context as any)?.session?.user ??
+					// biome-ignore lint/suspicious/noExplicitAny: Better Auth context shape
+					(context as any)?.newSession?.user;
+				await handleAuthLifecycleEviction(sessionCacheRedis, {
+					path: String(path),
+					cookieHeader,
+					userId: sessionUser?.id ?? null,
+				});
+			} catch (err) {
+				log.error({
+					...{ data: err },
+					message: "Session cache eviction failed",
+				});
+			}
+
 			// 🔐 User registered
 			if (path === "/sign-up/email-otp") {
 				const newSession = context.newSession;

--- a/packages/auth/src/server/index.ts
+++ b/packages/auth/src/server/index.ts
@@ -7,4 +7,5 @@
 export { auth, OpenAPI } from "./auth";
 export { authServerConfig } from "./config";
 export { redis as authRedis } from "./redis";
+export { sessionCacheRedis } from "./session-cache-redis";
 export * from "./signup-invite";

--- a/packages/auth/src/server/session-cache-redis.ts
+++ b/packages/auth/src/server/session-cache-redis.ts
@@ -1,0 +1,14 @@
+import { RedisCache } from "@reloop/cache/redis-client";
+import { SESSION_CACHE_REDIS_PREFIX } from "../middleware/eviction";
+import { authServerConfig } from "./config";
+
+/**
+ * Shared session-validation cache used by the middleware plugin and by
+ * central eviction in the auth service. Must use {@link SESSION_CACHE_REDIS_PREFIX}
+ * so every service hits the same Redis keys.
+ */
+export const sessionCacheRedis = new RedisCache(
+	SESSION_CACHE_REDIS_PREFIX,
+	5,
+	authServerConfig.REDIS_URL,
+);

--- a/packages/auth/test/session-eviction.test.ts
+++ b/packages/auth/test/session-eviction.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, test } from "bun:test";
+import {
+	type AuthContext,
+	applySessionCacheEviction,
+	evictAllSessionsForUser,
+	evictionEventFromAuthPath,
+	evictSessionByToken,
+	handleAuthLifecycleEviction,
+	sessionTokenCacheKey,
+	sessionUserIndexKey,
+} from "../src/middleware";
+import { MemoryRedis } from "./memory-redis";
+
+async function seedUserSessions(
+	redis: MemoryRedis,
+	userId: string,
+	tokens: string[],
+): Promise<void> {
+	for (const token of tokens) {
+		const ctx: AuthContext = {
+			userId,
+			organizationId: "org-1",
+			role: "user",
+			authType: "session",
+		};
+		await redis.set(sessionTokenCacheKey(token), ctx, 5);
+	}
+	await redis.set(sessionUserIndexKey(userId), tokens, 5);
+}
+
+describe("session cache eviction", () => {
+	test("logout evicts the specific session-token entry and prunes the user index", async () => {
+		const redis = new MemoryRedis();
+		const userId = "user-1";
+		const keep = "tok-keep";
+		const drop = "tok-drop";
+		await seedUserSessions(redis, userId, [keep, drop]);
+
+		await applySessionCacheEviction(redis, {
+			type: "logout",
+			sessionToken: drop,
+			userId,
+		});
+
+		expect(await redis.get(sessionTokenCacheKey(drop))).toBeUndefined();
+		expect(await redis.get(sessionTokenCacheKey(keep))).toBeDefined();
+		expect(await redis.get<string[]>(sessionUserIndexKey(userId))).toEqual([
+			keep,
+		]);
+	});
+
+	test("logout without userId still deletes the token entry", async () => {
+		const redis = new MemoryRedis();
+		const token = "tok-solo";
+		await redis.set(sessionTokenCacheKey(token), {
+			userId: "u",
+			organizationId: "o",
+			role: null,
+			authType: "session",
+		} satisfies AuthContext);
+
+		await applySessionCacheEviction(redis, {
+			type: "logout",
+			sessionToken: token,
+		});
+
+		expect(await redis.get(sessionTokenCacheKey(token))).toBeUndefined();
+	});
+
+	test("password-change evicts all tokens via the per-user index", async () => {
+		const redis = new MemoryRedis();
+		const userId = "user-pw";
+		const tokens = ["t1", "t2", "t3"];
+		await seedUserSessions(redis, userId, tokens);
+
+		await applySessionCacheEviction(redis, {
+			type: "password-change",
+			userId,
+		});
+
+		for (const t of tokens) {
+			expect(await redis.get(sessionTokenCacheKey(t))).toBeUndefined();
+		}
+		expect(await redis.get(sessionUserIndexKey(userId))).toBeUndefined();
+	});
+
+	test("organization-switch evicts all tokens via the per-user index", async () => {
+		const redis = new MemoryRedis();
+		const userId = "user-org";
+		const tokens = ["a", "b"];
+		await seedUserSessions(redis, userId, tokens);
+
+		await applySessionCacheEviction(redis, {
+			type: "organization-switch",
+			userId,
+		});
+
+		for (const t of tokens) {
+			expect(await redis.get(sessionTokenCacheKey(t))).toBeUndefined();
+		}
+		expect(await redis.get(sessionUserIndexKey(userId))).toBeUndefined();
+	});
+
+	test("evictAllSessionsForUser is a no-op when the index is empty", async () => {
+		const redis = new MemoryRedis();
+		await evictAllSessionsForUser(redis, "nobody");
+		expect(await redis.get(sessionUserIndexKey("nobody"))).toBeUndefined();
+	});
+
+	test("evictSessionByToken removes the last index entry entirely", async () => {
+		const redis = new MemoryRedis();
+		const userId = "user-last";
+		const token = "only";
+		await seedUserSessions(redis, userId, [token]);
+
+		await evictSessionByToken(redis, token, userId);
+
+		expect(await redis.get(sessionTokenCacheKey(token))).toBeUndefined();
+		expect(await redis.get(sessionUserIndexKey(userId))).toBeUndefined();
+	});
+});
+
+describe("evictionEventFromAuthPath (lifecycle mapping)", () => {
+	test("maps /sign-out to logout with token from cookie", () => {
+		const event = evictionEventFromAuthPath({
+			path: "/sign-out",
+			cookieHeader: "reloop.session_token=abc123.sig; other=1",
+			userId: "u1",
+		});
+		expect(event).toEqual({
+			type: "logout",
+			sessionToken: "abc123",
+			userId: "u1",
+		});
+	});
+
+	test("maps /change-password and /reset-password to password-change", () => {
+		expect(
+			evictionEventFromAuthPath({ path: "/change-password", userId: "u" }),
+		).toEqual({ type: "password-change", userId: "u" });
+		expect(
+			evictionEventFromAuthPath({ path: "/reset-password", userId: "u" }),
+		).toEqual({ type: "password-change", userId: "u" });
+	});
+
+	test("maps /organization/set-active to organization-switch", () => {
+		expect(
+			evictionEventFromAuthPath({
+				path: "/organization/set-active",
+				userId: "u",
+			}),
+		).toEqual({ type: "organization-switch", userId: "u" });
+	});
+
+	test("ignores unrelated paths", () => {
+		expect(
+			evictionEventFromAuthPath({ path: "/get-session", userId: "u" }),
+		).toBeNull();
+	});
+
+	test("handleAuthLifecycleEviction drives logout end-to-end", async () => {
+		const redis = new MemoryRedis();
+		const token = "live-tok";
+		const userId = "live-user";
+		await seedUserSessions(redis, userId, [token, "other"]);
+
+		const event = await handleAuthLifecycleEviction(redis, {
+			path: "/sign-out",
+			cookieHeader: `reloop.session_token=${token}.sig`,
+			userId,
+		});
+
+		expect(event?.type).toBe("logout");
+		expect(await redis.get(sessionTokenCacheKey(token))).toBeUndefined();
+		expect(await redis.get(sessionTokenCacheKey("other"))).toBeDefined();
+	});
+
+	test("handleAuthLifecycleEviction drives password-change end-to-end", async () => {
+		const redis = new MemoryRedis();
+		const userId = "pw-user";
+		await seedUserSessions(redis, userId, ["x", "y"]);
+
+		const event = await handleAuthLifecycleEviction(redis, {
+			path: "/change-password",
+			userId,
+		});
+
+		expect(event?.type).toBe("password-change");
+		expect(await redis.get(sessionTokenCacheKey("x"))).toBeUndefined();
+		expect(await redis.get(sessionTokenCacheKey("y"))).toBeUndefined();
+		expect(await redis.get(sessionUserIndexKey(userId))).toBeUndefined();
+	});
+
+	test("handleAuthLifecycleEviction drives organization-switch end-to-end", async () => {
+		const redis = new MemoryRedis();
+		const userId = "org-user";
+		await seedUserSessions(redis, userId, ["o1"]);
+
+		const event = await handleAuthLifecycleEviction(redis, {
+			path: "/organization/set-active",
+			userId,
+		});
+
+		expect(event?.type).toBe("organization-switch");
+		expect(await redis.get(sessionTokenCacheKey("o1"))).toBeUndefined();
+		expect(await redis.get(sessionUserIndexKey(userId))).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary

- Centralized session-validation cache eviction in the auth service (owner of lifecycle events).
- **Logout** → delete that session-token cache entry (and prune user index).
- **Password-change / org-switch** → read per-user index, delete all tokens + index.
- Uses middleware-owned keys (`session:token:…`, `session:user:…`) + shared Redis prefix `reloop-session`.
- Package tests drive each event and assert Redis entries are gone.

Stacked on #56 (#47). Closes #48.

## Test plan

- [x] `bun test` in `packages/auth` — 33 pass (incl. 13 eviction cases)
- [x] Characterization tripwire still green
- [x] `tsc --noEmit` for `@reloop/auth`
- [ ] CI green once stack base merges

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR centralizes session-cache eviction in the auth lifecycle. The main changes are:

- New eviction helpers for logout, password-change, and org-switch events.
- Shared `reloop-session` Redis prefix for session validation cache keys.
- Auth server after-hook wiring to trigger cache eviction.
- Tests for the main eviction paths and key deletion behavior.

<h3>Confidence Score: 4/5</h3>

The session-cache eviction path needs fixes before merging.

- Concurrent session validation can leave token cache entries without a user index.
- Redis failures can let lifecycle requests finish while eviction did not happen.
- Happy-path tests cover key deletion, but not the shared-index races or failure behavior.

packages/auth/src/middleware/eviction.ts; packages/auth/src/server/auth.ts

<details open><summary><h3>Security Review</h3></summary>

The new eviction path can leave stale session-validation cache entries active when index updates race with session validation or Redis operations fail silently.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/auth/src/middleware/eviction.ts | Adds lifecycle eviction helpers, but the Redis index mutations are non-atomic and Redis failures can leave stale cache entries in place. |
| packages/auth/src/server/auth.ts | Adds after-hook eviction wiring based on path, cookie, and session user context. |
| packages/auth/src/server/session-cache-redis.ts | Adds the shared session-cache Redis instance using the expected prefix and constructor shape. |
| packages/auth/src/middleware/index.ts | Re-exports the new eviction API from the middleware entrypoint. |
| packages/auth/src/server/index.ts | Re-exports the shared session-cache Redis instance from the server entrypoint. |
| packages/auth/src/middleware/types.ts | Documents the shared Redis prefix requirement for middleware config. |
| packages/auth/test/session-eviction.test.ts | Adds happy-path coverage for lifecycle event mapping and cache key deletion. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
  participant Auth as Auth lifecycle hook
  participant Evict as eviction.ts
  participant Redis as Redis session cache
  participant MW as Session middleware

  Auth->>Evict: password-change/org-switch(userId)
  Evict->>Redis: get(session:user:userId)
  Redis-->>Evict: [oldToken]
  MW->>Redis: set(session:token:newToken)
  MW->>Redis: set(session:user:userId, [oldToken,newToken])
  Evict->>Redis: delete(session:token:oldToken)
  Evict->>Redis: delete(session:user:userId)
  Note over Redis: newToken cache entry survives while its index is removed
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
  participant Auth as Auth lifecycle hook
  participant Evict as eviction.ts
  participant Redis as Redis session cache
  participant MW as Session middleware

  Auth->>Evict: password-change/org-switch(userId)
  Evict->>Redis: get(session:user:userId)
  Redis-->>Evict: [oldToken]
  MW->>Redis: set(session:token:newToken)
  MW->>Redis: set(session:user:userId, [oldToken,newToken])
  Evict->>Redis: delete(session:token:oldToken)
  Evict->>Redis: delete(session:user:userId)
  Note over Redis: newToken cache entry survives while its index is removed
```

</a>

<sub>Reviews (1): Last reviewed commit: ["feat(auth): centralize session-cache evi..."](https://github.com/reloop-labs/reloop/commit/8537ca209d0c4bc548c03cd9357647583b4024eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43727238)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->