### PR TITLE
docs: fix Reloop SDK init in Express example to use apiKey option

### DIFF
--- a/apps/frontend/docs/content/docs/examples/nodejs/express.mdx
+++ b/apps/frontend/docs/content/docs/examples/nodejs/express.mdx
@@ -30,7 +30,7 @@ import express from 'express';
 import Reloop from 'reloop-email';
 
 const app = express();
-const reloop = new Reloop(process.env.RELOOP_API_KEY);
+const reloop = new Reloop({ apiKey: process.env.RELOOP_API_KEY });
 
 app.post('/send-email', async (req, res) => {
   try {


### PR DESCRIPTION
**Summary:**

Fix the Express.js docs example to initialize the Reloop Node SDK with { apiKey } instead of a bare API key string, matching the current reloop-email constructor.

**Test plan:**
Open /docs/examples/nodejs/express and confirm the sample shows new Reloop({ apiKey: process.env.RELOOP_API_KEY })

**Issue:**
#91 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Node.js Express example to show the current client initialization format using an options object for the API key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR corrects the Express.js documentation example to pass the API key through the current Reloop SDK options-object constructor.

- Replaces the positional API-key argument with `{ apiKey: process.env.RELOOP_API_KEY }`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The changed constructor call matches the repository’s current Reloop client options contract, and no changed-code-triggered failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/frontend/docs/content/docs/examples/nodejs/express.mdx | Updates the Express example’s SDK initialization to match the current constructor contract without introducing an actionable defect. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: fix Reloop SDK init in Express exa..."](https://github.com/reloop-labs/reloop/commit/83fa3746a62d942b4cafee727f799456bee1594e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52601131)</sub>

<!-- /greptile_comment -->