### PR TITLE
fix: link the auth card logo to the home page

### DIFF
--- a/apps/frontend/dashboard/src/features/auth/auth-card.tsx
+++ b/apps/frontend/dashboard/src/features/auth/auth-card.tsx
@@ -102,14 +102,16 @@ export function AuthCard({
 				<AnimatedHeight>
 					<div className="space-y-6 overflow-hidden rounded-2xl border border-stroke-soft-200 bg-bg-white-0 px-6 pt-5 pb-7 dark:border-stroke-soft-100/40 dark:bg-[#0c0c0c]">
 						{showBrandMark ? (
-							<div
-								className="w-fit overflow-hidden rounded-2xl border border-stroke-soft-200 bg-bg-soft-50 dark:border-stroke-soft-100/40 dark:bg-white/[0.03]"
-								aria-hidden
+							// Plain <a> so we leave /dashboard basePath and hit the marketing site root.
+							<a
+								href="/"
+								aria-label="Reloop home"
+								className="block w-fit overflow-hidden rounded-2xl border border-stroke-soft-200 bg-bg-soft-50 transition-opacity hover:opacity-80 dark:border-stroke-soft-100/40 dark:bg-white/[0.03]"
 							>
 								<div className="m-px flex size-11 items-center justify-center rounded-[14px] border border-stroke-soft-200 bg-bg-white-0 dark:border-stroke-soft-100/40 dark:bg-[#0c0c0c]">
 									<Logo className="h-10 w-10" />
 								</div>
-							</div>
+							</a>
 						) : null}
 
 						{children}


### PR DESCRIPTION
**Summary:**

- Makes the Reloop logo on login and signup clickable so it returns to the home page.
- Uses a plain anchor tag instead of Next.js Link, so navigation leaves the /dashboard base path and hits /.

**Test plan:**

- [x] Open /dashboard/login and click the logo — you should land on the marketing site root (/), not /dashboard.

- [x] Repeat from /dashboard/signup.

- [x] Confirm the logo still looks the same and has a hover state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added an accessible label to the brand mark.

* **Usability**
  * Made the brand mark clickable, linking back to the home page.
  * Added hover styling to clarify its interactive behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes the auth-card logo link to the marketing-site root using a plain anchor, deliberately bypassing Next.js dashboard base-path handling.
- Replaces the decorative logo wrapper with an accessible home link.
- Adds a hover-opacity transition while preserving the existing card appearance.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness, accessibility, or security issues identified.

The new anchor follows the repository’s established mechanism for leaving the dashboard base path, and the configured routing sends the resulting root request to the marketing site.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/frontend/dashboard/src/features/auth/auth-card.tsx | The logo is correctly converted into a labeled anchor whose root-relative target exits the configured `/dashboard` base path; no actionable defect was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: link the auth card logo to the home..."](https://github.com/reloop-labs/reloop/commit/951ff4d0129f4d209c9d403859343bf38d539ed8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53108754)</sub>

<!-- /greptile_comment -->