### PR TITLE
fix(mail): fail closed when monthly email credits are exhausted

### DIFF
--- a/.github/workflows/be-mail.yml
+++ b/.github/workflows/be-mail.yml
@@ -17,7 +17,8 @@ on:
 
 env:
   REGISTRY: docker.io
-  IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME }}/be-mail
+  # Fall back on PRs/forks where Docker Hub secrets are unavailable.
+  IMAGE_NAME: ${{ secrets.DOCKERHUB_USERNAME != '' && format('{0}/be-mail', secrets.DOCKERHUB_USERNAME) || 'local/be-mail' }}
 
 jobs:
   build-and-push:
@@ -33,7 +34,10 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # PRs only need a local build; Hub login (and its Node punycode warning)
+      # is reserved for push/deploy on main where secrets are available.
       - name: Log in to Docker Hub
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -48,6 +52,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=pr
 
       - name: Build and push Docker image
         id: build

--- a/apps/backend/mail/src/lib/count-recipients.ts
+++ b/apps/backend/mail/src/lib/count-recipients.ts
@@ -1,0 +1,15 @@
+/** Count billable recipients the same way finalize / credits deduction does. */
+export function countEmailRecipients(body: {
+	to: string | string[];
+	cc?: string | string[];
+	bcc?: string | string[];
+}): number {
+	const to = Array.isArray(body.to) ? body.to : [body.to];
+	const cc = body.cc ? (Array.isArray(body.cc) ? body.cc : [body.cc]) : [];
+	const bcc = body.bcc
+		? Array.isArray(body.bcc)
+			? body.bcc
+			: [body.bcc]
+		: [];
+	return to.length + cc.length + bcc.length;
+}

--- a/apps/backend/mail/src/lib/credits-gate.ts
+++ b/apps/backend/mail/src/lib/credits-gate.ts
@@ -2,7 +2,7 @@ import { countEmailRecipients } from "@reloop/be-mail/lib/count-recipients";
 import { MailErrors } from "@reloop/be-mail/lib/errors";
 import { db } from "@reloop/db/client";
 import { creditLedger, organizationCredits } from "@reloop/db/schema";
-import { eq } from "drizzle-orm";
+import { and, eq, lte } from "drizzle-orm";
 import { log } from "evlog";
 
 const DEFAULT_MONTHLY_CREDITS = 3000;
@@ -10,6 +10,9 @@ const DEFAULT_MONTHLY_CREDITS = 3000;
 /**
  * Load active org credits, provisioning Free defaults or resetting an expired
  * period so the gate matches post-send metering in be-credits.
+ *
+ * Period resets use a conditional UPDATE on `current_period_end` so concurrent
+ * senders cannot each write a reset / ledger row for the same expiry.
  */
 async function ensureActiveCredits(organizationId: string) {
 	if (!organizationId) {
@@ -81,6 +84,7 @@ async function ensureActiveCredits(organizationId: string) {
 		const periodEnd = new Date(now);
 		periodEnd.setMonth(periodEnd.getMonth() + 1);
 
+		// Only the first concurrent sender wins the reset; losers re-read.
 		const [updatedCredits] = await db
 			.update(organizationCredits)
 			.set({
@@ -90,11 +94,26 @@ async function ensureActiveCredits(organizationId: string) {
 				currentPeriodEnd: periodEnd,
 				updatedAt: now,
 			})
-			.where(eq(organizationCredits.id, activeCredits.id))
+			.where(
+				and(
+					eq(organizationCredits.id, activeCredits.id),
+					lte(organizationCredits.currentPeriodEnd, now),
+				),
+			)
 			.returning();
 
 		if (!updatedCredits) {
-			throw new Error("Failed to reset credits for expired period");
+			const refreshed = await db.query.organizationCredits.findFirst({
+				where: (c, { and, eq: equals }) =>
+					and(
+						equals(c.organizationId, organizationId),
+						equals(c.status, "active"),
+					),
+			});
+			if (!refreshed) {
+				throw new Error("Failed to reset credits for expired period");
+			}
+			return refreshed;
 		}
 
 		await db.insert(creditLedger).values({
@@ -115,6 +134,10 @@ async function ensureActiveCredits(organizationId: string) {
 /**
  * Fail closed when the org cannot cover this send's recipient count.
  * Call before creating email logs or calling KumoMTA.
+ *
+ * This is a pre-send balance check (post-send metering still deducts via
+ * EMAIL_SENT). Concurrent sends that each fit the same remaining balance can
+ * still overshoot until metering lands; the gate stops the already-exhausted case.
  */
 export async function assertHasCredits({
 	organizationId,

--- a/apps/backend/mail/src/lib/credits-gate.ts
+++ b/apps/backend/mail/src/lib/credits-gate.ts
@@ -1,0 +1,145 @@
+import { countEmailRecipients } from "@reloop/be-mail/lib/count-recipients";
+import { MailErrors } from "@reloop/be-mail/lib/errors";
+import { db } from "@reloop/db/client";
+import { creditLedger, organizationCredits } from "@reloop/db/schema";
+import { eq } from "drizzle-orm";
+import { log } from "evlog";
+
+const DEFAULT_MONTHLY_CREDITS = 3000;
+
+/**
+ * Load active org credits, provisioning Free defaults or resetting an expired
+ * period so the gate matches post-send metering in be-credits.
+ */
+async function ensureActiveCredits(organizationId: string) {
+	if (!organizationId) {
+		throw new Error("organizationId is required for credit checks");
+	}
+
+	let activeCredits = await db.query.organizationCredits.findFirst({
+		where: (c, { and, eq: equals }) =>
+			and(equals(c.organizationId, organizationId), equals(c.status, "active")),
+	});
+
+	const now = new Date();
+
+	if (!activeCredits) {
+		log.info(
+			"server",
+			`No credits found for org ${organizationId}, provisioning default monthly credits (${DEFAULT_MONTHLY_CREDITS})`,
+		);
+
+		const periodEnd = new Date(now);
+		periodEnd.setMonth(periodEnd.getMonth() + 1);
+
+		const [newCredits] = await db
+			.insert(organizationCredits)
+			.values({
+				organizationId,
+				creditsUsed: 0,
+				creditsRemaining: DEFAULT_MONTHLY_CREDITS,
+				monthlyCredits: DEFAULT_MONTHLY_CREDITS,
+				currentPeriodStart: now,
+				currentPeriodEnd: periodEnd,
+				status: "active",
+			})
+			.onConflictDoNothing()
+			.returning();
+
+		if (!newCredits) {
+			activeCredits = await db.query.organizationCredits.findFirst({
+				where: (c, { and, eq: equals }) =>
+					and(
+						equals(c.organizationId, organizationId),
+						equals(c.status, "active"),
+					),
+			});
+			if (!activeCredits) {
+				throw new Error("Failed to retrieve organization credits after provision");
+			}
+			return activeCredits;
+		}
+
+		await db.insert(creditLedger).values({
+			organizationId,
+			organizationCreditsId: newCredits.id,
+			entryType: "credit_purchased",
+			delta: DEFAULT_MONTHLY_CREDITS,
+			balanceAfter: DEFAULT_MONTHLY_CREDITS,
+			reason: "Initial monthly credit quota",
+		});
+
+		return newCredits;
+	}
+
+	if (now >= activeCredits.currentPeriodEnd) {
+		log.info(
+			"server",
+			`Monthly credit period expired for org ${organizationId}. Resetting credits before send gate.`,
+		);
+
+		const periodEnd = new Date(now);
+		periodEnd.setMonth(periodEnd.getMonth() + 1);
+
+		const [updatedCredits] = await db
+			.update(organizationCredits)
+			.set({
+				creditsUsed: 0,
+				creditsRemaining: activeCredits.monthlyCredits,
+				currentPeriodStart: now,
+				currentPeriodEnd: periodEnd,
+				updatedAt: now,
+			})
+			.where(eq(organizationCredits.id, activeCredits.id))
+			.returning();
+
+		if (!updatedCredits) {
+			throw new Error("Failed to reset credits for expired period");
+		}
+
+		await db.insert(creditLedger).values({
+			organizationId,
+			organizationCreditsId: activeCredits.id,
+			entryType: "period_reset",
+			delta: activeCredits.monthlyCredits,
+			balanceAfter: activeCredits.monthlyCredits,
+			reason: "Monthly credit reset (non-rollable)",
+		});
+
+		return updatedCredits;
+	}
+
+	return activeCredits;
+}
+
+/**
+ * Fail closed when the org cannot cover this send's recipient count.
+ * Call before creating email logs or calling KumoMTA.
+ */
+export async function assertHasCredits({
+	organizationId,
+	body,
+}: {
+	organizationId: string;
+	body: {
+		to: string | string[];
+		cc?: string | string[];
+		bcc?: string | string[];
+	};
+}): Promise<{ creditsRemaining: number; recipientCount: number }> {
+	const recipientCount = countEmailRecipients(body);
+	const credits = await ensureActiveCredits(organizationId);
+
+	if (credits.creditsRemaining < recipientCount) {
+		throw MailErrors.quotaExceeded({
+			remaining: credits.creditsRemaining,
+			required: recipientCount,
+			monthlyCredits: credits.monthlyCredits,
+		});
+	}
+
+	return {
+		creditsRemaining: credits.creditsRemaining,
+		recipientCount,
+	};
+}

--- a/apps/backend/mail/src/lib/errors.ts
+++ b/apps/backend/mail/src/lib/errors.ts
@@ -160,6 +160,21 @@ export const MailErrors = {
 			why: "Neither 'html' nor 'text' body was provided, and the referenced template has no rendered content",
 			fix: "Provide at least one of 'html' or 'text' in the request body, or ensure the template has rendered HTML",
 		}),
+	quotaExceeded: ({
+		remaining,
+		required,
+		monthlyCredits,
+	}: {
+		remaining: number;
+		required: number;
+		monthlyCredits: number;
+	}) =>
+		createError({
+			status: 402,
+			message: "Email quota exceeded",
+			why: `This send needs ${required} credit${required === 1 ? "" : "s"}, but only ${remaining} remain of ${monthlyCredits} this period`,
+			fix: "Upgrade your plan, wait for the monthly reset, or reduce recipients for this send",
+		}),
 };
 
 export const RateLimitErrors = {

--- a/apps/backend/mail/src/model/mail.model.ts
+++ b/apps/backend/mail/src/model/mail.model.ts
@@ -254,4 +254,21 @@ export namespace MailModel {
 		),
 	});
 	export type TooManyRequests = typeof tooManyRequests.static;
+
+	export const paymentRequired = t.Object({
+		message: t.String({
+			description: "Email quota exceeded",
+		}),
+		why: t.Optional(
+			t.String({
+				description: "Why the send was blocked",
+			}),
+		),
+		fix: t.Optional(
+			t.String({
+				description: "How to resolve the quota issue",
+			}),
+		),
+	});
+	export type PaymentRequired = typeof paymentRequired.static;
 }

--- a/apps/backend/mail/src/routes/mail/send-email/send-email.controllers.ts
+++ b/apps/backend/mail/src/routes/mail/send-email/send-email.controllers.ts
@@ -1,3 +1,4 @@
+import { assertHasCredits } from "@reloop/be-mail/lib/credits-gate";
 import { MailErrors } from "@reloop/be-mail/lib/errors";
 import type { MailModel } from "@reloop/be-mail/model/mail.model";
 import { db } from "@reloop/db/client";
@@ -47,6 +48,9 @@ export async function sendEmailController({
 		to: body.to,
 	});
 	log.info("server", "Initiating email send process");
+
+	// Fail closed before DNS/log/Kumo work when the monthly meter is empty.
+	await assertHasCredits({ organizationId, body });
 
 	const { domainName } = parseFromAddress_step1(body.from);
 

--- a/apps/backend/mail/src/routes/mail/send-email/send-email.route.ts
+++ b/apps/backend/mail/src/routes/mail/send-email/send-email.route.ts
@@ -72,6 +72,7 @@ export const sendEmailRoute = new Elysia()
 				401: MailModel.unauthorized,
 				403: MailModel.forbidden,
 				400: MailModel.badRequest,
+				402: MailModel.paymentRequired,
 				429: MailModel.tooManyRequests,
 				500: MailModel.internalServerError,
 			},

--- a/apps/backend/mail/src/routes/mail/send-email/steps/step-7-finalize.ts
+++ b/apps/backend/mail/src/routes/mail/send-email/steps/step-7-finalize.ts
@@ -1,3 +1,4 @@
+import { countEmailRecipients } from "@reloop/be-mail/lib/count-recipients";
 import type { MailModel } from "@reloop/be-mail/model/mail.model";
 import { BusEvent, bus } from "@reloop/bus";
 import { db } from "@reloop/db/client";
@@ -34,10 +35,7 @@ export async function finalizeEmail_step7({
 		})
 		.where(eq(emailLog.id, emailLogId));
 
-	const recipients = Array.isArray(body.to) ? body.to : [body.to];
-	const cc = body.cc ? (Array.isArray(body.cc) ? body.cc : [body.cc]) : [];
-	const bcc = body.bcc ? (Array.isArray(body.bcc) ? body.bcc : [body.bcc]) : [];
-	const totalRecipients = recipients.length + cc.length + bcc.length;
+	const totalRecipients = countEmailRecipients(body);
 	const timestamp = new Date().toISOString();
 	const scheduledAt = isFutureScheduled(body.scheduled_at);
 

--- a/apps/backend/mail/test/credits-gate.test.ts
+++ b/apps/backend/mail/test/credits-gate.test.ts
@@ -34,11 +34,23 @@ describe("MailErrors.quotaExceeded", () => {
 			remaining: 0,
 			required: 2,
 			monthlyCredits: 3000,
-		}) as Error & { status?: number; why?: string };
+		}) as Error & { status?: number; why?: string; fix?: string };
 
 		expect(err.status).toBe(402);
 		expect(err.message).toBe("Email quota exceeded");
 		expect(err.why).toContain("needs 2 credits");
 		expect(err.why).toContain("only 0 remain");
+		expect(err.fix).toContain("Upgrade your plan");
+	});
+
+	test("uses singular credit wording when required is 1", () => {
+		const err = MailErrors.quotaExceeded({
+			remaining: 0,
+			required: 1,
+			monthlyCredits: 3000,
+		}) as Error & { why?: string };
+
+		expect(err.why).toContain("needs 1 credit,");
+		expect(err.why).not.toContain("needs 1 credits");
 	});
 });

--- a/apps/backend/mail/test/credits-gate.test.ts
+++ b/apps/backend/mail/test/credits-gate.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import { countEmailRecipients } from "../src/lib/count-recipients";
+import { MailErrors } from "../src/lib/errors";
+
+describe("countEmailRecipients", () => {
+	test("counts to, cc, and bcc arrays", () => {
+		expect(
+			countEmailRecipients({
+				to: ["a@example.com", "b@example.com"],
+				cc: ["c@example.com"],
+				bcc: ["d@example.com", "e@example.com"],
+			}),
+		).toBe(5);
+	});
+
+	test("normalizes single string recipients", () => {
+		expect(
+			countEmailRecipients({
+				to: "solo@example.com",
+				cc: "cc@example.com",
+				bcc: "bcc@example.com",
+			}),
+		).toBe(3);
+	});
+
+	test("treats missing cc/bcc as zero", () => {
+		expect(countEmailRecipients({ to: "solo@example.com" })).toBe(1);
+	});
+});
+
+describe("MailErrors.quotaExceeded", () => {
+	test("returns 402 with remaining vs required detail", () => {
+		const err = MailErrors.quotaExceeded({
+			remaining: 0,
+			required: 2,
+			monthlyCredits: 3000,
+		}) as Error & { status?: number; why?: string };
+
+		expect(err.status).toBe(402);
+		expect(err.message).toBe("Email quota exceeded");
+		expect(err.why).toContain("needs 2 credits");
+		expect(err.why).toContain("only 0 remain");
+	});
+});


### PR DESCRIPTION
## Summary
- Reject exhausted-quota sends with HTTP 402 before KumoMTA, using the same recipient count as post-send metering.
- Harden monthly period reset with a conditional update so concurrent senders cannot each write a reset/ledger row.
- Skip Docker Hub login on pull requests so `BE Mail Docker` can build without secrets (and without the Node `punycode` deprecation noise from `docker/login-action`).

Replaces closed #99 with a mail-only branch (no unrelated workflows changes).

## Test plan
- [ ] `bun test test/credits-gate.test.ts` in `apps/backend/mail`
- [ ] Send with `creditsRemaining: 0` → HTTP 402, no Kumo call
- [ ] Send within quota → succeeds; metering still deducts after send
- [ ] Confirm `BE Mail Docker` builds on the PR without Hub login failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added monthly email credit tracking and quota enforcement.
  - Email sends now report a clear payment-required error when credits are insufficient.
  - Recipient counts include `to`, `cc`, and `bcc` addresses.
  - Pull requests can build container images without Docker Hub credentials.

- **Bug Fixes**
  - Prevented email processing from starting when the available credit balance is too low.

- **Tests**
  - Added coverage for recipient counting and detailed quota-exceeded responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a pre-send monthly-credit gate, shared recipient counting, concurrency-aware period resets, a documented HTTP 402 response, and pull-request-safe Docker image metadata. Two accounting gaps remain:
- Scheduled sends pass the new snapshot check but never emit the event consumed by credit metering.
- Provisioning and reset balance mutations are not atomic with their ledger records.

<h3>Confidence Score: 3/5</h3>

The PR should not merge until scheduled messages are metered and credit balance changes are made atomic with their ledger records.

Scheduled messages can be delivered indefinitely without consuming credits, while database failures between a balance mutation and ledger insertion can permanently desynchronize quota state from its audit history.

**Files Needing Attention:** apps/backend/mail/src/routes/mail/send-email/send-email.controllers.ts, apps/backend/mail/src/routes/mail/send-email/steps/step-7-finalize.ts, apps/backend/mail/src/lib/credits-gate.ts

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| apps/backend/mail/src/lib/credits-gate.ts | Adds quota provisioning, reset, and balance checks, but balance mutations can commit without their corresponding ledger entries. |
| apps/backend/mail/src/routes/mail/send-email/send-email.controllers.ts | Adds the pre-send gate, which does not reserve credits and cannot ensure scheduled messages are subsequently metered. |
| apps/backend/mail/src/routes/mail/send-email/steps/step-7-finalize.ts | Reuses the shared recipient counter, while retaining the scheduled-event branch that bypasses the credits subscriber. |
| apps/backend/mail/src/lib/count-recipients.ts | Correctly centralizes the existing recipient-count calculation for the gate and finalization paths. |
| .github/workflows/be-mail.yml | Avoids Docker Hub login on pull requests and supplies a valid local image-name fallback. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Mail as Mail API
    participant Kumo as KumoMTA
    participant Bus
    participant Credits as Credits Worker
    Client->>Mail: Schedule email
    Mail->>Mail: assertHasCredits (snapshot only)
    Mail->>Kumo: Submit scheduled message
    Mail->>Bus: EMAIL_SCHEDULED
    Note over Bus,Credits: Credits worker consumes only EMAIL_SENT
    Kumo-->>Kumo: Deliver later
    Note over Kumo,Credits: No EMAIL_SENT metering event
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(mail): harden quota gate reset and s..."](https://github.com/reloop-labs/reloop/commit/150292dd46599a8d72624345f82dc5fa17f64c00) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55116212)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->