### PR TITLE
fix(dashboard): wait for session before protected providers

### DIFF
--- a/apps/frontend/dashboard/src/app/(protected)/protected-layout-client.tsx
+++ b/apps/frontend/dashboard/src/app/(protected)/protected-layout-client.tsx
@@ -21,9 +21,13 @@ export function ProtectedLayoutClient({
 		}
 	}, [isFetched, isPending, router, session]);
 
+	if (isPending || !isFetched) {
+		return <DashboardLoadingChrome />;
+	}
+
 	// Confirmed signed-out: keep dashboard chrome while redirecting to login
 	// (never swap to a full-viewport spinner after the shell has been shown).
-	if (isFetched && !session) {
+	if (!session) {
 		return <DashboardLoadingChrome />;
 	}
 

--- a/apps/frontend/dashboard/src/app/app-router-contract.test.ts
+++ b/apps/frontend/dashboard/src/app/app-router-contract.test.ts
@@ -16,6 +16,10 @@ describe("App Router provider lifetimes", () => {
 			"./(protected)/(dashboard)/dashboard-layout-client.tsx",
 		);
 
+		expect(protectedLayout).toContain("if (isPending || !isFetched)");
+		expect(
+			protectedLayout.indexOf("if (isPending || !isFetched)"),
+		).toBeLessThan(protectedLayout.indexOf("<ActiveOrganizationProvider>"));
 		expect(protectedLayout).toContain("<ActiveOrganizationProvider>");
 		expect(protectedLayout).toContain("{children}");
 		expect(dashboardLayout).not.toContain("ActiveOrganizationProvider");


### PR DESCRIPTION
## Summary

- render the dashboard loading chrome while the session query is pending
- only mount `ActiveOrganizationProvider` after the session query has settled
- add a provider-lifetime regression assertion for the loading gate

This prevents client-only session query updates from changing the protected tree during hydration, which could repeatedly trigger hydration recovery and passive-effect reconnection.

## Testing

- `bun run test src/app/app-router-contract.test.ts --configLoader runner`
- `bunx biome check "apps/frontend/dashboard/src/app/(protected)/protected-layout-client.tsx" apps/frontend/dashboard/src/app/app-router-contract.test.ts`
- `git diff --check origin/main...HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dashboard loading behavior while session information is being retrieved.
  * Prevented premature signed-out redirects during session checks.
  * Ensured protected dashboard content waits for session data before loading organization-specific features.

* **Tests**
  * Added coverage for protected layout behavior during pending and incomplete session retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR delays mounting the protected organization-provider tree until the client session query has settled, preserving dashboard loading chrome during that interval.
- Adds an early session-loading return before `ActiveOrganizationProvider`.
- Simplifies the subsequent signed-out branch once query settlement is guaranteed.
- Adds a source-contract assertion for the gate's position relative to the provider.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with only a non-blocking concern that the new regression test is coupled to the condition's exact source spelling.

The runtime gate correctly keeps the protected provider unmounted during the initial unresolved session state, while the accepted concern is limited to test brittleness under semantics-preserving refactors.

**Files Needing Attention:** apps/frontend/dashboard/src/app/app-router-contract.test.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/frontend/dashboard/src/app/(protected)/protected-layout-client.tsx | Adds a settlement gate before the protected provider; no blocking behavioral defect was established. |
| apps/frontend/dashboard/src/app/app-router-contract.test.ts | Adds coverage for gate ordering, but the exact raw-source match makes the regression assertion unnecessarily brittle. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[ProtectedLayoutClient renders] --> B{Session pending or not fetched?}
    B -- Yes --> C[Render DashboardLoadingChrome]
    B -- No --> D{Session exists?}
    D -- No --> E[Render loading chrome and redirect to login]
    D -- Yes --> F[Mount ActiveOrganizationProvider]
    F --> G[Render protected children]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): wait for session before ..."](https://github.com/reloop-labs/reloop/commit/9eab9001260a971eb9bae64c4eb17407ee408a42) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50891598)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->