### PR TITLE
Disable API Key clears credential cache

### DIFF
--- a/apps/backend/api-key/src/credential/api-key-credential.ts
+++ b/apps/backend/api-key/src/credential/api-key-credential.ts
@@ -1,0 +1,169 @@
+import { ApiKeyErrors } from "@reloop/api-key/error/api-key.error-response";
+import type { ApiKeyCredentialCache } from "@reloop/auth/apikey/credential-cache";
+import {
+	BusEvent,
+	type BusEvent as BusEventName,
+	type EventPayloads,
+} from "@reloop/bus";
+import type { DatabaseInstance } from "@reloop/db/client";
+import * as schema from "@reloop/db/schema";
+import { and, eq } from "drizzle-orm";
+import { createError } from "evlog";
+
+export type ApiKeyCredentialBus = {
+	publish<T extends BusEventName>(
+		event: T,
+		payload: EventPayloads[T],
+		opts?: { msgId?: string },
+	): Promise<void>;
+};
+
+export type ApiKeyCredentialLog = {
+	info: (message: string) => void;
+	warn: (message: string) => void;
+	error: (message: string, data?: unknown) => void;
+};
+
+export type ApiKeyCredentialDeps = {
+	db: DatabaseInstance;
+	credentialCache: ApiKeyCredentialCache;
+	bus: ApiKeyCredentialBus;
+};
+
+export type ApiKeyRowWithUser = typeof schema.apikey.$inferSelect & {
+	user: {
+		id: string;
+		name: string | null;
+		image: string | null;
+		email: string;
+	};
+};
+
+export type DisableApiKeyResult = {
+	row: ApiKeyRowWithUser;
+	/** True when the row was already disabled before this call. */
+	alreadyDisabled: boolean;
+};
+
+function defaultLog(): ApiKeyCredentialLog {
+	return {
+		info: () => {},
+		warn: () => {},
+		error: () => {},
+	};
+}
+
+/**
+ * Service-local mutators for API Key credential material.
+ * Auth owns the credential cache; this module owns DB lifecycle + invalidate + bus.
+ */
+export function createApiKeyCredential(deps: ApiKeyCredentialDeps) {
+	const { db, credentialCache, bus } = deps;
+
+	return {
+		async disable({
+			id,
+			organizationId,
+			log = defaultLog(),
+		}: {
+			id: string;
+			organizationId: string;
+			log?: ApiKeyCredentialLog;
+		}): Promise<DisableApiKeyResult> {
+			const { hashedKey, alreadyDisabled } = await db.transaction(
+				async (tx) => {
+					const locked = await tx
+						.select()
+						.from(schema.apikey)
+						.where(
+							and(
+								eq(schema.apikey.id, id),
+								eq(schema.apikey.organizationId, organizationId),
+							),
+						)
+						.for("update");
+
+					const row = locked[0];
+					if (!row) {
+						log.warn("API key not found");
+						throw ApiKeyErrors.notFound(id);
+					}
+
+					if (!row.enabled) {
+						log.info("API key is already disabled");
+						return {
+							hashedKey: row.key,
+							alreadyDisabled: true as const,
+						};
+					}
+
+					const [updated] = await tx
+						.update(schema.apikey)
+						.set({ enabled: false, updatedAt: new Date() })
+						.where(
+							and(
+								eq(schema.apikey.id, id),
+								eq(schema.apikey.organizationId, organizationId),
+							),
+						)
+						.returning();
+
+					if (!updated) {
+						log.error("Failed to disable API key");
+						throw ApiKeyErrors.disableFailed(id);
+					}
+
+					log.info("API key disabled successfully");
+					return {
+						hashedKey: updated.key,
+						alreadyDisabled: false as const,
+					};
+				},
+			);
+
+			// Post-commit: fail closed if cache cannot be cleared
+			try {
+				await credentialCache.invalidate(hashedKey);
+			} catch (cause) {
+				log.error("Failed to invalidate API key credential cache", cause);
+				throw createError({
+					status: 503,
+					message: "Failed to revoke API key credential cache",
+					why: "The API key was disabled in the database but its auth cache entry could not be cleared.",
+					fix: "Retry the disable operation. If the problem persists, contact support.",
+				});
+			}
+
+			if (!alreadyDisabled) {
+				try {
+					await bus.publish(BusEvent.API_KEY_DISABLED, {
+						api_key_id: id,
+						organizationId,
+					});
+					log.info("NATS event published");
+				} catch (err) {
+					log.error("NATS publish failed after disable (auth already revoked)", err);
+				}
+			}
+
+			const withUser = await db.query.apikey.findFirst({
+				where: and(
+					eq(schema.apikey.id, id),
+					eq(schema.apikey.organizationId, organizationId),
+				),
+				with: { user: true },
+			});
+
+			if (!withUser?.user) {
+				throw ApiKeyErrors.notFound(id);
+			}
+
+			return {
+				row: withUser as ApiKeyRowWithUser,
+				alreadyDisabled,
+			};
+		},
+	};
+}
+
+export type ApiKeyCredential = ReturnType<typeof createApiKeyCredential>;

--- a/apps/backend/api-key/src/credential/api-key-credential.ts
+++ b/apps/backend/api-key/src/credential/api-key-credential.ts
@@ -30,13 +30,16 @@ export type ApiKeyCredentialDeps = {
 	bus: ApiKeyCredentialBus;
 };
 
+export type ApiKeyCreator = {
+	id: string;
+	name: string | null;
+	image: string | null;
+	email: string;
+};
+
+/** API Key row after disable; creator may be missing if the user relation is gone. */
 export type ApiKeyRowWithUser = typeof schema.apikey.$inferSelect & {
-	user: {
-		id: string;
-		name: string | null;
-		image: string | null;
-		email: string;
-	};
+	user?: ApiKeyCreator | null;
 };
 
 export type DisableApiKeyResult = {
@@ -70,56 +73,60 @@ export function createApiKeyCredential(deps: ApiKeyCredentialDeps) {
 			organizationId: string;
 			log?: ApiKeyCredentialLog;
 		}): Promise<DisableApiKeyResult> {
-			const { hashedKey, alreadyDisabled } = await db.transaction(
-				async (tx) => {
-					const locked = await tx
-						.select()
-						.from(schema.apikey)
-						.where(
-							and(
-								eq(schema.apikey.id, id),
-								eq(schema.apikey.organizationId, organizationId),
-							),
-						)
-						.for("update");
+			const {
+				hashedKey,
+				alreadyDisabled,
+				committedRow,
+			} = await db.transaction(async (tx) => {
+				const locked = await tx
+					.select()
+					.from(schema.apikey)
+					.where(
+						and(
+							eq(schema.apikey.id, id),
+							eq(schema.apikey.organizationId, organizationId),
+						),
+					)
+					.for("update");
 
-					const row = locked[0];
-					if (!row) {
-						log.warn("API key not found");
-						throw ApiKeyErrors.notFound(id);
-					}
+				const row = locked[0];
+				if (!row) {
+					log.warn("API key not found");
+					throw ApiKeyErrors.notFound(id);
+				}
 
-					if (!row.enabled) {
-						log.info("API key is already disabled");
-						return {
-							hashedKey: row.key,
-							alreadyDisabled: true as const,
-						};
-					}
-
-					const [updated] = await tx
-						.update(schema.apikey)
-						.set({ enabled: false, updatedAt: new Date() })
-						.where(
-							and(
-								eq(schema.apikey.id, id),
-								eq(schema.apikey.organizationId, organizationId),
-							),
-						)
-						.returning();
-
-					if (!updated) {
-						log.error("Failed to disable API key");
-						throw ApiKeyErrors.disableFailed(id);
-					}
-
-					log.info("API key disabled successfully");
+				if (!row.enabled) {
+					log.info("API key is already disabled");
 					return {
-						hashedKey: updated.key,
-						alreadyDisabled: false as const,
+						hashedKey: row.key,
+						alreadyDisabled: true as const,
+						committedRow: row,
 					};
-				},
-			);
+				}
+
+				const [updated] = await tx
+					.update(schema.apikey)
+					.set({ enabled: false, updatedAt: new Date() })
+					.where(
+						and(
+							eq(schema.apikey.id, id),
+							eq(schema.apikey.organizationId, organizationId),
+						),
+					)
+					.returning();
+
+				if (!updated) {
+					log.error("Failed to disable API key");
+					throw ApiKeyErrors.disableFailed(id);
+				}
+
+				log.info("API key disabled successfully");
+				return {
+					hashedKey: updated.key,
+					alreadyDisabled: false as const,
+					committedRow: updated,
+				};
+			});
 
 			// Post-commit: fail closed if cache cannot be cleared
 			try {
@@ -142,10 +149,14 @@ export function createApiKeyCredential(deps: ApiKeyCredentialDeps) {
 					});
 					log.info("NATS event published");
 				} catch (err) {
-					log.error("NATS publish failed after disable (auth already revoked)", err);
+					log.error(
+						"NATS publish failed after disable (auth already revoked)",
+						err,
+					);
 				}
 			}
 
+			// Prefer full row + creator for the response; never 404 after a committed disable.
 			const withUser = await db.query.apikey.findFirst({
 				where: and(
 					eq(schema.apikey.id, id),
@@ -154,12 +165,21 @@ export function createApiKeyCredential(deps: ApiKeyCredentialDeps) {
 				with: { user: true },
 			});
 
-			if (!withUser?.user) {
-				throw ApiKeyErrors.notFound(id);
+			if (withUser) {
+				return {
+					row: {
+						...withUser,
+						user: withUser.user ?? null,
+					},
+					alreadyDisabled,
+				};
 			}
 
+			log.warn(
+				"API key row missing after successful disable; returning committed row without creator",
+			);
 			return {
-				row: withUser as ApiKeyRowWithUser,
+				row: { ...committedRow, user: null },
 				alreadyDisabled,
 			};
 		},

--- a/apps/backend/api-key/src/routes/api-key/disable-api-key/disable-api-key.controllers.ts
+++ b/apps/backend/api-key/src/routes/api-key/disable-api-key/disable-api-key.controllers.ts
@@ -1,11 +1,67 @@
-import { ApiKeyErrors } from "@reloop/api-key/error/api-key.error-response";
+import { apiKeyCredential } from "@reloop/api-key/utils/loader";
 import type { ApiKeyTypes } from "@reloop/api-key/types/api-key.type";
-import { BusEvent, bus } from "@reloop/bus";
-import { db } from "@reloop/db/client";
-import * as schema from "@reloop/db/schema";
 import { API_KEY_UPDATE_WEBHOOK_EVENT } from "@reloop/webhook-events";
-import { and, eq } from "drizzle-orm";
 import { useLogger } from "evlog/elysia";
+
+function toApiKeyResponse(
+	row: {
+		id: string;
+		name: string | null;
+		start: string | null;
+		prefix: string | null;
+		refillInterval: number | null;
+		refillAmount: number | null;
+		lastRefillAt: Date | null;
+		enabled: boolean;
+		rateLimitEnabled: boolean;
+		rateLimitTimeWindow: number;
+		rateLimitMax: number;
+		requestCount: number;
+		remaining: number | null;
+		lastRequest: Date | null;
+		expiresAt: Date | null;
+		createdAt: Date;
+		updatedAt: Date;
+		permissions: string | null;
+		metadata: string | null;
+		user: {
+			id: string;
+			name: string | null;
+			image: string | null;
+			email: string;
+		};
+	},
+): ApiKeyTypes.ApiKeyResponse {
+	return {
+		id: row.id,
+		name: row.name,
+		start: row.start,
+		prefix: row.prefix,
+		refillInterval: row.refillInterval,
+		refillAmount: row.refillAmount,
+		lastRefillAt: row.lastRefillAt?.toISOString() ?? null,
+		enabled: row.enabled,
+		rateLimitEnabled: row.rateLimitEnabled,
+		rateLimitTimeWindow: row.rateLimitTimeWindow,
+		rateLimitMax: row.rateLimitMax,
+		requestCount: row.requestCount,
+		remaining: row.remaining,
+		lastRequest: row.lastRequest?.toISOString() ?? null,
+		expiresAt: row.expiresAt?.toISOString() ?? null,
+		createdAt: row.createdAt.toISOString(),
+		updatedAt: row.updatedAt.toISOString(),
+		permissions: row.permissions,
+		metadata: row.metadata,
+		createdBy: {
+			id: row.user.id,
+			name: row.user.name,
+			image: row.user.image,
+			email: row.user.email,
+		},
+		object: "api_key" as const,
+		event: API_KEY_UPDATE_WEBHOOK_EVENT.id,
+	};
+}
 
 export async function disableApiKeyController({
 	id,
@@ -14,116 +70,24 @@ export async function disableApiKeyController({
 	id: string;
 	organizationId: string;
 }): Promise<ApiKeyTypes.ApiKeyResponse> {
-	const log = useLogger();
-	try {
-		// Single UPDATE...RETURNING — only updates if currently enabled
-		const [updatedKey] = await db
-			.update(schema.apikey)
-			.set({ enabled: false, updatedAt: new Date() })
-			.where(
-				and(
-					eq(schema.apikey.id, id),
-					eq(schema.apikey.organizationId, organizationId),
-				),
-			)
-			.returning();
+	const elysiaLog = useLogger();
+	const log = {
+		info: (message: string) => {
+			elysiaLog.info(message);
+		},
+		warn: (message: string) => {
+			elysiaLog.warn(message);
+		},
+		error: (message: string, _data?: unknown) => {
+			elysiaLog.error(message);
+		},
+	};
 
-		// If no row returned, either not found or already disabled — check which
-		let updatedKeyData: typeof schema.apikey.$inferSelect;
-		if (!updatedKey) {
-			const existing = await db.query.apikey.findFirst({
-				where: and(
-					eq(schema.apikey.id, id),
-					eq(schema.apikey.organizationId, organizationId),
-				),
-				with: { user: true },
-			});
-			if (!existing) {
-				log.warn("API key not found");
-				throw ApiKeyErrors.notFound(id);
-			}
-			log.info("API key is already disabled");
-			updatedKeyData = existing;
-			const result = {
-				id: updatedKeyData.id,
-				name: updatedKeyData.name,
-				start: updatedKeyData.start,
-				prefix: updatedKeyData.prefix,
-				refillInterval: updatedKeyData.refillInterval,
-				refillAmount: updatedKeyData.refillAmount,
-				lastRefillAt: updatedKeyData.lastRefillAt?.toISOString() ?? null,
-				enabled: updatedKeyData.enabled,
-				rateLimitEnabled: updatedKeyData.rateLimitEnabled,
-				rateLimitTimeWindow: updatedKeyData.rateLimitTimeWindow,
-				rateLimitMax: updatedKeyData.rateLimitMax,
-				requestCount: updatedKeyData.requestCount,
-				remaining: updatedKeyData.remaining,
-				lastRequest: updatedKeyData.lastRequest?.toISOString() ?? null,
-				expiresAt: updatedKeyData.expiresAt?.toISOString() ?? null,
-				createdAt: updatedKeyData.createdAt.toISOString(),
-				updatedAt: updatedKeyData.updatedAt.toISOString(),
-				permissions: updatedKeyData.permissions,
-				metadata: updatedKeyData.metadata,
-				createdBy: {
-					id: existing.user.id,
-					name: existing.user.name,
-					image: existing.user.image,
-					email: existing.user.email,
-				},
-				object: "api_key" as const,
-				event: API_KEY_UPDATE_WEBHOOK_EVENT.id,
-			};
-			return result;
-		}
+	const { row } = await apiKeyCredential.disable({
+		id,
+		organizationId,
+		log,
+	});
 
-		log.info("API key disabled successfully");
-		await bus.publish(BusEvent.API_KEY_DISABLED, {
-			api_key_id: id,
-			organizationId,
-		});
-		log.info("NATS event published");
-
-		// Fetch user for response
-		const keyWithUser = await db.query.apikey.findFirst({
-			where: eq(schema.apikey.id, id),
-			with: { user: true },
-		});
-
-		const result = {
-			id: updatedKey.id,
-			name: updatedKey.name,
-			start: updatedKey.start,
-			prefix: updatedKey.prefix,
-			refillInterval: updatedKey.refillInterval,
-			refillAmount: updatedKey.refillAmount,
-			lastRefillAt: updatedKey.lastRefillAt?.toISOString() ?? null,
-			enabled: updatedKey.enabled,
-			rateLimitEnabled: updatedKey.rateLimitEnabled,
-			rateLimitTimeWindow: updatedKey.rateLimitTimeWindow,
-			rateLimitMax: updatedKey.rateLimitMax,
-			requestCount: updatedKey.requestCount,
-			remaining: updatedKey.remaining,
-			lastRequest: updatedKey.lastRequest?.toISOString() ?? null,
-			expiresAt: updatedKey.expiresAt?.toISOString() ?? null,
-			createdAt: updatedKey.createdAt.toISOString(),
-			updatedAt: updatedKey.updatedAt.toISOString(),
-			permissions: updatedKey.permissions,
-			metadata: updatedKey.metadata,
-			createdBy: keyWithUser?.user
-				? {
-						id: keyWithUser.user.id,
-						name: keyWithUser.user.name,
-						image: keyWithUser.user.image,
-						email: keyWithUser.user.email,
-					}
-				: undefined,
-			object: "api_key" as const,
-			event: API_KEY_UPDATE_WEBHOOK_EVENT.id,
-		};
-
-		return result;
-	} catch (error) {
-		log.error("Error disabling API key");
-		throw error;
-	}
+	return toApiKeyResponse(row);
 }

--- a/apps/backend/api-key/src/routes/api-key/disable-api-key/disable-api-key.controllers.ts
+++ b/apps/backend/api-key/src/routes/api-key/disable-api-key/disable-api-key.controllers.ts
@@ -24,12 +24,12 @@ function toApiKeyResponse(
 		updatedAt: Date;
 		permissions: string | null;
 		metadata: string | null;
-		user: {
+		user?: {
 			id: string;
 			name: string | null;
 			image: string | null;
 			email: string;
-		};
+		} | null;
 	},
 ): ApiKeyTypes.ApiKeyResponse {
 	return {
@@ -52,12 +52,14 @@ function toApiKeyResponse(
 		updatedAt: row.updatedAt.toISOString(),
 		permissions: row.permissions,
 		metadata: row.metadata,
-		createdBy: {
-			id: row.user.id,
-			name: row.user.name,
-			image: row.user.image,
-			email: row.user.email,
-		},
+		createdBy: row.user
+			? {
+					id: row.user.id,
+					name: row.user.name,
+					image: row.user.image,
+					email: row.user.email,
+				}
+			: undefined,
 		object: "api_key" as const,
 		event: API_KEY_UPDATE_WEBHOOK_EVENT.id,
 	};

--- a/apps/backend/api-key/src/utils/loader.ts
+++ b/apps/backend/api-key/src/utils/loader.ts
@@ -1,6 +1,9 @@
 import { apiKeyConfig } from "@reloop/api-key/api-key.config";
 import { createApiKeyCredential } from "@reloop/api-key/credential/api-key-credential";
-import { createApiKeyCredentialCache } from "@reloop/auth/apikey/credential-cache";
+import {
+	authRedisAsCredentialStore,
+	createApiKeyCredentialCache,
+} from "@reloop/auth/apikey/credential-cache";
 import { createSessionCacheRedis } from "@reloop/auth/middleware";
 import { bus } from "@reloop/bus";
 import { RedisCache } from "@reloop/cache/redis-client";
@@ -13,8 +16,10 @@ export const redis = new RedisCache("api-key", 86400);
 /** Same Redis family as request-auth validation cache (reloop-session prefix). */
 const authCredentialRedis = createSessionCacheRedis(apiKeyConfig.REDIS_URL);
 
-export const apiKeyCredentialCache =
-	createApiKeyCredentialCache(authCredentialRedis);
+/** Uses deleteStrict so invalidate fails closed without breaking session soft-delete. */
+export const apiKeyCredentialCache = createApiKeyCredentialCache(
+	authRedisAsCredentialStore(authCredentialRedis),
+);
 
 export const apiKeyCredential = createApiKeyCredential({
 	db,

--- a/apps/backend/api-key/src/utils/loader.ts
+++ b/apps/backend/api-key/src/utils/loader.ts
@@ -1,10 +1,26 @@
 import { apiKeyConfig } from "@reloop/api-key/api-key.config";
+import { createApiKeyCredential } from "@reloop/api-key/credential/api-key-credential";
+import { createApiKeyCredentialCache } from "@reloop/auth/apikey/credential-cache";
+import { createSessionCacheRedis } from "@reloop/auth/middleware";
 import { bus } from "@reloop/bus";
 import { RedisCache } from "@reloop/cache/redis-client";
 import { db } from "@reloop/db/client";
 import { log } from "evlog";
 
+/** Management rate-limit Redis (api-key prefix) — not used for auth credentials. */
 export const redis = new RedisCache("api-key", 86400);
+
+/** Same Redis family as request-auth validation cache (reloop-session prefix). */
+const authCredentialRedis = createSessionCacheRedis(apiKeyConfig.REDIS_URL);
+
+export const apiKeyCredentialCache =
+	createApiKeyCredentialCache(authCredentialRedis);
+
+export const apiKeyCredential = createApiKeyCredential({
+	db,
+	credentialCache: apiKeyCredentialCache,
+	bus,
+});
 
 export const loader = async () => {
 	try {

--- a/apps/backend/api-key/test/api-key-credential-disable.test.ts
+++ b/apps/backend/api-key/test/api-key-credential-disable.test.ts
@@ -1,0 +1,347 @@
+import { describe, expect, test } from "bun:test";
+import { createApiKeyCredential } from "@reloop/api-key/credential/api-key-credential";
+import {
+	createApiKeyCredentialCache,
+	type ApiKeyCredentialEntry,
+} from "@reloop/auth/apikey/credential-cache";
+import { generateApiKey, hashApiKey } from "@reloop/auth/apikey";
+import { validateApiKey } from "@reloop/auth/apikey/validate";
+import { BusEvent } from "@reloop/bus";
+
+type FakeRow = {
+	id: string;
+	organizationId: string;
+	userId: string;
+	key: string;
+	enabled: boolean;
+	name: string | null;
+	start: string | null;
+	prefix: string | null;
+	refillInterval: null;
+	refillAmount: null;
+	lastRefillAt: null;
+	rateLimitEnabled: boolean;
+	rateLimitTimeWindow: number;
+	rateLimitMax: number;
+	requestCount: number;
+	remaining: null;
+	lastRequest: null;
+	expiresAt: null;
+	createdAt: Date;
+	updatedAt: Date;
+	permissions: null;
+	metadata: null;
+	user: {
+		id: string;
+		name: string;
+		image: null;
+		email: string;
+	};
+};
+
+/**
+ * Minimal db stand-in: transaction + query.findFirst for disable path.
+ * Not a full drizzle mock — only methods the mutator uses.
+ */
+function createFakeDb(initial: FakeRow) {
+	let row = { ...initial };
+
+	const db = {
+		async transaction<T>(fn: (tx: typeof tx) => Promise<T>): Promise<T> {
+			return fn(tx);
+		},
+		query: {
+			apikey: {
+				findFirst: async () => ({
+					...row,
+					user: row.user,
+				}),
+			},
+		},
+	};
+
+	const tx = {
+		select() {
+			return {
+				from() {
+					return {
+						where() {
+							return {
+								for() {
+									return Promise.resolve([{ ...row }]);
+								},
+							};
+						},
+					};
+				},
+			};
+		},
+		update() {
+			return {
+				set(values: { enabled?: boolean; updatedAt?: Date }) {
+					return {
+						where() {
+							return {
+								returning() {
+									row = {
+										...row,
+										...values,
+										enabled: values.enabled ?? row.enabled,
+										updatedAt: values.updatedAt ?? row.updatedAt,
+									};
+									return Promise.resolve([{ ...row }]);
+								},
+							};
+						},
+					};
+				},
+			};
+		},
+	};
+
+	return {
+		db: db as never,
+		getRow: () => row,
+	};
+}
+
+function memoryStore() {
+	const map = new Map<string, string>();
+	return {
+		async get<T>(key: string): Promise<T | undefined> {
+			const raw = map.get(key);
+			if (raw === undefined) return undefined;
+			return JSON.parse(raw) as T;
+		},
+		async set(key: string, value: unknown): Promise<void> {
+			map.set(key, JSON.stringify(value));
+		},
+		async delete(key: string): Promise<void> {
+			map.delete(key);
+		},
+		has(key: string) {
+			return map.has(key);
+		},
+	};
+}
+
+describe("ApiKeyCredential.disable", () => {
+	test("after disable, previously cached secret fails validateApiKey", async () => {
+		const raw = generateApiKey();
+		const hashed = hashApiKey(raw);
+		const entry: ApiKeyCredentialEntry = {
+			userId: "user-1",
+			organizationId: "org-1",
+			apiKeyId: "key-1",
+		};
+
+		const store = memoryStore();
+		const credentialCache = createApiKeyCredentialCache(store);
+		await credentialCache.write(hashed, entry);
+
+		// Cache hit path would auth before disable
+		const before = await validateApiKey(raw, store, {
+			query: {
+				apikey: {
+					findFirst: async () => null,
+				},
+			},
+			update: () => ({
+				set: () => ({
+					where: () => ({
+						catch: () => {},
+					}),
+				}),
+			}),
+		} as never);
+		expect(before).toEqual({
+			...entry,
+			authType: "apikey",
+		});
+
+		const now = new Date();
+		const { db } = createFakeDb({
+			id: "key-1",
+			organizationId: "org-1",
+			userId: "user-1",
+			key: hashed,
+			enabled: true,
+			name: "test",
+			start: raw.slice(0, 17),
+			prefix: "rl_prod",
+			refillInterval: null,
+			refillAmount: null,
+			lastRefillAt: null,
+			rateLimitEnabled: true,
+			rateLimitTimeWindow: 1000,
+			rateLimitMax: 100,
+			requestCount: 0,
+			remaining: null,
+			lastRequest: null,
+			expiresAt: null,
+			createdAt: now,
+			updatedAt: now,
+			permissions: null,
+			metadata: null,
+			user: {
+				id: "user-1",
+				name: "Test",
+				image: null,
+				email: "t@example.com",
+			},
+		});
+
+		const publishes: unknown[] = [];
+		const credential = createApiKeyCredential({
+			db,
+			credentialCache,
+			bus: {
+				publish: async (event, payload) => {
+					publishes.push({ event, payload });
+				},
+			},
+		});
+
+		const result = await credential.disable({
+			id: "key-1",
+			organizationId: "org-1",
+		});
+
+		expect(result.alreadyDisabled).toBe(false);
+		expect(result.row.enabled).toBe(false);
+		expect(publishes).toEqual([
+			{
+				event: BusEvent.API_KEY_DISABLED,
+				payload: { api_key_id: "key-1", organizationId: "org-1" },
+			},
+		]);
+
+		// Cache cleared; DB path returns no enabled row → null
+		const after = await validateApiKey(raw, store, {
+			query: {
+				apikey: {
+					findFirst: async () => null,
+				},
+			},
+			update: () => ({
+				set: () => ({
+					where: () => ({
+						catch: () => {},
+					}),
+				}),
+			}),
+		} as never);
+		expect(after).toBeNull();
+	});
+
+	test("invalidate failure fails the operation after DB disable", async () => {
+		const raw = generateApiKey();
+		const hashed = hashApiKey(raw);
+		const now = new Date();
+		const { db } = createFakeDb({
+			id: "key-1",
+			organizationId: "org-1",
+			userId: "user-1",
+			key: hashed,
+			enabled: true,
+			name: "test",
+			start: null,
+			prefix: null,
+			refillInterval: null,
+			refillAmount: null,
+			lastRefillAt: null,
+			rateLimitEnabled: true,
+			rateLimitTimeWindow: 1000,
+			rateLimitMax: 100,
+			requestCount: 0,
+			remaining: null,
+			lastRequest: null,
+			expiresAt: null,
+			createdAt: now,
+			updatedAt: now,
+			permissions: null,
+			metadata: null,
+			user: {
+				id: "user-1",
+				name: "Test",
+				image: null,
+				email: "t@example.com",
+			},
+		});
+
+		const credential = createApiKeyCredential({
+			db,
+			credentialCache: {
+				read: async () => undefined,
+				write: async () => {},
+				invalidate: async () => {
+					throw new Error("redis down");
+				},
+			},
+			bus: {
+				publish: async () => {
+					throw new Error("should not publish");
+				},
+			},
+		});
+
+		await expect(
+			credential.disable({ id: "key-1", organizationId: "org-1" }),
+		).rejects.toMatchObject({
+			message: "Failed to revoke API key credential cache",
+		});
+	});
+
+	test("bus failure after successful invalidate still succeeds", async () => {
+		const hashed = hashApiKey(generateApiKey());
+		const store = memoryStore();
+		const credentialCache = createApiKeyCredentialCache(store);
+		const now = new Date();
+		const { db } = createFakeDb({
+			id: "key-1",
+			organizationId: "org-1",
+			userId: "user-1",
+			key: hashed,
+			enabled: true,
+			name: "test",
+			start: null,
+			prefix: null,
+			refillInterval: null,
+			refillAmount: null,
+			lastRefillAt: null,
+			rateLimitEnabled: true,
+			rateLimitTimeWindow: 1000,
+			rateLimitMax: 100,
+			requestCount: 0,
+			remaining: null,
+			lastRequest: null,
+			expiresAt: null,
+			createdAt: now,
+			updatedAt: now,
+			permissions: null,
+			metadata: null,
+			user: {
+				id: "user-1",
+				name: "Test",
+				image: null,
+				email: "t@example.com",
+			},
+		});
+
+		const credential = createApiKeyCredential({
+			db,
+			credentialCache,
+			bus: {
+				publish: async () => {
+					throw new Error("nats down");
+				},
+			},
+		});
+
+		const result = await credential.disable({
+			id: "key-1",
+			organizationId: "org-1",
+		});
+		expect(result.row.enabled).toBe(false);
+	});
+});

--- a/apps/backend/api-key/test/api-key-credential-disable.test.ts
+++ b/apps/backend/api-key/test/api-key-credential-disable.test.ts
@@ -292,6 +292,67 @@ describe("ApiKeyCredential.disable", () => {
 		});
 	});
 
+	test("missing creator after commit still returns successful disable (no 404)", async () => {
+		const hashed = hashApiKey(generateApiKey());
+		const store = memoryStore();
+		const credentialCache = createApiKeyCredentialCache(store);
+		const now = new Date();
+		const { db, getRow } = createFakeDb({
+			id: "key-1",
+			organizationId: "org-1",
+			userId: "user-1",
+			key: hashed,
+			enabled: true,
+			name: "test",
+			start: null,
+			prefix: null,
+			refillInterval: null,
+			refillAmount: null,
+			lastRefillAt: null,
+			rateLimitEnabled: true,
+			rateLimitTimeWindow: 1000,
+			rateLimitMax: 100,
+			requestCount: 0,
+			remaining: null,
+			lastRequest: null,
+			expiresAt: null,
+			createdAt: now,
+			updatedAt: now,
+			permissions: null,
+			metadata: null,
+			user: {
+				id: "user-1",
+				name: "Test",
+				image: null,
+				email: "t@example.com",
+			},
+		});
+
+		// Simulate missing user relation on post-commit reload
+		(db as { query: { apikey: { findFirst: () => Promise<unknown> } } }).query =
+			{
+				apikey: {
+					findFirst: async () => ({
+						...getRow(),
+						user: null,
+					}),
+				},
+			};
+
+		const credential = createApiKeyCredential({
+			db,
+			credentialCache,
+			bus: { publish: async () => {} },
+		});
+
+		const result = await credential.disable({
+			id: "key-1",
+			organizationId: "org-1",
+		});
+		expect(result.row.enabled).toBe(false);
+		expect(result.row.user).toBeNull();
+	});
+
 	test("bus failure after successful invalidate still succeeds", async () => {
 		const hashed = hashApiKey(generateApiKey());
 		const store = memoryStore();


### PR DESCRIPTION
## Summary

- Introduce service-local **ApiKeyCredential** mutator with **disable**
- Order: txn + `FOR UPDATE` → DB disable → commit → **invalidate** (fail closed) → NATS best-effort
- Credential cache uses **auth validation Redis** (`reloop-session`), not management rate-limit Redis
- Thin disable controller/route; response shape unchanged on success

Closes #66 (depends on #65 / #70).

## Test plan

- [x] `cd apps/backend/api-key && bun test test/` (disable mutator + auth-smoke)
- [ ] CI green
- [ ] After merge of #70, retarget this PR to `main` if needed

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves API key disable into a credential-aware flow. The main changes are:

- Adds a service-local API key credential mutator.
- Disables keys inside a locked database transaction.
- Invalidates the auth credential cache after commit.
- Publishes the disable event best-effort after revocation.
- Updates the disable controller to use the new mutator.
- Adds tests for cache invalidation and missing creator responses.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The committed disable path now returns a response when the creator relation is missing.
- Cache invalidation is wired to the auth credential cache used by validation.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/backend/api-key/src/credential/api-key-credential.ts | Adds the disable mutator with transaction locking, cache invalidation, best-effort event publishing, and a post-commit response fallback. |
| apps/backend/api-key/src/routes/api-key/disable-api-key/disable-api-key.controllers.ts | Delegates disable behavior to the credential mutator and maps rows with optional creators into the API response. |
| apps/backend/api-key/src/utils/loader.ts | Wires the credential mutator to the database, auth credential cache, and bus. |
| apps/backend/api-key/test/api-key-credential-disable.test.ts | Adds tests for disable cache clearing, invalidate failure handling, missing creator handling, and bus failure handling. |

<sub>Reviews (2): Last reviewed commit: ["fix: address Greptile review on disable ..."](https://github.com/reloop-labs/reloop/commit/76dc9aa76da51266cef91371ea8a3fa19f6c8035) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43771376)</sub>

<!-- /greptile_comment -->