### PR TITLE
Delete API Key clears credential cache

### DIFF
--- a/apps/backend/api-key/src/credential/api-key-credential.ts
+++ b/apps/backend/api-key/src/credential/api-key-credential.ts
@@ -48,12 +48,25 @@ export type DisableApiKeyResult = {
 	alreadyDisabled: boolean;
 };
 
+export type DeleteApiKeyResult = {
+	id: string;
+};
+
 function defaultLog(): ApiKeyCredentialLog {
 	return {
 		info: () => {},
 		warn: () => {},
 		error: () => {},
 	};
+}
+
+function credentialCacheRevokeError(action: "disabled" | "deleted") {
+	return createError({
+		status: 503,
+		message: "Failed to revoke API key credential cache",
+		why: `The API key was ${action} in the database but its auth cache entry could not be cleared.`,
+		fix: `Retry the ${action === "deleted" ? "delete" : "disable"} operation. If the problem persists, contact support.`,
+	});
 }
 
 /**
@@ -133,12 +146,7 @@ export function createApiKeyCredential(deps: ApiKeyCredentialDeps) {
 				await credentialCache.invalidate(hashedKey);
 			} catch (cause) {
 				log.error("Failed to invalidate API key credential cache", cause);
-				throw createError({
-					status: 503,
-					message: "Failed to revoke API key credential cache",
-					why: "The API key was disabled in the database but its auth cache entry could not be cleared.",
-					fix: "Retry the disable operation. If the problem persists, contact support.",
-				});
+				throw credentialCacheRevokeError("disabled");
 			}
 
 			if (!alreadyDisabled) {
@@ -182,6 +190,77 @@ export function createApiKeyCredential(deps: ApiKeyCredentialDeps) {
 				row: { ...committedRow, user: null },
 				alreadyDisabled,
 			};
+		},
+
+		async delete({
+			id,
+			organizationId,
+			log = defaultLog(),
+		}: {
+			id: string;
+			organizationId: string;
+			log?: ApiKeyCredentialLog;
+		}): Promise<DeleteApiKeyResult> {
+			const { hashedKey } = await db.transaction(async (tx) => {
+				const locked = await tx
+					.select()
+					.from(schema.apikey)
+					.where(
+						and(
+							eq(schema.apikey.id, id),
+							eq(schema.apikey.organizationId, organizationId),
+						),
+					)
+					.for("update");
+
+				const row = locked[0];
+				if (!row) {
+					log.warn("API key not found");
+					throw ApiKeyErrors.notFound(id);
+				}
+
+				const hashedKey = row.key;
+
+				const [deleted] = await tx
+					.delete(schema.apikey)
+					.where(
+						and(
+							eq(schema.apikey.id, id),
+							eq(schema.apikey.organizationId, organizationId),
+						),
+					)
+					.returning({ id: schema.apikey.id });
+
+				if (!deleted) {
+					log.error("Failed to delete API key");
+					throw ApiKeyErrors.deleteFailed(id);
+				}
+
+				log.info("API key deleted successfully");
+				return { hashedKey };
+			});
+
+			try {
+				await credentialCache.invalidate(hashedKey);
+			} catch (cause) {
+				log.error("Failed to invalidate API key credential cache", cause);
+				throw credentialCacheRevokeError("deleted");
+			}
+
+			try {
+				await bus.publish(BusEvent.API_KEY_DELETED, {
+					api_key_id: id,
+					organizationId,
+				});
+				log.info("NATS event published");
+			} catch (err) {
+				log.error(
+					"NATS publish failed after delete (auth already revoked)",
+					err,
+				);
+			}
+
+			return { id };
 		},
 	};
 }

--- a/apps/backend/api-key/src/routes/api-key/delete-api-key/delete-api-key.controllers.ts
+++ b/apps/backend/api-key/src/routes/api-key/delete-api-key/delete-api-key.controllers.ts
@@ -1,9 +1,5 @@
-import { ApiKeyErrors } from "@reloop/api-key/error/api-key.error-response";
-import { BusEvent, bus } from "@reloop/bus";
-import { db } from "@reloop/db/client";
-import * as schema from "@reloop/db/schema";
+import { apiKeyCredential } from "@reloop/api-key/utils/loader";
 import { API_KEY_DELETE_WEBHOOK_EVENT } from "@reloop/webhook-events";
-import { and, eq } from "drizzle-orm";
 import { useLogger } from "evlog/elysia";
 
 export async function deleteApiKeyController({
@@ -13,42 +9,31 @@ export async function deleteApiKeyController({
 	apiKeyId: string;
 	organizationId: string;
 }): Promise<{ id: string; message: string; object: "api_key"; event: string }> {
-	const log = useLogger();
+	const elysiaLog = useLogger();
+	const log = {
+		info: (message: string) => {
+			elysiaLog.info(message);
+		},
+		warn: (message: string) => {
+			elysiaLog.warn(message);
+		},
+		error: (message: string, _data?: unknown) => {
+			elysiaLog.error(message);
+		},
+	};
+
 	log.info("Deleting API key");
-	try {
-		const [deleted] = await db
-			.delete(schema.apikey)
-			.where(
-				and(
-					eq(schema.apikey.id, apiKeyId),
-					eq(schema.apikey.organizationId, organizationId),
-				),
-			)
-			.returning({ id: schema.apikey.id });
 
-		if (!deleted) {
-			log.warn("API key not found");
-			throw ApiKeyErrors.notFound(apiKeyId);
-		}
+	const { id } = await apiKeyCredential.delete({
+		id: apiKeyId,
+		organizationId,
+		log,
+	});
 
-		log.info("API key deleted successfully");
-
-		await bus.publish(BusEvent.API_KEY_DELETED, {
-			api_key_id: apiKeyId,
-			organizationId,
-		});
-		log.info("NATS event published");
-
-		const result = {
-			id: apiKeyId,
-			message: "API key deleted successfully",
-			object: "api_key" as const,
-			event: API_KEY_DELETE_WEBHOOK_EVENT.id,
-		};
-
-		return result;
-	} catch (error) {
-		log.error("Error deleting API key");
-		throw error;
-	}
+	return {
+		id,
+		message: "API key deleted successfully",
+		object: "api_key" as const,
+		event: API_KEY_DELETE_WEBHOOK_EVENT.id,
+	};
 }

--- a/apps/backend/api-key/test/api-key-credential-disable.test.ts
+++ b/apps/backend/api-key/test/api-key-credential-disable.test.ts
@@ -40,11 +40,11 @@ type FakeRow = {
 };
 
 /**
- * Minimal db stand-in: transaction + query.findFirst for disable path.
+ * Minimal db stand-in for disable/delete mutator paths.
  * Not a full drizzle mock — only methods the mutator uses.
  */
 function createFakeDb(initial: FakeRow) {
-	let row = { ...initial };
+	let row: FakeRow | null = { ...initial };
 
 	const db = {
 		async transaction<T>(fn: (tx: typeof tx) => Promise<T>): Promise<T> {
@@ -52,10 +52,13 @@ function createFakeDb(initial: FakeRow) {
 		},
 		query: {
 			apikey: {
-				findFirst: async () => ({
-					...row,
-					user: row.user,
-				}),
+				findFirst: async () =>
+					row
+						? {
+								...row,
+								user: row.user,
+							}
+						: undefined,
 			},
 		},
 	};
@@ -68,7 +71,7 @@ function createFakeDb(initial: FakeRow) {
 						where() {
 							return {
 								for() {
-									return Promise.resolve([{ ...row }]);
+									return Promise.resolve(row ? [{ ...row }] : []);
 								},
 							};
 						},
@@ -83,6 +86,7 @@ function createFakeDb(initial: FakeRow) {
 						where() {
 							return {
 								returning() {
+									if (!row) return Promise.resolve([]);
 									row = {
 										...row,
 										...values,
@@ -97,12 +101,78 @@ function createFakeDb(initial: FakeRow) {
 				},
 			};
 		},
+		delete() {
+			return {
+				where() {
+					return {
+						returning() {
+							if (!row) return Promise.resolve([]);
+							const id = row.id;
+							row = null;
+							return Promise.resolve([{ id }]);
+						},
+					};
+				},
+			};
+		},
 	};
 
 	return {
 		db: db as never,
 		getRow: () => row,
 	};
+}
+
+function sampleRow(hashed: string, overrides: Partial<FakeRow> = {}): FakeRow {
+	const now = new Date();
+	return {
+		id: "key-1",
+		organizationId: "org-1",
+		userId: "user-1",
+		key: hashed,
+		enabled: true,
+		name: "test",
+		start: null,
+		prefix: null,
+		refillInterval: null,
+		refillAmount: null,
+		lastRefillAt: null,
+		rateLimitEnabled: true,
+		rateLimitTimeWindow: 1000,
+		rateLimitMax: 100,
+		requestCount: 0,
+		remaining: null,
+		lastRequest: null,
+		expiresAt: null,
+		createdAt: now,
+		updatedAt: now,
+		permissions: null,
+		metadata: null,
+		user: {
+			id: "user-1",
+			name: "Test",
+			image: null,
+			email: "t@example.com",
+		},
+		...overrides,
+	};
+}
+
+function stubValidateDb() {
+	return {
+		query: {
+			apikey: {
+				findFirst: async () => null,
+			},
+		},
+		update: () => ({
+			set: () => ({
+				where: () => ({
+					catch: () => {},
+				}),
+			}),
+		}),
+	} as never;
 }
 
 function memoryStore() {
@@ -404,5 +474,97 @@ describe("ApiKeyCredential.disable", () => {
 			organizationId: "org-1",
 		});
 		expect(result.row.enabled).toBe(false);
+	});
+});
+
+describe("ApiKeyCredential.delete", () => {
+	test("after delete, previously cached secret fails validateApiKey", async () => {
+		const raw = generateApiKey();
+		const hashed = hashApiKey(raw);
+		const entry: ApiKeyCredentialEntry = {
+			userId: "user-1",
+			organizationId: "org-1",
+			apiKeyId: "key-1",
+		};
+
+		const store = memoryStore();
+		const credentialCache = createApiKeyCredentialCache(store);
+		await credentialCache.write(hashed, entry);
+
+		const before = await validateApiKey(raw, store, stubValidateDb());
+		expect(before?.authType).toBe("apikey");
+
+		const publishes: unknown[] = [];
+		const { db } = createFakeDb(sampleRow(hashed));
+		const credential = createApiKeyCredential({
+			db,
+			credentialCache,
+			bus: {
+				publish: async (event, payload) => {
+					publishes.push({ event, payload });
+				},
+			},
+		});
+
+		const result = await credential.delete({
+			id: "key-1",
+			organizationId: "org-1",
+		});
+		expect(result).toEqual({ id: "key-1" });
+		expect(publishes).toEqual([
+			{
+				event: BusEvent.API_KEY_DELETED,
+				payload: { api_key_id: "key-1", organizationId: "org-1" },
+			},
+		]);
+
+		const after = await validateApiKey(raw, store, stubValidateDb());
+		expect(after).toBeNull();
+	});
+
+	test("invalidate failure fails the operation after DB delete", async () => {
+		const hashed = hashApiKey(generateApiKey());
+		const { db } = createFakeDb(sampleRow(hashed));
+		const credential = createApiKeyCredential({
+			db,
+			credentialCache: {
+				read: async () => undefined,
+				write: async () => {},
+				invalidate: async () => {
+					throw new Error("redis down");
+				},
+			},
+			bus: {
+				publish: async () => {
+					throw new Error("should not publish");
+				},
+			},
+		});
+
+		await expect(
+			credential.delete({ id: "key-1", organizationId: "org-1" }),
+		).rejects.toMatchObject({
+			message: "Failed to revoke API key credential cache",
+		});
+	});
+
+	test("bus failure after successful invalidate still succeeds", async () => {
+		const hashed = hashApiKey(generateApiKey());
+		const store = memoryStore();
+		const credentialCache = createApiKeyCredentialCache(store);
+		const { db } = createFakeDb(sampleRow(hashed));
+		const credential = createApiKeyCredential({
+			db,
+			credentialCache,
+			bus: {
+				publish: async () => {
+					throw new Error("nats down");
+				},
+			},
+		});
+
+		await expect(
+			credential.delete({ id: "key-1", organizationId: "org-1" }),
+		).resolves.toEqual({ id: "key-1" });
 	});
 });


### PR DESCRIPTION
## Summary

- Extend **ApiKeyCredential** mutator with **delete**
- Order: txn + `FOR UPDATE` → capture hash → delete → commit → **invalidate** (must succeed) → bus best-effort
- Thin delete controller; success shape unchanged
- Tests: cached secret fails `validateApiKey` after delete; invalidate/bus failure modes

Closes #67 (part of #64).

## Test plan

- [x] `cd apps/backend/api-key && bun test test/`
- [ ] CI green

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves API key deletion into the credential mutator. The main changes are:

- Adds `ApiKeyCredential.delete` with row locking and cache invalidation.
- Updates the delete controller to delegate to the credential service.
- Adds tests for cache revocation, invalidate failure, and bus failure.

<h3>Confidence Score: 4/5</h3>

The delete flow can leave a cached API key usable after the database row is gone.

- Cache invalidation happens after the delete commits.
- A retry after that failure cannot recover the hash needed to clear the cache.
- Bus publish failures now return success while webhook delivery is skipped.

apps/backend/api-key/src/credential/api-key-credential.ts

<details open><summary><h3>Security Review</h3></summary>

A deleted API key can remain usable from the credential cache if invalidation fails after the database row is removed.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/backend/api-key/src/credential/api-key-credential.ts | Adds the delete mutator, with a stale-cache failure path after committed deletion and best-effort delete event publishing. |
| apps/backend/api-key/src/routes/api-key/delete-api-key/delete-api-key.controllers.ts | Simplifies the controller to delegate deletion to the credential service and return the existing success shape. |
| apps/backend/api-key/test/api-key-credential-disable.test.ts | Extends the fake DB and adds tests for delete cache revocation and failure modes. |

<sub>Reviews (1): Last reviewed commit: ["Delete API Key clears auth credential ca..."](https://github.com/reloop-labs/reloop/commit/80fbb0cd12e5e687940ff9e08c606f6717ad55f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43773627)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->