### PR TITLE
fix: load dashboard font with next/font/local

### DIFF
--- a/apps/frontend/dashboard/src/app/layout.tsx
+++ b/apps/frontend/dashboard/src/app/layout.tsx
@@ -1,9 +1,36 @@
 import type { Metadata } from "next";
+import localFont from "next/font/local";
 import "../styles.css";
 import { Providers } from "./providers";
 
 // TODO: Remove this opt-out after the dashboard supports Cache Components.
 export const instant = false;
+
+const openRunde = localFont({
+	src: [
+		{
+			path: "../../public/font/openRunde/OpenRunde-Regular.woff2",
+			weight: "400",
+			style: "normal",
+		},
+		{
+			path: "../../public/font/openRunde/OpenRunde-Medium.woff2",
+			weight: "500",
+			style: "normal",
+		},
+		{
+			path: "../../public/font/openRunde/OpenRunde-Semibold.woff2",
+			weight: "600",
+			style: "normal",
+		},
+		{
+			path: "../../public/font/openRunde/OpenRunde-Bold.woff2",
+			weight: "700",
+			style: "normal",
+		},
+	],
+	variable: "--font-open-runde",
+});
 
 export const metadata: Metadata = {
 	title: {
@@ -42,7 +69,9 @@ export default function RootLayout({
 }>) {
 	return (
 		<html lang="en" suppressHydrationWarning>
-			<body className="bg-bg-white-0 font-sans text-text-strong-950 antialiased">
+			<body
+				className={`${openRunde.variable} bg-bg-white-0 font-sans text-text-strong-950 antialiased`}
+			>
 				<Providers>{children}</Providers>
 			</body>
 		</html>

--- a/apps/frontend/dashboard/src/styles.css
+++ b/apps/frontend/dashboard/src/styles.css
@@ -1,40 +1,8 @@
 @import "@reloop/tailwind/style.css";
 
-@font-face {
-	font-family: "Open Runde";
-	src: url("/dashboard/font/openRunde/OpenRunde-Regular.woff2") format("woff2");
-	font-weight: 400;
-	font-style: normal;
-	font-display: swap;
-}
-
-@font-face {
-	font-family: "Open Runde";
-	src: url("/dashboard/font/openRunde/OpenRunde-Medium.woff2") format("woff2");
-	font-weight: 500;
-	font-style: normal;
-	font-display: swap;
-}
-
-@font-face {
-	font-family: "Open Runde";
-	src: url("/dashboard/font/openRunde/OpenRunde-Semibold.woff2") format("woff2");
-	font-weight: 600;
-	font-style: normal;
-	font-display: swap;
-}
-
-@font-face {
-	font-family: "Open Runde";
-	src: url("/dashboard/font/openRunde/OpenRunde-Bold.woff2") format("woff2");
-	font-weight: 700;
-	font-style: normal;
-	font-display: swap;
-}
-
 @theme inline {
-	--font-sans: "Open Runde", ui-sans-serif, system-ui, sans-serif;
-	--font-geist-sans: "Open Runde", ui-sans-serif, system-ui, sans-serif;
+	--font-sans: var(--font-open-runde);
+	--font-geist-sans: var(--font-open-runde);
 	--animate-door-draw-left: stroke-draw 0.28s ease-out both;
 	--animate-door-draw-top: stroke-draw 0.32s ease-out 0.1s both;
 	--animate-door-draw-right: stroke-draw 0.28s ease-out 0.22s both;
@@ -284,14 +252,16 @@
 @custom-variant light (&:where(.light, .light *));
 
 :root {
-	--font-geist-sans: "Open Runde", ui-sans-serif, system-ui, sans-serif;
+	--font-geist-sans: var(--font-open-runde);
 	font-family:
-		"Open Runde", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
-		"Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+		var(--font-open-runde), ui-sans-serif, system-ui, -apple-system,
+		BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans",
+		sans-serif;
 }
 
 body {
 	font-family:
-		"Open Runde", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
-		"Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+		var(--font-open-runde), ui-sans-serif, system-ui, -apple-system,
+		BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans",
+		sans-serif;
 }


### PR DESCRIPTION
## Summary

- load all Open Runde weights through `next/font/local` in the dashboard root layout
- expose the generated font through the existing Tailwind CSS variables
- remove the late-loading global `@font-face` declarations so Next can preload the font assets

## Validation

- `bunx biome check src/app/layout.tsx src/styles.css`
- `bun run typecheck`
- verified the Next font manifest includes all four generated Open Runde assets

## Note

- `bun run build` was stopped after remaining in the production compilation phase for several minutes without further output or an error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the dashboard’s typography to use the Open Runde font consistently.
  * Improved font loading and fallback behavior across the application.
  * Removed redundant font declarations from the global styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Migrates dashboard font loading to Next.js local font optimization.
- Registers all four Open Runde weights through `next/font/local`.
- Applies the generated font variable to the dashboard body.
- Reuses that variable in the dashboard’s Tailwind and global font-family declarations.
- Removes the previous global `@font-face` declarations.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete regressions identified in the changed font-loading path.

The referenced font assets exist at the resolved paths, all declared weights remain available, and the generated variable is applied to the body where normal and portaled dashboard descendants inherit it.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/frontend/dashboard/src/app/layout.tsx | Registers the existing Open Runde assets with `next/font/local` and scopes the generated variable to the body and its descendants. |
| apps/frontend/dashboard/src/styles.css | Replaces manually loaded font faces with references to the generated Next.js font variable while retaining system fallbacks. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: load dashboard font with next font"](https://github.com/reloop-labs/reloop/commit/951600fe46eec2a2c062de733980407b55e95144) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47974701)</sub>

<!-- /greptile_comment -->