### PR TITLE
Add ApiKeyCredentialCache and route validate through it

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -8,6 +8,7 @@
 		"./server/config": "./src/server/config.ts",
 		"./types": "./src/types.ts",
 		"./apikey": "./src/apikey/index.ts",
+		"./apikey/credential-cache": "./src/apikey/credential-cache.ts",
 		"./apikey/validate": "./src/apikey/validate.ts",
 		"./middleware": "./src/middleware/index.ts",
 		"./roles": "./src/roles.ts",

--- a/packages/auth/src/apikey/credential-cache.ts
+++ b/packages/auth/src/apikey/credential-cache.ts
@@ -39,6 +39,29 @@ export type ApiKeyCredentialCache = {
 	invalidate(hashedKey: string): Promise<void>;
 };
 
+/**
+ * Auth Redis / session cache often uses best-effort `delete`.
+ * Prefer `deleteStrict` when available so credential invalidate fails closed.
+ */
+export function authRedisAsCredentialStore(redis: {
+	get<T>(key: string): Promise<T | undefined>;
+	set(key: string, value: unknown, ttlSeconds?: number): Promise<void>;
+	delete(key: string): Promise<void>;
+	deleteStrict?(key: string): Promise<void>;
+}): ApiKeyCredentialStore {
+	return {
+		get: (key) => redis.get(key),
+		set: (key, value, ttl) => redis.set(key, value, ttl),
+		delete: async (key) => {
+			if (redis.deleteStrict) {
+				await redis.deleteStrict(key);
+				return;
+			}
+			await redis.delete(key);
+		},
+	};
+}
+
 export function createApiKeyCredentialCache(
 	store: ApiKeyCredentialStore,
 ): ApiKeyCredentialCache {

--- a/packages/auth/src/apikey/credential-cache.ts
+++ b/packages/auth/src/apikey/credential-cache.ts
@@ -1,0 +1,72 @@
+/**
+ * API Key credential cache — single seam for auth validation and lifecycle invalidate.
+ * Keys are always the **hashed** secret (as stored on the apikey row), never the raw secret.
+ */
+
+export const API_KEY_CREDENTIAL_CACHE_TTL_SECONDS = 30 * 24 * 60 * 60;
+
+const CACHE_KEY_PREFIX = "apikey:v1";
+
+/** Redis / memory key for a hashed API Key secret. */
+export function apiKeyCredentialCacheKey(hashedKey: string): string {
+	return `${CACHE_KEY_PREFIX}:${hashedKey}`;
+}
+
+export type ApiKeyCredentialEntry = {
+	userId: string;
+	organizationId: string;
+	apiKeyId: string;
+};
+
+/**
+ * Low-level store (e.g. AuthRedis / MemoryRedis).
+ * `delete` must reject when the operation cannot be confirmed so invalidate can fail closed.
+ */
+export type ApiKeyCredentialStore = {
+	get<T>(key: string): Promise<T | undefined>;
+	set(key: string, value: unknown, ttlSeconds?: number): Promise<void>;
+	delete(key: string): Promise<void>;
+};
+
+export type ApiKeyCredentialCache = {
+	read(hashedKey: string): Promise<ApiKeyCredentialEntry | undefined>;
+	write(
+		hashedKey: string,
+		entry: ApiKeyCredentialEntry,
+		ttlSeconds?: number,
+	): Promise<void>;
+	/** Removes the cached credential. Throws if delete cannot be confirmed. */
+	invalidate(hashedKey: string): Promise<void>;
+};
+
+export function createApiKeyCredentialCache(
+	store: ApiKeyCredentialStore,
+): ApiKeyCredentialCache {
+	return {
+		async read(hashedKey) {
+			return store.get<ApiKeyCredentialEntry>(
+				apiKeyCredentialCacheKey(hashedKey),
+			);
+		},
+
+		async write(hashedKey, entry, ttlSeconds = API_KEY_CREDENTIAL_CACHE_TTL_SECONDS) {
+			await store.set(
+				apiKeyCredentialCacheKey(hashedKey),
+				entry,
+				ttlSeconds,
+			);
+		},
+
+		async invalidate(hashedKey) {
+			const key = apiKeyCredentialCacheKey(hashedKey);
+			try {
+				await store.delete(key);
+			} catch (cause) {
+				throw new Error(
+					`API key credential cache invalidate failed for key "${key}"`,
+					{ cause },
+				);
+			}
+		},
+	};
+}

--- a/packages/auth/src/apikey/helpers.ts
+++ b/packages/auth/src/apikey/helpers.ts
@@ -1,4 +1,5 @@
 import { createHash, randomBytes } from "node:crypto";
+import { apiKeyCredentialCacheKey } from "@reloop/auth/apikey/credential-cache";
 
 export const API_KEY_PREFIX = "rl_prod";
 export const API_KEY_LENGTH = 20;
@@ -16,6 +17,10 @@ export function getKeyStart(key: string): string {
 	return key.substring(0, 17);
 }
 
-export function getApiKeyCacheKey(apiKey: string): string {
-	return `apikey:v1:${apiKey}`;
+/**
+ * Redis key for a hashed API Key secret.
+ * Delegates to `apiKeyCredentialCacheKey` so the formula stays single-sourced.
+ */
+export function getApiKeyCacheKey(hashedKey: string): string {
+	return apiKeyCredentialCacheKey(hashedKey);
 }

--- a/packages/auth/src/apikey/validate.ts
+++ b/packages/auth/src/apikey/validate.ts
@@ -1,11 +1,17 @@
-import { getApiKeyCacheKey, hashApiKey } from "@reloop/auth/apikey/helpers";
+import {
+	createApiKeyCredentialCache,
+	type ApiKeyCredentialStore,
+} from "@reloop/auth/apikey/credential-cache";
+import { hashApiKey } from "@reloop/auth/apikey/helpers";
 import { db as defaultDb } from "@reloop/db/client";
 import { apikey } from "@reloop/db/schema";
 import { and, eq, sql } from "drizzle-orm";
 
+/** Store used by validate (get/set; delete optional for this path). */
 export type ApiKeyCache = {
 	get<T>(key: string): Promise<T | undefined>;
 	set(key: string, value: unknown, ttlSeconds?: number): Promise<void>;
+	delete?(key: string): Promise<void>;
 };
 
 export interface ApiKeyValidationResult {
@@ -13,6 +19,23 @@ export interface ApiKeyValidationResult {
 	organizationId: string;
 	apiKeyId: string;
 	authType: "apikey";
+}
+
+function asCredentialStore(redis: ApiKeyCache): ApiKeyCredentialStore {
+	return {
+		get: (key) => redis.get(key),
+		set: (key, value, ttl) => redis.set(key, value, ttl),
+		delete: async (key) => {
+			if (redis.delete) {
+				await redis.delete(key);
+				return;
+			}
+			// Callers that only implement get/set never hit invalidate via this store.
+			throw new Error(
+				"API key credential store does not implement delete; cannot invalidate",
+			);
+		},
+	};
 }
 
 export async function validateApiKey(
@@ -27,13 +50,9 @@ export async function validateApiKey(
 	}
 
 	const hashedKey = hashApiKey(apiKey);
-	const cacheKey = getApiKeyCacheKey(hashedKey);
+	const credentialCache = createApiKeyCredentialCache(asCredentialStore(redis));
 
-	const cached = await redis.get<{
-		userId: string;
-		organizationId: string;
-		apiKeyId: string;
-	}>(cacheKey);
+	const cached = await credentialCache.read(hashedKey);
 
 	if (cached) {
 		db.update(apikey)
@@ -57,12 +76,12 @@ export async function validateApiKey(
 	});
 
 	if (apiKeyRecord) {
-		const result = {
+		const entry = {
 			userId: apiKeyRecord.userId,
 			organizationId: apiKeyRecord.organizationId,
 			apiKeyId: apiKeyRecord.id,
 		};
-		await redis.set(cacheKey, result, 30 * 24 * 60 * 60);
+		await credentialCache.write(hashedKey, entry);
 
 		db.update(apikey)
 			.set({
@@ -73,7 +92,7 @@ export async function validateApiKey(
 			.catch((err) => console.error("Failed to update API key stats:", err));
 
 		return {
-			...result,
+			...entry,
 			authType: "apikey",
 		};
 	}

--- a/packages/auth/src/middleware/types.ts
+++ b/packages/auth/src/middleware/types.ts
@@ -24,7 +24,13 @@ export type SupportAuthContext = AuthContext & {
 export type AuthRedis = {
 	get<T>(key: string): Promise<T | undefined>;
 	set(key: string, value: unknown, ttlSeconds?: number): Promise<void>;
+	/** Best-effort delete (session cleanup may swallow Redis errors). */
 	delete(key: string): Promise<void>;
+	/**
+	 * Fail-closed delete when present (e.g. RedisCache).
+	 * Used by API key credential invalidate — must throw if delete cannot be confirmed.
+	 */
+	deleteStrict?(key: string): Promise<void>;
 };
 
 export type AuthMiddlewareConfig = {

--- a/packages/auth/test/apikey-credential-cache.test.ts
+++ b/packages/auth/test/apikey-credential-cache.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
 	API_KEY_CREDENTIAL_CACHE_TTL_SECONDS,
 	apiKeyCredentialCacheKey,
+	authRedisAsCredentialStore,
 	createApiKeyCredentialCache,
 	type ApiKeyCredentialEntry,
 	type ApiKeyCredentialStore,
@@ -78,6 +79,30 @@ describe("ApiKeyCredentialCache", () => {
 		await expect(cache.invalidate("prod-hash")).rejects.toThrow(
 			/credential cache invalidate failed/,
 		);
+	});
+
+	test("authRedisAsCredentialStore prefers deleteStrict over best-effort delete", async () => {
+		let strictCalled = false;
+		let softCalled = false;
+		const store = authRedisAsCredentialStore({
+			async get() {
+				return undefined;
+			},
+			async set() {},
+			async delete() {
+				softCalled = true;
+			},
+			async deleteStrict() {
+				strictCalled = true;
+				throw new Error("redis unavailable");
+			},
+		});
+		const cache = createApiKeyCredentialCache(store);
+		await expect(cache.invalidate("h")).rejects.toThrow(
+			/credential cache invalidate failed/,
+		);
+		expect(strictCalled).toBe(true);
+		expect(softCalled).toBe(false);
 	});
 
 	test("write uses default 30-day TTL when caller omits ttl", async () => {

--- a/packages/auth/test/apikey-credential-cache.test.ts
+++ b/packages/auth/test/apikey-credential-cache.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, test } from "bun:test";
+import {
+	API_KEY_CREDENTIAL_CACHE_TTL_SECONDS,
+	apiKeyCredentialCacheKey,
+	createApiKeyCredentialCache,
+	type ApiKeyCredentialEntry,
+	type ApiKeyCredentialStore,
+} from "@reloop/auth/apikey/credential-cache";
+import { MemoryRedis } from "./memory-redis";
+
+const sampleEntry: ApiKeyCredentialEntry = {
+	userId: "user-1",
+	organizationId: "org-1",
+	apiKeyId: "key-1",
+};
+
+describe("ApiKeyCredentialCache", () => {
+	test("apiKeyCredentialCacheKey namespaces under apikey:v1", () => {
+		expect(apiKeyCredentialCacheKey("abc")).toBe("apikey:v1:abc");
+	});
+
+	test("write then read returns the credential entry", async () => {
+		const cache = createApiKeyCredentialCache(new MemoryRedis());
+		const hashed = "deadbeef";
+
+		await cache.write(hashed, sampleEntry);
+		await expect(cache.read(hashed)).resolves.toEqual(sampleEntry);
+	});
+
+	test("read returns undefined when missing", async () => {
+		const cache = createApiKeyCredentialCache(new MemoryRedis());
+		await expect(cache.read("missing")).resolves.toBeUndefined();
+	});
+
+	test("invalidate removes a written entry", async () => {
+		const cache = createApiKeyCredentialCache(new MemoryRedis());
+		const hashed = "to-drop";
+
+		await cache.write(hashed, sampleEntry);
+		await cache.invalidate(hashed);
+		await expect(cache.read(hashed)).resolves.toBeUndefined();
+	});
+
+	test("invalidate is a no-op success when entry was never written", async () => {
+		const cache = createApiKeyCredentialCache(new MemoryRedis());
+		await expect(cache.invalidate("never-there")).resolves.toBeUndefined();
+	});
+
+	test("invalidate fails closed when store delete rejects", async () => {
+		const store: ApiKeyCredentialStore = {
+			async get() {
+				return undefined;
+			},
+			async set() {},
+			async delete() {
+				throw new Error("redis unavailable");
+			},
+		};
+		const cache = createApiKeyCredentialCache(store);
+
+		await expect(cache.invalidate("any-hash")).rejects.toThrow(
+			/credential cache invalidate failed/,
+		);
+	});
+
+	test("invalidate fails closed when AuthRedis-shaped store delete rejects (production path)", async () => {
+		// Mirrors RedisCache: get/set ok, delete throws on failure (post-#65 fail-closed)
+		const store: ApiKeyCredentialStore = {
+			async get() {
+				return sampleEntry;
+			},
+			async set() {},
+			async delete() {
+				throw new Error("Redis delete error for reloop-session cache");
+			},
+		};
+		const cache = createApiKeyCredentialCache(store);
+		await expect(cache.invalidate("prod-hash")).rejects.toThrow(
+			/credential cache invalidate failed/,
+		);
+	});
+
+	test("write uses default 30-day TTL when caller omits ttl", async () => {
+		let seenTtl: number | undefined;
+		const store: ApiKeyCredentialStore = {
+			async get() {
+				return undefined;
+			},
+			async set(_key, _value, ttlSeconds) {
+				seenTtl = ttlSeconds;
+			},
+			async delete() {},
+		};
+		const cache = createApiKeyCredentialCache(store);
+
+		await cache.write("h", sampleEntry);
+		expect(seenTtl).toBe(API_KEY_CREDENTIAL_CACHE_TTL_SECONDS);
+		expect(API_KEY_CREDENTIAL_CACHE_TTL_SECONDS).toBe(30 * 24 * 60 * 60);
+	});
+
+	test("keys are hash-based: different hashes do not collide", async () => {
+		const cache = createApiKeyCredentialCache(new MemoryRedis());
+		const other: ApiKeyCredentialEntry = {
+			userId: "user-2",
+			organizationId: "org-2",
+			apiKeyId: "key-2",
+		};
+
+		await cache.write("hash-a", sampleEntry);
+		await cache.write("hash-b", other);
+
+		await expect(cache.read("hash-a")).resolves.toEqual(sampleEntry);
+		await expect(cache.read("hash-b")).resolves.toEqual(other);
+		await cache.invalidate("hash-a");
+		await expect(cache.read("hash-a")).resolves.toBeUndefined();
+		await expect(cache.read("hash-b")).resolves.toEqual(other);
+	});
+});

--- a/packages/auth/test/middleware.plugin.test.ts
+++ b/packages/auth/test/middleware.plugin.test.ts
@@ -9,9 +9,9 @@ import {
 import { randomBytes } from "node:crypto";
 import {
 	API_KEY_PREFIX,
-	getApiKeyCacheKey,
 	hashApiKey,
 } from "@reloop/auth/apikey/helpers";
+import { createApiKeyCredentialCache } from "@reloop/auth/apikey/credential-cache";
 import {
 	type AuthContext,
 	createAuthPlugin,
@@ -389,7 +389,7 @@ describe("createAuthPlugin — authKey", () => {
 		const redis = new MemoryRedis();
 		const raw = makeRawKey();
 		const hashed = hashApiKey(raw);
-		await redis.set(getApiKeyCacheKey(hashed), {
+		await createApiKeyCredentialCache(redis).write(hashed, {
 			userId: "key-user",
 			organizationId: "key-org",
 			apiKeyId: "key-id-1",
@@ -424,7 +424,7 @@ describe("createAuthPlugin — authKey", () => {
 		const redis = new MemoryRedis();
 		const raw = makeRawKey();
 		const hashed = hashApiKey(raw);
-		await redis.set(getApiKeyCacheKey(hashed), {
+		await createApiKeyCredentialCache(redis).write(hashed, {
 			userId: "key-user",
 			organizationId: "key-org",
 			apiKeyId: "key-id-2",
@@ -539,7 +539,7 @@ describe("createAuthPlugin — internal", () => {
 	test("authKeyInternal: API key wins over internal", async () => {
 		const redis = new MemoryRedis();
 		const raw = makeRawKey();
-		await redis.set(getApiKeyCacheKey(hashApiKey(raw)), {
+		await createApiKeyCredentialCache(redis).write(hashApiKey(raw), {
 			userId: "key-user",
 			organizationId: "key-org",
 			apiKeyId: "k1",

--- a/packages/cache/src/redis-client.ts
+++ b/packages/cache/src/redis-client.ts
@@ -92,6 +92,10 @@ export class RedisCache {
 		}
 	}
 
+	/**
+	 * Best-effort delete (session cleanup, secondary storage).
+	 * Logs and swallows Redis errors so logout/session paths stay available.
+	 */
 	async delete(key: string): Promise<void> {
 		try {
 			const redis = await this.getRedisClient();
@@ -102,10 +106,24 @@ export class RedisCache {
 				error,
 			);
 			this.redis = null;
-			// Fail closed — callers (e.g. API key credential invalidate) must not treat a failed delete as success
-			throw error instanceof Error
-				? error
-				: new Error(String(error));
+		}
+	}
+
+	/**
+	 * Fail-closed delete for security-sensitive paths (e.g. API key credential invalidate).
+	 * Rethrows so callers cannot treat a failed delete as success.
+	 */
+	async deleteStrict(key: string): Promise<void> {
+		try {
+			const redis = await this.getRedisClient();
+			await redis.del(this.getKey(key));
+		} catch (error) {
+			console.error(
+				`Redis deleteStrict error for ${this.prefix} cache, key "${key}":`,
+				error,
+			);
+			this.redis = null;
+			throw error instanceof Error ? error : new Error(String(error));
 		}
 	}
 

--- a/packages/cache/src/redis-client.ts
+++ b/packages/cache/src/redis-client.ts
@@ -102,6 +102,10 @@ export class RedisCache {
 				error,
 			);
 			this.redis = null;
+			// Fail closed — callers (e.g. API key credential invalidate) must not treat a failed delete as success
+			throw error instanceof Error
+				? error
+				: new Error(String(error));
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Introduce **ApiKeyCredentialCache** (`read` / `write` / `invalidate`) as the single hash-keyed seam for API Key credential caching in `@reloop/auth`.
- Route **`validateApiKey`** so all cache get/set goes through that module (30-day TTL and key formula owned there).
- Export `@reloop/auth/apikey/credential-cache` separately from pure helpers; keep `getApiKeyCacheKey` as a thin delegate for existing callers.
- Make **`RedisCache.delete` fail closed** (rethrow) so invalidate cannot silently succeed when Redis is down.

Closes #65 (part of #64).

## Follow-ups (not in this PR)

- Dual store types (`ApiKeyCache` vs `ApiKeyCredentialStore`) + `asCredentialStore` adapter — optional cleanup.
- Lifecycle invalidate on disable/delete/rotate is **#66–#68**.

## Test plan

- [x] `cd packages/auth && bun test test/` (credential-cache + middleware + helpers isolation)
- [x] `cd packages/auth && bun run typecheck`
- [ ] CI green on this PR
- [ ] Spot-check: valid `x-api-key` still authenticates via existing middleware path

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a shared API key credential cache path for auth validation. The main changes are:

- New `ApiKeyCredentialCache` module for read, write, and invalidate.
- API key validation now reads and writes through the cache wrapper.
- A separate `deleteStrict` Redis method for fail-closed deletes.
- `RedisCache.delete` remains best-effort for session cleanup.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- Session cleanup paths continue to use best-effort Redis deletes.
- The strict delete path is separated for callers that need confirmed invalidation.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/cache/src/redis-client.ts | Restores best-effort Redis deletes and adds a strict delete method for confirmed removal. |
| packages/auth/src/apikey/credential-cache.ts | Adds the shared hash-keyed API key credential cache wrapper. |
| packages/auth/src/apikey/validate.ts | Routes API key validation cache reads and writes through the new cache wrapper. |
| packages/auth/src/middleware/types.ts | Extends the auth Redis interface with optional strict delete support. |

<sub>Reviews (2): Last reviewed commit: ["fix: keep session Redis delete best-effo..."](https://github.com/reloop-labs/reloop/commit/5669374d0b962ca9641d31d0f4705803da139c9d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43771022)</sub>

<!-- /greptile_comment -->