### PR TITLE
fix(workflows): persist edits before status changes

### DIFF
--- a/apps/frontend/dashboard/src/features/workflows/components/workflow-editor-toolbar.tsx
+++ b/apps/frontend/dashboard/src/features/workflows/components/workflow-editor-toolbar.tsx
@@ -33,30 +33,26 @@ export const WorkflowEditorToolbar = ({
 
 	const handleToggleActive = async (checked: boolean) => {
 		if (busy) return;
-		if (checked) {
-			if (!validation.isValid) {
-				toast.error(validation.warnings[0] ?? "Complete the workflow first");
-				return;
-			}
-			setBusy(true);
-			try {
-				await onStatusChange("active");
-				toast.success("Workflow activated");
-			} catch (e) {
-				toast.error(e instanceof Error ? e.message : "Failed to activate");
-			} finally {
-				setBusy(false);
-			}
-		} else {
-			setBusy(true);
-			try {
-				await onStatusChange("paused");
-				toast.success("Workflow paused");
-			} catch (e) {
-				toast.error(e instanceof Error ? e.message : "Failed to pause");
-			} finally {
-				setBusy(false);
-			}
+		if (checked && !validation.isValid) {
+			toast.error(validation.warnings[0] ?? "Complete the workflow first");
+			return;
+		}
+
+		setBusy(true);
+		try {
+			await onSave();
+			await onStatusChange(checked ? "active" : "paused");
+			toast.success(checked ? "Workflow activated" : "Workflow paused");
+		} catch (e) {
+			toast.error(
+				e instanceof Error
+					? e.message
+					: checked
+						? "Failed to activate"
+						: "Failed to pause",
+			);
+		} finally {
+			setBusy(false);
 		}
 	};
 

--- a/apps/frontend/dashboard/src/features/workflows/workflow-editor-page.tsx
+++ b/apps/frontend/dashboard/src/features/workflows/workflow-editor-page.tsx
@@ -21,7 +21,6 @@ export function WorkflowEditorPage({ workflowId }: { workflowId: string }) {
 	const {
 		getWorkflow,
 		updateWorkflow,
-		setWorkflowGraph,
 		setWorkflowStatus,
 		isHydrated,
 	} = useWorkflows();
@@ -66,25 +65,10 @@ export function WorkflowEditorPage({ workflowId }: { workflowId: string }) {
 	const handleStatusChange = useCallback(
 		async (status: WorkflowStatus) => {
 			if (!workflow) return;
-			// Persist latest graph before activate
-			if (status === "active" && localNodes && localEdges) {
-				await setWorkflowGraph(workflow.id, localNodes, localEdges);
-			} else if (localName !== workflow.name) {
-				await updateWorkflow(workflow.id, { name: localName });
-			}
 			await setWorkflowStatus(workflow.id, status);
 			await detailQuery.refetch();
 		},
-		[
-			workflow,
-			localNodes,
-			localEdges,
-			localName,
-			setWorkflowGraph,
-			setWorkflowStatus,
-			updateWorkflow,
-			detailQuery,
-		],
+		[workflow, setWorkflowStatus, detailQuery],
 	);
 
 	const handleSave = useCallback(


### PR DESCRIPTION
**Problem**
Workflow edits could be lost when activating or pausing a workflow:

Activating after changing both the name and graph only persisted the graph.
Pausing after editing the graph could discard those edits.
The status change could succeed even though the latest workflow state had not been saved.
This happened because status handling conditionally saved only part of the workflow.

**Fix**
The workflow editor now saves the complete current state before changing its status.

Save the current name, nodes, and edges first.
Proceed with activation or pausing only after the save succeeds.
Prevent status changes when saving fails.
Remove the redundant partial-save logic from the page component.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workflow changes are now saved before activating or pausing a workflow.
  * Added clearer success and error feedback for activation and pause actions.
  * Improved workflow status updates and refreshed details after changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The workflow editor now persists the current name and graph before activating or pausing, preventing status transitions when saving fails.
- Moves complete-state persistence into the toolbar’s status-toggle sequence.
- Simplifies the page-level status callback by removing redundant partial-save behavior.
- Preserves activation validation and reports save or status errors through the existing toast path.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The toolbar’s zero-argument save callback is correctly adapted by the editor to persist the current nodes and edges, and the status mutation runs only after that complete save succeeds.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/frontend/dashboard/src/features/workflows/components/workflow-editor-toolbar.tsx | Serializes the existing full-save callback before activation or pausing and prevents the status mutation when saving fails. |
| apps/frontend/dashboard/src/features/workflows/workflow-editor-page.tsx | Removes partial persistence from the status callback because full-state saving is now performed before that callback is invoked. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(workflows): persist edits before sta..."](https://github.com/reloop-labs/reloop/commit/c66fa7eb64f953fe4d65afa4f2c20efdaea033e1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51772485)</sub>

<!-- /greptile_comment -->