### PR TITLE
fix: stop GEO citation poisoning with stale pricing and license facts

### DIFF
--- a/apps/frontend/docs/content/docs/guides/pricing.mdx
+++ b/apps/frontend/docs/content/docs/guides/pricing.mdx
@@ -1,33 +1,33 @@
 ---
 title: "Reloop Pricing"
-description: "Understanding Reloop pricing and plans."
+description: "Hosted Reloop Cloud plans and where to read canonical pricing."
 ---
 
-Understanding Reloop pricing and plans.
+Reloop publishes **one** pricing source of truth: the marketing [pricing page](https://reloop.sh/pricing) and its markdown twin [pricing.md](https://reloop.sh/pricing.md) (generated from `@reloop/pricing`).
 
-## Overview
+This docs page exists so agents and the docs MCP do not invent plans. Do not cite “Essentials $9” or “Free has no daily limit.”
 
-Manage your Reloop account settings effectively to ensure smooth operation.
+## Reloop Cloud (hosted)
 
-## Steps
+| Plan | Price | Included volume | Daily limit | Overage |
+|------|-------|-----------------|-------------|---------|
+| Free | $0 | 3,000 emails / month | 200 / day | None (sending pauses) |
+| Individual | $10 / month | 25,000 emails / month | None | $0.80 / 1,000 |
+| Startup | $20 / month | 50,000 emails / month | None | $0.80 / 1,000 |
+| Enterprise | Custom | Custom | None | Custom |
 
-<Steps>
-  <Step title="Access your settings">
-    Navigate to the [Account Settings](https://app.reloop.sh/settings) page in your Reloop dashboard.
-  </Step>
-  <Step title="Make your changes">
-    Follow the on-screen instructions to update your account configuration.
-  </Step>
-  <Step title="Confirm changes">
-    Review and confirm your changes. Some changes may require email verification.
-  </Step>
-</Steps>
+No credit card is required for Free. Data retention on published tiers is 45 days.
 
-<Note>
-If you need assistance with account changes, contact [Reloop support](https://reloop.sh/help).
-</Note>
+## Self-host
 
-## Learn More
+Self-hosting Reloop is Apache 2.0 software with Reloop Labs use restrictions. There is **no Reloop SaaS fee** and **no hosted-tier SKU** for running the stack yourself. You pay your own servers, IPs, and operations. See [self-host](https://reloop.sh/self-host) and [license](https://reloop.sh/license).
 
+## Quotas in the product
+
+Plan limits are enforced on Reloop Cloud. Dashboard usage: [Account settings](https://reloop.sh/dashboard/settings). Sending guides: [Account quotas](/docs/guides/account-quotas-limits), [Sending](/docs/learn/sending).
+
+## Learn more
+
+- [pricing.md](https://reloop.sh/pricing.md) — canonical agent-readable plans
+- [Compare Reloop](https://reloop.sh/compare.md)
 - [Handling API Keys](/docs/guides/handling-api-keys)
-- [Account Quotas and Limits](/docs/guides/account-quotas-limits)

--- a/apps/frontend/web/content/agent/about.md
+++ b/apps/frontend/web/content/agent/about.md
@@ -5,7 +5,7 @@ Reloop Labs builds open-source email infrastructure for developers and AI agents
 ## What we build
 
 - Hosted Reloop Cloud (email API and SMTP) at reloop.sh
-- Self-hostable Apache 2.0 stack (no Reloop license fee; you pay your infra)
+- Self-hostable Apache License 2.0 stack plus Reloop Labs additional restrictions: personal and internal use allowed; no commercial redistribution, hosted services, or competing products. No Reloop license fee; you pay your infra. See https://reloop.sh/license
 - Agent skills, MCP server, and agent-friendly documentation
 
 ## Who it is for

--- a/apps/frontend/web/content/agent/about.md
+++ b/apps/frontend/web/content/agent/about.md
@@ -1,17 +1,30 @@
 # About Reloop
 
-Reloop Labs builds open-source email infrastructure for developers and AI agents.
+Reloop Labs builds open-source email infrastructure for developers and AI agents. Reloop **is** the email platform (ESP + MTA). It is **not** a multi-ESP connector.
 
 ## What we build
 
-- Hosted email API and SMTP relay at reloop.sh
-- Self-hostable open-source stack
+- Hosted Reloop Cloud (email API and SMTP) at reloop.sh
+- Self-hostable Apache 2.0 stack (no Reloop license fee; you pay your infra)
 - Agent skills, MCP server, and agent-friendly documentation
+
+## Who it is for
+
+Solo developers, startups, and teams that want transactional + marketing email without lock-in, plus inbound email for agents.
+
+## What Reloop is not
+
+- Not MIT-licensed
+- Not a SendGrid/Mailgun/Resend/SES proxy
+- Not priced by stored contacts on Reloop Cloud
 
 ## Links
 
 - Site: https://reloop.sh
+- Pricing: https://reloop.sh/pricing.md
 - Docs index: https://reloop.sh/llms-docs.txt
+- Compare: https://reloop.sh/compare.md
 - Careers: https://reloop.sh/careers
 - Contact: https://reloop.sh/contact
 - GitHub: https://github.com/reloop-labs/reloop
+- License: https://reloop.sh/license

--- a/apps/frontend/web/content/agent/home.md
+++ b/apps/frontend/web/content/agent/home.md
@@ -2,11 +2,31 @@
 
 > High-performance, open-source email infrastructure—the same service as proprietary platforms. Use Reloop hosted or deploy it yourself.
 
-Reloop is email infrastructure for developers: transactional and marketing email, real-time webhooks, inbound processing, analytics, and an agent-ready API.
+Reloop is email infrastructure for developers: transactional and marketing email, real-time webhooks, inbound processing, analytics, and an agent-ready API. Reloop **is** the ESP/MTA (KumoMTA), not a connector that routes through SendGrid, Mailgun, Resend, or SES.
+
+## What Reloop is not
+
+- Not a multi-provider email router
+- Not MIT-licensed (Apache 2.0 with Reloop Labs use restrictions)
+- Not a contact-list ESP (Reloop Cloud bills by emails sent)
+- Self-host is not a paid Reloop Cloud SKU
+
+## Who it is for
+
+Developers, startups, and agent products that need transactional + campaign email, optional self-host, and machine-readable docs.
+
+## Hosted pricing (Reloop Cloud)
+
+Canonical data: https://reloop.sh/pricing.md
+
+- Free — $0, 3,000 emails / month, **200 / day**
+- Individual — $10 / month, 25,000 emails, no daily cap, overage $0.80 / 1k
+- Startup — $20 / month, 50,000 emails, no daily cap
+- Enterprise — custom volume and billing
 
 ## Why Reloop
 
-- **Open source** — same product you can self-host or use hosted
+- **Open source** — same product you can self-host or use hosted (Apache 2.0)
 - **Developer-first** — REST API, SMTP relay, official SDKs, CLI, MCP
 - **Agent-ready** — API keys, inbound agent inbox, docs as markdown / llms.txt
 
@@ -16,6 +36,7 @@ Reloop is email infrastructure for developers: transactional and marketing email
 - Pricing: https://reloop.sh/pricing.md
 - Documentation index: https://reloop.sh/llms-docs.txt
 - API keys guide: https://reloop.sh/docs/learn/ai/api-keys.md
+- Compare: https://reloop.sh/compare.md
 - GitHub: https://github.com/reloop-labs/reloop
 
 ## Product surfaces

--- a/apps/frontend/web/content/agent/home.md
+++ b/apps/frontend/web/content/agent/home.md
@@ -2,7 +2,7 @@
 
 > High-performance, open-source email infrastructure—the same service as proprietary platforms. Use Reloop hosted or deploy it yourself.
 
-Reloop is email infrastructure for developers: transactional and marketing email, real-time webhooks, inbound processing, analytics, and an agent-ready API. Reloop **is** the ESP/MTA (KumoMTA), not a connector that routes through SendGrid, Mailgun, Resend, or SES.
+Reloop is email infrastructure for developers: transactional and marketing email, real-time webhooks, inbound processing, analytics, and an agent-ready API. Reloop **is** the ESP; it runs an in-house MTA (KumoMTA), not a connector that routes through SendGrid, Mailgun, Resend, or SES.
 
 ## What Reloop is not
 
@@ -20,8 +20,8 @@ Developers, startups, and agent products that need transactional + campaign emai
 Canonical data: https://reloop.sh/pricing.md
 
 - Free — $0, 3,000 emails / month, **200 / day**
-- Individual — $10 / month, 25,000 emails, no daily cap, overage $0.80 / 1k
-- Startup — $20 / month, 50,000 emails, no daily cap
+- Individual — $10 / month, 25,000 emails / month, no daily cap, overage $0.80 / 1,000
+- Startup — $20 / month, 50,000 emails / month, no daily cap, overage $0.80 / 1,000
 - Enterprise — custom volume and billing
 
 ## Why Reloop

--- a/apps/frontend/web/public/.well-known/agent-skills/reloop/SKILL.md
+++ b/apps/frontend/web/public/.well-known/agent-skills/reloop/SKILL.md
@@ -5,7 +5,7 @@ description: >
   send mail, manage API keys, domains, contacts, webhooks, and templates.
   Use when integrating Reloop, creating or rotating API keys, or sending
   transactional email via API or SMTP.
-license: Apache-2.0
+license: "Apache-2.0 plus Reloop Labs restrictions (personal/internal use; no commercial redistribution, hosted services, or competing products). See https://reloop.sh/license"
 metadata:
   author: reloop-labs
   docs: https://reloop.sh/docs

--- a/apps/frontend/web/public/.well-known/agent-skills/reloop/SKILL.md
+++ b/apps/frontend/web/public/.well-known/agent-skills/reloop/SKILL.md
@@ -5,7 +5,7 @@ description: >
   send mail, manage API keys, domains, contacts, webhooks, and templates.
   Use when integrating Reloop, creating or rotating API keys, or sending
   transactional email via API or SMTP.
-license: MIT
+license: Apache-2.0
 metadata:
   author: reloop-labs
   docs: https://reloop.sh/docs
@@ -18,6 +18,8 @@ metadata:
 # Reloop
 
 Reloop is email infrastructure for developers: transactional and marketing email, real-time webhooks, inbound processing, and analytics. SDKs cover Node.js, Python, PHP, Ruby, Go, Rust, Java, .NET, and a CLI.
+
+License: Apache 2.0 with Reloop Labs use restrictions (not MIT). Canonical hosted pricing: https://reloop.sh/pricing.md
 
 ## Documentation index
 

--- a/apps/frontend/web/public/about.md
+++ b/apps/frontend/web/public/about.md
@@ -7,7 +7,7 @@ Reloop Labs builds open-source email infrastructure for developers and AI agents
 ## What we build
 
 - Hosted Reloop Cloud (email API and SMTP) at reloop.sh
-- Self-hostable Apache 2.0 stack (no Reloop license fee; you pay your infra)
+- Self-hostable Apache License 2.0 stack plus Reloop Labs additional restrictions: personal and internal use allowed; no commercial redistribution, hosted services, or competing products. No Reloop license fee; you pay your infra. See https://reloop.sh/license
 - Agent skills, MCP server, and agent-friendly documentation
 
 ## Who it is for

--- a/apps/frontend/web/public/about.md
+++ b/apps/frontend/web/public/about.md
@@ -2,18 +2,31 @@
 
 # About Reloop
 
-Reloop Labs builds open-source email infrastructure for developers and AI agents.
+Reloop Labs builds open-source email infrastructure for developers and AI agents. Reloop **is** the email platform (ESP + MTA). It is **not** a multi-ESP connector.
 
 ## What we build
 
-- Hosted email API and SMTP relay at reloop.sh
-- Self-hostable open-source stack
+- Hosted Reloop Cloud (email API and SMTP) at reloop.sh
+- Self-hostable Apache 2.0 stack (no Reloop license fee; you pay your infra)
 - Agent skills, MCP server, and agent-friendly documentation
+
+## Who it is for
+
+Solo developers, startups, and teams that want transactional + marketing email without lock-in, plus inbound email for agents.
+
+## What Reloop is not
+
+- Not MIT-licensed
+- Not a SendGrid/Mailgun/Resend/SES proxy
+- Not priced by stored contacts on Reloop Cloud
 
 ## Links
 
 - Site: https://reloop.sh
+- Pricing: https://reloop.sh/pricing.md
 - Docs index: https://reloop.sh/llms-docs.txt
+- Compare: https://reloop.sh/compare.md
 - Careers: https://reloop.sh/careers
 - Contact: https://reloop.sh/contact
 - GitHub: https://github.com/reloop-labs/reloop
+- License: https://reloop.sh/license

--- a/apps/frontend/web/public/index.md
+++ b/apps/frontend/web/public/index.md
@@ -4,11 +4,31 @@
 
 > High-performance, open-source email infrastructure—the same service as proprietary platforms. Use Reloop hosted or deploy it yourself.
 
-Reloop is email infrastructure for developers: transactional and marketing email, real-time webhooks, inbound processing, analytics, and an agent-ready API.
+Reloop is email infrastructure for developers: transactional and marketing email, real-time webhooks, inbound processing, analytics, and an agent-ready API. Reloop **is** the ESP/MTA (KumoMTA), not a connector that routes through SendGrid, Mailgun, Resend, or SES.
+
+## What Reloop is not
+
+- Not a multi-provider email router
+- Not MIT-licensed (Apache 2.0 with Reloop Labs use restrictions)
+- Not a contact-list ESP (Reloop Cloud bills by emails sent)
+- Self-host is not a paid Reloop Cloud SKU
+
+## Who it is for
+
+Developers, startups, and agent products that need transactional + campaign email, optional self-host, and machine-readable docs.
+
+## Hosted pricing (Reloop Cloud)
+
+Canonical data: https://reloop.sh/pricing.md
+
+- Free — $0, 3,000 emails / month, **200 / day**
+- Individual — $10 / month, 25,000 emails, no daily cap, overage $0.80 / 1k
+- Startup — $20 / month, 50,000 emails, no daily cap
+- Enterprise — custom volume and billing
 
 ## Why Reloop
 
-- **Open source** — same product you can self-host or use hosted
+- **Open source** — same product you can self-host or use hosted (Apache 2.0)
 - **Developer-first** — REST API, SMTP relay, official SDKs, CLI, MCP
 - **Agent-ready** — API keys, inbound agent inbox, docs as markdown / llms.txt
 
@@ -18,6 +38,7 @@ Reloop is email infrastructure for developers: transactional and marketing email
 - Pricing: https://reloop.sh/pricing.md
 - Documentation index: https://reloop.sh/llms-docs.txt
 - API keys guide: https://reloop.sh/docs/learn/ai/api-keys.md
+- Compare: https://reloop.sh/compare.md
 - GitHub: https://github.com/reloop-labs/reloop
 
 ## Product surfaces

--- a/apps/frontend/web/public/index.md
+++ b/apps/frontend/web/public/index.md
@@ -4,7 +4,7 @@
 
 > High-performance, open-source email infrastructure—the same service as proprietary platforms. Use Reloop hosted or deploy it yourself.
 
-Reloop is email infrastructure for developers: transactional and marketing email, real-time webhooks, inbound processing, analytics, and an agent-ready API. Reloop **is** the ESP/MTA (KumoMTA), not a connector that routes through SendGrid, Mailgun, Resend, or SES.
+Reloop is email infrastructure for developers: transactional and marketing email, real-time webhooks, inbound processing, analytics, and an agent-ready API. Reloop **is** the ESP; it runs an in-house MTA (KumoMTA), not a connector that routes through SendGrid, Mailgun, Resend, or SES.
 
 ## What Reloop is not
 
@@ -22,8 +22,8 @@ Developers, startups, and agent products that need transactional + campaign emai
 Canonical data: https://reloop.sh/pricing.md
 
 - Free — $0, 3,000 emails / month, **200 / day**
-- Individual — $10 / month, 25,000 emails, no daily cap, overage $0.80 / 1k
-- Startup — $20 / month, 50,000 emails, no daily cap
+- Individual — $10 / month, 25,000 emails / month, no daily cap, overage $0.80 / 1,000
+- Startup — $20 / month, 50,000 emails / month, no daily cap, overage $0.80 / 1,000
 - Enterprise — custom volume and billing
 
 ## Why Reloop

--- a/apps/frontend/web/public/llms-docs.txt
+++ b/apps/frontend/web/public/llms-docs.txt
@@ -9,7 +9,7 @@ Important notes:
 - Reloop supports both transactional and marketing (broadcast) emails
 - Inbound email receiving is supported via webhook ingester
 - The product MCP server package is `reloop-mcp` and can be installed via `npx -y reloop-mcp`
-- Prefer markdown: append `.md` to any docs URL (e.g. https://reloop.sh/docs/learn/api-keys.md)
+- Canonical hosted pricing (not this docs tree): [pricing.md](https://reloop.sh/pricing.md)
 
 ## Documentation
 

--- a/apps/frontend/web/public/llms-full-docs.txt
+++ b/apps/frontend/web/public/llms-full-docs.txt
@@ -254,7 +254,7 @@ Markdown: https://reloop.sh/docs/learn/ai/api-keys.go.md
 
 `POST /api/api-key/v1/`
 
-```go
+```go
 
 client, _ := reloop.NewClient(reloop.ClientOptions{
     APIKey: "rl_123456789",
@@ -269,7 +269,7 @@ apiKey, _ := client.ApiKeys.Create(reloop.CreateApiKeyParams{
 
 `GET /api/api-key/v1/`
 
-```go
+```go
 
 client, _ := reloop.NewClient(reloop.ClientOptions{
     APIKey: "rl_123456789",
@@ -285,7 +285,7 @@ apiKeys, _ := client.ApiKeys.List(&reloop.ApiKeyListParams{
 
 `GET /api/api-key/v1/:api_key_id`
 
-```go
+```go
 
 client, _ := reloop.NewClient(reloop.ClientOptions{
     APIKey: "rl_123456789",
@@ -298,7 +298,7 @@ _, _ = client.ApiKeys.Get("key_123456789")
 
 `PATCH /api/api-key/v1/:api_key_id`
 
-```go
+```go
 
 client, _ := reloop.NewClient(reloop.ClientOptions{
     APIKey: "rl_123456789",
@@ -313,7 +313,7 @@ apiKey, _ := client.ApiKeys.Update("key_123456789", reloop.UpdateApiKeyParams{
 
 `POST /api/api-key/v1/rotate/:api_key_id`
 
-```go
+```go
 
 client, _ := reloop.NewClient(reloop.ClientOptions{
     APIKey: "rl_123456789",
@@ -326,7 +326,7 @@ _, _ = client.ApiKeys.Rotate("key_123456789")
 
 `POST /api/api-key/v1/disable/:api_key_id`
 
-```go
+```go
 
 client, _ := reloop.NewClient(reloop.ClientOptions{
     APIKey: "rl_123456789",
@@ -339,7 +339,7 @@ _, _ = client.ApiKeys.Disable("key_123456789")
 
 `POST /api/api-key/v1/enable/:api_key_id`
 
-```go
+```go
 
 client, _ := reloop.NewClient(reloop.ClientOptions{
     APIKey: "rl_123456789",
@@ -352,7 +352,7 @@ _, _ = client.ApiKeys.Enable("key_123456789")
 
 `DELETE /api/api-key/v1/:api_key_id`
 
-```go
+```go
 
 client, _ := reloop.NewClient(reloop.ClientOptions{
     APIKey: "rl_123456789",
@@ -381,8 +381,7 @@ Markdown: https://reloop.sh/docs/learn/ai/api-keys.java.md
 
 `POST /api/api-key/v1/`
 
-```java
-
+```java
 ReloopClient reloop = new ReloopClient("rl_123456789");
 
 CreateApiKeyParams params = new CreateApiKeyParams();
@@ -395,8 +394,7 @@ System.out.println(apiKey.id + " " + apiKey.key);
 
 `GET /api/api-key/v1/`
 
-```java
-
+```java
 ReloopClient reloop = new ReloopClient("rl_123456789");
 
 ApiKeyListParams params = new ApiKeyListParams();
@@ -411,7 +409,7 @@ System.out.println(apiKeys.total + " " + apiKeys.apiKeys);
 
 `GET /api/api-key/v1/:api_key_id`
 
-```java
+```java
 
 ReloopClient reloop = new ReloopClient("rl_123456789");
 
@@ -423,8 +421,7 @@ System.out.println(apiKey.id + " " + apiKey.name + " " + apiKey.enabled);
 
 `PATCH /api/api-key/v1/:api_key_id`
 
-```java
-
+```java
 ReloopClient reloop = new ReloopClient("rl_123456789");
 
 UpdateApiKeyParams params = new UpdateApiKeyParams();
@@ -437,7 +434,7 @@ System.out.println(apiKey.id + " " + apiKey.name);
 
 `POST /api/api-key/v1/rotate/:api_key_id`
 
-```java
+```java
 
 ReloopClient reloop = new ReloopClient("rl_123456789");
 
@@ -449,7 +446,7 @@ System.out.println(apiKey.id + " " + apiKey.key);
 
 `POST /api/api-key/v1/disable/:api_key_id`
 
-```java
+```java
 
 ReloopClient reloop = new ReloopClient("rl_123456789");
 
@@ -461,7 +458,7 @@ System.out.println(apiKey.id + " " + apiKey.enabled);
 
 `POST /api/api-key/v1/enable/:api_key_id`
 
-```java
+```java
 
 ReloopClient reloop = new ReloopClient("rl_123456789");
 
@@ -473,7 +470,7 @@ System.out.println(apiKey.id + " " + apiKey.enabled);
 
 `DELETE /api/api-key/v1/:api_key_id`
 
-```java
+```java
 
 ReloopClient reloop = new ReloopClient("rl_123456789");
 
@@ -557,7 +554,7 @@ Markdown: https://reloop.sh/docs/learn/ai/api-keys.node.md
 
 `POST /api/api-key/v1/`
 
-```javascript
+```javascript
 
 const reloop = new Reloop({ apiKey: "rl_123456789" });
 
@@ -574,7 +571,7 @@ console.log(apiKey.id, apiKey.key);
 
 `GET /api/api-key/v1/`
 
-```javascript
+```javascript
 
 const reloop = new Reloop({ apiKey: "rl_123456789" });
 
@@ -593,7 +590,7 @@ console.log(apiKeys.total, apiKeys.apiKeys);
 
 `GET /api/api-key/v1/:api_key_id`
 
-```javascript
+```javascript
 
 const reloop = new Reloop({ apiKey: "rl_123456789" });
 
@@ -608,7 +605,7 @@ console.log(apiKey.id, apiKey.name, apiKey.enabled);
 
 `PATCH /api/api-key/v1/:api_key_id`
 
-```javascript
+```javascript
 
 const reloop = new Reloop({ apiKey: "rl_123456789" });
 
@@ -625,7 +622,7 @@ console.log(apiKey.id, apiKey.name);
 
 `POST /api/api-key/v1/rotate/:api_key_id`
 
-```javascript
+```javascript
 
 const reloop = new Reloop({ apiKey: "rl_123456789" });
 
@@ -640,7 +637,7 @@ console.log(apiKey.id, apiKey.key);
 
 `POST /api/api-key/v1/disable/:api_key_id`
 
-```javascript
+```javascript
 
 const reloop = new Reloop({ apiKey: "rl_123456789" });
 
@@ -655,7 +652,7 @@ console.log(apiKey.id, apiKey.enabled);
 
 `POST /api/api-key/v1/enable/:api_key_id`
 
-```javascript
+```javascript
 
 const reloop = new Reloop({ apiKey: "rl_123456789" });
 
@@ -670,7 +667,7 @@ console.log(apiKey.id, apiKey.enabled);
 
 `DELETE /api/api-key/v1/:api_key_id`
 
-```javascript
+```javascript
 
 const reloop = new Reloop({ apiKey: "rl_123456789" });
 
@@ -1302,6 +1299,7 @@ Markdown: https://reloop.sh/docs/learn/api-keys.md
     4. Update the key name and click **Save changes** (or press `Enter`)
     <Video src="/docs/images/docs/api-keys/edit-api-key.mp4" autoPlay loop muted playsInline />
 
+
     ## Rotate an API key
 
     <Info>
@@ -1383,6 +1381,7 @@ Markdown: https://reloop.sh/docs/learn/api-keys.md
     <ApiKeyCodeSamples id="apiKey.delete" />
   </Tab>
 </Tabs>
+
 
 ## FAQ
 
@@ -4033,8 +4032,7 @@ Webhooks are "user-defined HTTP callbacks". They are usually triggered by some e
 
 Set up a URL on your server that can receive HTTP POST requests.
 
-```javascript
-
+```javascript
   if (req.method === 'POST') {
     const event = req.body;
     console.log(event);
@@ -4082,8 +4080,7 @@ Headers include `Reloop-Id`, `Reloop-Timestamp`, and `Reloop-Signature` for veri
 
 Once you've tested your logic, update your endpoint to handle specific event types and deploy it to your production server.
 
-```javascript
-
+```javascript
   if (req.method === 'POST') {
     const event = req.body;
     if (event.type === "email.bounced") {
@@ -4393,8 +4390,7 @@ Every delivery includes:
 4. Compare the hex digest to the `v1=` value with a constant-time compare.
 5. Reject if the timestamp is older than ~5 minutes (replay protection).
 
-```typescript
-
+```typescript
   secret: string;
   rawBody: string;
   signatureHeader: string;
@@ -4870,8 +4866,7 @@ Follow the [Local Development](#local-development) steps above first.
 ### Using Stdio Transport
 
 1. Set your API key:
-    ```bash
-
+    ```bash
     ```
 
 2. Start the inspector:
@@ -4996,7 +4991,7 @@ Let's add a webhook to Reloop using the server you just built. Use the email.rec
 **Test receiving an email:**
 
 <CodeBlock title="Webhook Handler Example">
-```typescript
+```typescript
 
 const reloop = new Reloop(process.env.RELOOP_API_KEY);
 
@@ -5285,6 +5280,7 @@ Markdown: https://reloop.sh/docs/resources/sdks.md
   </Card>
 </CardGroup>
 
+
 ## Missing your language?
 
 We're actively expanding our SDK coverage. If your language or framework isn't listed above, you can:
@@ -5330,8 +5326,7 @@ go get github.com/reloop-labs/reloop-go
 ## Sending an Email
 
 ```go
-package main
-
+package main
 	"context"
 	"net/http"
 	"os"
@@ -5553,7 +5548,7 @@ RELOOP_API_KEY=re_your_api_key_here
 
 Here is an example of an Express route that sends an email:
 
-```typescript
+```typescript
 
 const app = express();
 const reloop = new Reloop({ apiKey: process.env.RELOOP_API_KEY });
@@ -5602,8 +5597,7 @@ RELOOP_API_KEY=rl_your_api_key_here
 ## Shared client
 
 ```typescript
-// lib/reloop.ts
-
+// lib/reloop.ts
   apiKey: process.env.RELOOP_API_KEY!,
 });
 ```
@@ -5611,8 +5605,7 @@ RELOOP_API_KEY=rl_your_api_key_here
 ## Route Handler
 
 ```typescript
-// app/api/send-email/route.ts
-
+// app/api/send-email/route.ts
   try {
     const { to, subject, html, text } = await request.json();
 
@@ -5639,8 +5632,7 @@ RELOOP_API_KEY=rl_your_api_key_here
 
 ```typescript
 // app/actions/send-email.ts
-"use server";
-
+"use server";
   const { response, emailError } = await reloop.mail.send({
     from: "Acme <onboarding@mail.yourdomain.com>",
     to: email,
@@ -5736,7 +5728,7 @@ pip install reloop-email
 Add your API key to your settings:
 
 ```python
-# settings.py
+# settings.py
 
 RELOOP_API_KEY = os.environ.get("RELOOP_API_KEY", "re_your_api_key_here")
 ```
@@ -5787,16 +5779,14 @@ pip install reloop-email
 
 Add your API key to your environment:
 
-```bash
-
+```bash
 ```
 
 ## Sending an Email
 
 Here is a simple FastAPI route that sends an email:
 
-```python
-
+```python
 from fastapi import FastAPI, HTTPException
 from reloop_email import Reloop
 
@@ -5834,8 +5824,7 @@ pip install reloop-email
 
 ## Sending an Email
 
-```python
-
+```python
 from flask import Flask, jsonify
 from reloop_email import Reloop
 
@@ -5886,8 +5875,7 @@ bundle install
 
 Set your API key in your environment variables:
 
-```bash
-
+```bash
 ```
 
 ## Sending an Email
@@ -5979,8 +5967,7 @@ Markdown: https://reloop.sh/docs/examples/smtp/go.md
 ## Code Example
 
 ```go
-package main
-
+package main
 	"crypto/tls"
 	"fmt"
 	"net/smtp"
@@ -6253,8 +6240,7 @@ Markdown: https://reloop.sh/docs/examples/smtp/python.md
 
 ## Code Example
 
-```python
-
+```python
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 
@@ -7804,6 +7790,7 @@ Never create a second SPF TXT on the same host. Merge `include:reloop.sh` into t
 - DreamHost uses `@` or blank for the root host depending on the screen.
 - Confirm you are editing the zone that matches public nameservers.
 
+
 ## Receiving emails
 
 **Email Receiving** is on by default for new domains. If it stays on, you must publish the inbound **MX** Reloop shows (typically `inbound.reloop.sh`). Turn Email Receiving off for send-only if this hostname must keep another inbox.
@@ -7920,6 +7907,7 @@ Never create a second SPF TXT on the same host. Merge `include:reloop.sh` into t
 - Gandi LiveDNS uses relative hostnames; omit the domain suffix.
 - If the domain uses external nameservers, edit that host instead.
 
+
 ## Receiving emails
 
 **Email Receiving** is on by default for new domains. If it stays on, you must publish the inbound **MX** Reloop shows (typically `inbound.reloop.sh`). Turn Email Receiving off for send-only if this hostname must keep another inbox.
@@ -8035,6 +8023,7 @@ Never create a second SPF TXT on the same host. Merge `include:reloop.sh` into t
 
 - Glauca Digital supports Domain Connect ([HexDNS](https://docs.glauca.digital/hexdns/domain-connect/)). Reloop’s template may become available after public registry sync — if Reloop does not show **Auto populate**, use manual setup.
 - Default HexDNS nameservers are `ns1`–`ns4.as207960.net`.
+
 
 ## Receiving emails
 
@@ -8269,6 +8258,7 @@ Never create a second SPF TXT on the same host. Merge `include:reloop.sh` into t
 - Use the Hetzner DNS Console for zones on Hetzner nameservers.
 - Merge SPF carefully — Hetzner may already have a default TXT.
 
+
 ## Receiving emails
 
 **Email Receiving** is on by default for new domains. If it stays on, you must publish the inbound **MX** Reloop shows (typically `inbound.reloop.sh`). Turn Email Receiving off for send-only if this hostname must keep another inbox.
@@ -8384,6 +8374,7 @@ Never create a second SPF TXT on the same host. Merge `include:reloop.sh` into t
 
 - Hostinger hPanel is the editor when nameservers point at Hostinger.
 - If you pointed NS at Cloudflare (or another host), edit that host instead.
+
 
 ## Receiving emails
 
@@ -8699,6 +8690,7 @@ Never create a second SPF TXT on the same host. Merge `include:reloop.sh` into t
 - Use Advanced DNS when Namecheap nameservers are active.
 - For apex hosts Namecheap often uses `@`.
 
+
 ## Receiving emails
 
 **Email Receiving** is on by default for new domains. If it stays on, you must publish the inbound **MX** Reloop shows (typically `inbound.reloop.sh`). Turn Email Receiving off for send-only if this hostname must keep another inbox.
@@ -8836,6 +8828,7 @@ Never create a second SPF TXT on the same host. Merge `include:reloop.sh` into t
 - NameSilo syncs Domain Connect templates from the public registry — prefer Auto-populate when offered.
 - Confirm you are editing DNS at NameSilo (not a different host pointed to by custom NS).
 
+
 ## Receiving emails
 
 **Email Receiving** is on by default for new domains. If it stays on, you must publish the inbound **MX** Reloop shows (typically `inbound.reloop.sh`). Turn Email Receiving off for send-only if this hostname must keep another inbox.
@@ -8953,6 +8946,7 @@ Never create a second SPF TXT on the same host. Merge `include:reloop.sh` into t
 - Plesk is often behind a hosting brand: open the panel that actually serves your public nameservers.
 - Login URL varies by host; Reloop cannot deep-link to a single Plesk URL.
 
+
 ## Receiving emails
 
 **Email Receiving** is on by default for new domains. If it stays on, you must publish the inbound **MX** Reloop shows (typically `inbound.reloop.sh`). Turn Email Receiving off for send-only if this hostname must keep another inbox.
@@ -9068,6 +9062,7 @@ Never create a second SPF TXT on the same host. Merge `include:reloop.sh` into t
 
 - Porkbun uses relative host fields; omit your domain suffix.
 - Confirm DNS is managed at Porkbun (not parked elsewhere).
+
 
 ## Receiving emails
 
@@ -9185,6 +9180,7 @@ Never create a second SPF TXT on the same host. Merge `include:reloop.sh` into t
 - Edit the hosted zone whose NS match the public nameservers (`awsdns-`).
 - For MX, set the Priority field separately from the Value.
 
+
 ## Receiving emails
 
 **Email Receiving** is on by default for new domains. If it stays on, you must publish the inbound **MX** Reloop shows (typically `inbound.reloop.sh`). Turn Email Receiving off for send-only if this hostname must keep another inbox.
@@ -9301,6 +9297,7 @@ Never create a second SPF TXT on the same host. Merge `include:reloop.sh` into t
 - Domains migrated from Google Domains often still show `googledomains.com` nameservers — manage them in Squarespace.
 - Use `@` for the root host when Squarespace requires it.
 
+
 ## Receiving emails
 
 **Email Receiving** is on by default for new domains. If it stays on, you must publish the inbound **MX** Reloop shows (typically `inbound.reloop.sh`). Turn Email Receiving off for send-only if this hostname must keep another inbox.
@@ -9416,6 +9413,7 @@ Never create a second SPF TXT on the same host. Merge `include:reloop.sh` into t
 
 - Strato’s DNS UI labels vary by language (DE/EN).
 - Confirm public NS match Strato before editing.
+
 
 ## Receiving emails
 
@@ -9720,6 +9718,7 @@ Never create a second SPF TXT on the same host. Merge `include:reloop.sh` into t
 
 - WordPress.com is listed as a Domain Connect DNS provider. Reloop’s template is **not** onboarded there yet — use manual setup unless Reloop shows **Auto populate**.
 - If the domain uses custom nameservers elsewhere, edit that host instead.
+
 
 ## Receiving emails
 
@@ -10948,7 +10947,7 @@ npm install @playwright/test reloop
 
 ## Example Test
 
-```typescript
+```typescript
 
 const reloop = new Reloop(process.env.RELOOP_API_KEY);
 
@@ -11268,7 +11267,7 @@ Reloop's inbound email feature can be used to forward received emails to another
   <Step title="Forward the email">
     In your webhook handler, use the Reloop API to send the email to the forwarding address:
 
-    ```typescript
+    ```typescript
 
     const reloop = new Reloop(process.env.RELOOP_API_KEY);
 
@@ -11498,34 +11497,34 @@ For detailed guidance on email deliverability, see our [Email Best Practices](/d
 Source: https://reloop.sh/docs/guides/pricing
 Markdown: https://reloop.sh/docs/guides/pricing.md
 
-Understanding Reloop pricing and plans.
+Reloop publishes **one** pricing source of truth: the marketing [pricing page](https://reloop.sh/pricing) and its markdown twin [pricing.md](https://reloop.sh/pricing.md) (generated from `@reloop/pricing`).
 
-## Overview
+This docs page exists so agents and the docs MCP do not invent plans. Do not cite “Essentials $9” or “Free has no daily limit.”
 
-Manage your Reloop account settings effectively to ensure smooth operation.
+## Reloop Cloud (hosted)
 
-## Steps
+| Plan | Price | Included volume | Daily limit | Overage |
+|------|-------|-----------------|-------------|---------|
+| Free | $0 | 3,000 emails / month | 200 / day | None (sending pauses) |
+| Individual | $10 / month | 25,000 emails / month | None | $0.80 / 1,000 |
+| Startup | $20 / month | 50,000 emails / month | None | $0.80 / 1,000 |
+| Enterprise | Custom | Custom | None | Custom |
 
-<Steps>
-  <Step title="Access your settings">
-    Navigate to the [Account Settings](https://app.reloop.sh/settings) page in your Reloop dashboard.
-  </Step>
-  <Step title="Make your changes">
-    Follow the on-screen instructions to update your account configuration.
-  </Step>
-  <Step title="Confirm changes">
-    Review and confirm your changes. Some changes may require email verification.
-  </Step>
-</Steps>
+No credit card is required for Free. Data retention on published tiers is 45 days.
 
-<Note>
-If you need assistance with account changes, contact [Reloop support](https://reloop.sh/help).
-</Note>
+## Self-host
 
-## Learn More
+Self-hosting Reloop is Apache 2.0 software with Reloop Labs use restrictions. There is **no Reloop SaaS fee** and **no hosted-tier SKU** for running the stack yourself. You pay your own servers, IPs, and operations. See [self-host](https://reloop.sh/self-host) and [license](https://reloop.sh/license).
 
+## Quotas in the product
+
+Plan limits are enforced on Reloop Cloud. Dashboard usage: [Account settings](https://reloop.sh/dashboard/settings). Sending guides: [Account quotas](/docs/guides/account-quotas-limits), [Sending](/docs/learn/sending).
+
+## Learn more
+
+- [pricing.md](https://reloop.sh/pricing.md) — canonical agent-readable plans
+- [Compare Reloop](https://reloop.sh/compare.md)
 - [Handling API Keys](/docs/guides/handling-api-keys)
-- [Account Quotas and Limits](/docs/guides/account-quotas-limits)
 
 ---
 
@@ -12092,8 +12091,7 @@ When prompted, input your Reloop API key starting with `rl_`.
 
 Send emails with a standard POST request inside your Worker:
 
-```typescript
-
+```typescript
   async fetch(request, env) {
     const response = await fetch('https://api.reloop.sh/v1/emails', {
       method: 'POST',
@@ -12742,10 +12740,9 @@ Markdown: https://reloop.sh/docs/integrations/netlify.md
 
 Retrieve the variable inside a Netlify Serverless Function:
 
-```typescript
+```typescript
 
-const reloop = new Reloop(process.env.RELOOP_API_KEY);
-
+const reloop = new Reloop(process.env.RELOOP_API_KEY);
   const result = await reloop.mail.send({
     from: 'hello@yourdomain.com',
     to: 'customer@example.com',
@@ -12825,7 +12822,7 @@ Replit automatically injects secrets as environment variables.
 
 Send an email in Node.js on Replit:
 
-```javascript
+```javascript
 
 const reloop = new Reloop(process.env.RELOOP_API_KEY);
 
@@ -12948,10 +12945,9 @@ Copy the generated code into your Next.js project.
 
 In your Next.js project, create `/app/api/send/route.ts` to process the form using Reloop:
 
-```typescript
+```typescript
 
-const reloop = new Reloop(process.env.RELOOP_API_KEY);
-
+const reloop = new Reloop(process.env.RELOOP_API_KEY);
   const { name, email, message } = await req.json();
 
   const data = await reloop.mail.send({
@@ -12993,10 +12989,9 @@ To allow your serverless functions or Next.js API routes to authenticate with Re
 
 Use the official Node.js SDK to send emails in your serverless code:
 
-```typescript
+```typescript
 
-const reloop = new Reloop(process.env.RELOOP_API_KEY);
-
+const reloop = new Reloop(process.env.RELOOP_API_KEY);
   const data = await reloop.mail.send({
     from: 'onboarding@yourdomain.com',
     to: 'user@example.com',
@@ -13642,6 +13637,7 @@ Markdown: https://reloop.sh/docs/learn/contacts.md
     4. Update the fields and click **Update** (or press `Enter`)
     <Video src="/docs/images/docs/contacts/overview/edit-contact.mp4" autoPlay loop muted playsInline />
 
+
     ## Subscribe or unsubscribe a contact
 
     <Info>
@@ -13699,6 +13695,7 @@ Markdown: https://reloop.sh/docs/learn/contacts.md
   </Tab>
 </Tabs>
 
+
 ## FAQ
 
 <AccordionGroup>
@@ -13752,6 +13749,7 @@ Markdown: https://reloop.sh/docs/learn/contacts.md
     Per-topic subscription preferences.
   </Card>
 </CardGroup>
+
 
 ## API reference
 
@@ -14072,6 +14070,7 @@ Markdown: https://reloop.sh/docs/learn/domain.md
   </Tab>
 </Tabs>
 
+
 ## FAQ
 
 <AccordionGroup>
@@ -14117,6 +14116,7 @@ Markdown: https://reloop.sh/docs/learn/domain.md
     Authenticate REST and SMTP with API keys.
   </Card>
 </CardGroup>
+
 
 ## API reference
 
@@ -14422,6 +14422,7 @@ Markdown: https://reloop.sh/docs/self-host/services.md
 
 Reloop is built using a highly modular microservice architecture. This separation allows you to scale specific components (such as mail queues or logs processing) depending on your server workload.
 
+
 ## Component Breakdown
 
 The Reloop stack consists of **19 application services** (3 frontends, 16 backends) and **9 external backing systems**.
@@ -14488,6 +14489,7 @@ Generation, hashing, validation, and revocation of developer API keys.
 Run [`bun setup`](/docs/setup) once from the monorepo root. Env files come from `bun setup` / `bun env:setup`.
 </Tip>
 
+
 ## Overview
 
 | Property | Value |
@@ -14498,6 +14500,7 @@ Run [`bun setup`](/docs/setup) once from the monorepo root. Env files come from 
 | **Swagger UI** | [https://local.reloop.sh/api/api-key/openapi](https://local.reloop.sh/api/api-key/openapi) |
 | **Stack** | ElysiaJS · Better Auth API Key · PostgreSQL · Redis · NATS |
 
+
 ## Quick start
 
 ```bash
@@ -14505,6 +14508,7 @@ bun be:api-key:dev
 ```
 
 Or `bun backend:dev` / `bun dev`.
+
 
 ## Environment
 
@@ -14527,6 +14531,7 @@ NODE_ENV=development
 | `BASE_URL` | **YES** | `https://local.reloop.sh` |
 | `NATS_URL` | **YES** | `nats://localhost:4222` |
 
+
 ## Commands
 
 | Command | Description |
@@ -14536,6 +14541,7 @@ NODE_ENV=development
 | `bun run --filter=be-api-key start` | Run compiled production build |
 | `bun run --filter=be-api-key check-types` | TypeScript type-check |
 
+
 ## Architecture
 
 | Layer | Detail |
@@ -14544,6 +14550,7 @@ NODE_ENV=development
 | **Caching** | Validated keys are cached in Redis for fast lookups |
 | **Events** | Key lifecycle events published to NATS under `api-key.*` |
 | **Schema** | `apikey` table in `packages/db/src/schema/api-key.ts` |
+
 
 ## Next
 
@@ -14575,6 +14582,7 @@ User signup, login, sessions, organizations, and workspace membership via **Bett
 Run [`bun setup`](/docs/setup) once from the monorepo root (Postgres + Redis via Docker). Env files come from `bun setup` / `bun env:setup`.
 </Tip>
 
+
 ## Overview
 
 | Property | Value |
@@ -14584,6 +14592,7 @@ Run [`bun setup`](/docs/setup) once from the monorepo root (Postgres + Redis via
 | **Local URL** | [https://local.reloop.sh/api/auth](https://local.reloop.sh/api/auth) |
 | **Swagger UI** | [https://local.reloop.sh/api/auth/openapi](https://local.reloop.sh/api/auth/openapi) |
 | **Stack** | ElysiaJS · Better Auth · PostgreSQL · Redis · NATS |
+
 
 ## Quick start
 
@@ -14596,6 +14605,7 @@ Or start every backend: `bun backend:dev` / `bun dev`.
 <Warning>
 Open the dashboard at [https://local.reloop.sh/dashboard](https://local.reloop.sh/dashboard), not `localhost:3001`. Session cookies are scoped to `local.reloop.sh`. Local OTP is `888888`.
 </Warning>
+
 
 ## Environment
 
@@ -14637,6 +14647,7 @@ GITHUB_CLIENT_SECRET=
 | `DEFAULT_OTP` | No | `888888` | Dev OTP bypass |
 | `DISABLE_SIGNUP` | No | `false` | Set `true` after creating an admin |
 
+
 ## Commands
 
 | Command | Description |
@@ -14646,6 +14657,7 @@ GITHUB_CLIENT_SECRET=
 | `bun run --filter=be-auth start` | Run compiled production build |
 | `bun run --filter=be-auth check-types` | TypeScript type-check |
 
+
 ## Architecture
 
 | Layer | Detail |
@@ -14654,6 +14666,7 @@ GITHUB_CLIENT_SECRET=
 | **Multi-tenancy** | Users belong to organizations through `member` (`packages/db/src/schema/auth.ts`) |
 | **Events** | Auth lifecycle events published to NATS under `auth.*` |
 | **First login** | Use OTP `888888` locally when `DEFAULT_OTP` is set |
+
 
 ## Next
 
@@ -14685,6 +14698,7 @@ Subscriber profiles, groups, channels, custom properties, and suppression lists.
 Run [`bun setup`](/docs/setup) once from the monorepo root. Env files come from `bun setup` / `bun env:setup`.
 </Tip>
 
+
 ## Overview
 
 | Property | Value |
@@ -14695,6 +14709,7 @@ Run [`bun setup`](/docs/setup) once from the monorepo root. Env files come from 
 | **Swagger UI** | [https://local.reloop.sh/api/contacts/openapi](https://local.reloop.sh/api/contacts/openapi) |
 | **Stack** | ElysiaJS · PostgreSQL · Redis · NATS |
 
+
 ## Quick start
 
 ```bash
@@ -14702,6 +14717,7 @@ bun be:contacts:dev
 ```
 
 Or `bun backend:dev` / `bun dev`.
+
 
 ## Environment
 
@@ -14728,6 +14744,7 @@ NODE_ENV=development
 | `NATS_URL` | **YES** | `nats://localhost:4222` |
 | `PREFERENCES_SECRET` | Prod only | Dev default in `.env.dev` |
 
+
 ## Commands
 
 | Command | Description |
@@ -14737,6 +14754,7 @@ NODE_ENV=development
 | `bun run --filter=be-contacts start` | Run compiled production build |
 | `bun run --filter=be-contacts check-types` | TypeScript type-check |
 
+
 ## Architecture
 
 | Layer | Detail |
@@ -14745,6 +14763,7 @@ NODE_ENV=development
 | **Preferences** | Powers the [Links](/docs/setup/frontend/links) preference center |
 | **Events** | Lifecycle events published to NATS under `contacts.*` |
 | **Schema** | `contact`, `channel`, `group` in `packages/db/src/schema/` |
+
 
 ## Next
 
@@ -14776,6 +14795,7 @@ Subscription tiers, credit balances, usage tracking, and Stripe billing integrat
 Run [`bun setup`](/docs/setup) once from the monorepo root. Env files come from `bun setup` / `bun env:setup`.
 </Tip>
 
+
 ## Overview
 
 | Property | Value |
@@ -14786,6 +14806,7 @@ Run [`bun setup`](/docs/setup) once from the monorepo root. Env files come from 
 | **Swagger UI** | [https://local.reloop.sh/api/credits/openapi](https://local.reloop.sh/api/credits/openapi) |
 | **Stack** | ElysiaJS · PostgreSQL · NATS |
 
+
 ## Quick start
 
 ```bash
@@ -14793,6 +14814,7 @@ bun be:credits:dev
 ```
 
 Or `bun backend:dev` / `bun dev`.
+
 
 ## Environment
 
@@ -14811,6 +14833,7 @@ NATS_URL=nats://localhost:4222
 | `INITIAL_CREDITS` | **YES** | `100` |
 | `NATS_URL` | **YES** | `nats://localhost:4222` |
 
+
 ## Commands
 
 | Command | Description |
@@ -14820,6 +14843,7 @@ NATS_URL=nats://localhost:4222
 | `bun run --filter=be-credits start` | Run compiled production build |
 | `bun run --filter=be-credits check-types` | TypeScript type-check |
 
+
 ## Architecture
 
 | Layer | Detail |
@@ -14828,6 +14852,7 @@ NATS_URL=nats://localhost:4222
 | **Stripe** | Manages subscriptions, invoices, and billing webhooks |
 | **Events** | Publishes `billing.quota-warning` and related NATS subjects |
 | **Schema** | `plan`, `subscription`, `credit_ledger` in `packages/db/src/schema/billing.ts` |
+
 
 ## Next
 
@@ -14859,6 +14884,7 @@ Custom sending domains, DKIM keys, DNS verification, and tracking subdomain setu
 Run [`bun setup`](/docs/setup) once from the monorepo root. Env files come from `bun setup` / `bun env:setup`.
 </Tip>
 
+
 ## Overview
 
 | Property | Value |
@@ -14869,6 +14895,7 @@ Run [`bun setup`](/docs/setup) once from the monorepo root. Env files come from 
 | **Swagger UI** | [https://local.reloop.sh/api/domain/openapi](https://local.reloop.sh/api/domain/openapi) |
 | **Stack** | ElysiaJS · PostgreSQL · Redis · NATS |
 
+
 ## Quick start
 
 ```bash
@@ -14876,6 +14903,7 @@ bun be:domain:dev
 ```
 
 Or `bun backend:dev` / `bun dev`.
+
 
 ## Environment
 
@@ -14902,6 +14930,7 @@ NODE_ENV=development
 | `DKIM_SELECTOR` | **YES** | `reloop` |
 | `NATS_URL` | **YES** | `nats://localhost:4222` |
 
+
 ## Commands
 
 | Command | Description |
@@ -14911,6 +14940,7 @@ NODE_ENV=development
 | `bun run --filter=be-domain start` | Run compiled production build |
 | `bun run --filter=be-domain check-types` | TypeScript type-check |
 
+
 ## Architecture
 
 | Layer | Detail |
@@ -14919,6 +14949,7 @@ NODE_ENV=development
 | **Inbound validation** | Used by [inbound](/docs/setup/backend/inbound) to verify recipient addresses |
 | **Schema** | `domain` and `domain_dns_record` in `packages/db/src/schema/domain.ts` |
 | **Events** | Publishes domain lifecycle events to NATS |
+
 
 ## Next
 
@@ -14954,6 +14985,7 @@ Run [`bun setup`](/docs/setup) once from the monorepo root. Env files come from 
 **Email** ≠ **Mail**. Email sends platform notifications to Reloop users (invites, password resets). [Mail](/docs/setup/backend/mail) is the customer-facing send API for their audiences.
 </Warning>
 
+
 ## Overview
 
 | Property | Value |
@@ -14964,6 +14996,7 @@ Run [`bun setup`](/docs/setup) once from the monorepo root. Env files come from 
 | **Swagger UI** | [https://local.reloop.sh/api/email/openapi](https://local.reloop.sh/api/email/openapi) |
 | **Stack** | ElysiaJS · Redis · NATS |
 
+
 ## Quick start
 
 ```bash
@@ -14971,6 +15004,7 @@ bun be:email:dev
 ```
 
 Or `bun backend:dev` / `bun dev`. Locally, when `RELOOP_API_KEY` is unset, mail falls back to Mailpit SMTP (`localhost:1025`).
+
 
 ## Environment
 
@@ -14996,6 +15030,7 @@ NODE_ENV=development
 | `RELOOP_SENDER_DOMAIN` | Prod | — | System product mail From domain (auth, billing, invites) |
 | `ONBOARDING_TEST_DOMAIN` | Prod | — | Onboarding “Send email” From domain only (can differ) |
 
+
 ## Commands
 
 | Command | Description |
@@ -15005,6 +15040,7 @@ NODE_ENV=development
 | `bun run --filter=be-email start` | Run compiled production build |
 | `bun run --filter=be-email check-types` | TypeScript type-check |
 
+
 ## Architecture
 
 | Layer | Detail |
@@ -15012,6 +15048,7 @@ NODE_ENV=development
 | **Triggers** | Subscribes to NATS subjects (`auth.*`, `billing.*`, etc.) |
 | **Delivery** | Sends via the [mail](/docs/setup/backend/mail) pipeline using `RELOOP_API_KEY` when set |
 | **Schema** | `email_log` in `packages/db/src/schema/email.ts` |
+
 
 ## Next
 
@@ -15043,6 +15080,7 @@ Inbound KumoMTA MX receiver — accepts external mail, scans with [spam](/docs/s
 Run [`bun setup`](/docs/setup) or `bun docker:up` from the monorepo root. Inbound needs free port `25`.
 </Tip>
 
+
 ## Overview
 
 | Property | Value |
@@ -15053,6 +15091,7 @@ Run [`bun setup`](/docs/setup) or `bun docker:up` from the monorepo root. Inboun
 | **HTTP port** | `8030` (health check) |
 | **Stack** | KumoMTA · Lua · [spam](/docs/setup/backend/spam) |
 
+
 ## Quick start
 
 ```bash
@@ -15060,6 +15099,7 @@ bun docker:up
 ```
 
 Health check: [http://localhost:8030/health](http://localhost:8030/health).
+
 
 ## Configuration
 
@@ -15072,6 +15112,7 @@ Key variables in `local/docker-compose.yml`:
 | `KUMOMTA_RSPAMD_URL` | `http://reloop-spam:11333/checkv2` |
 | `KUMOMTA_CHECK_RECIPIENT_URL` | `http://host.docker.internal:8011/api/domain` |
 
+
 ## Commands
 
 | Command | Description |
@@ -15080,6 +15121,7 @@ Key variables in `local/docker-compose.yml`:
 | `docker compose -f local/docker-compose.yml up -d inbound` | Start inbound only |
 | `docker logs -f reloop-inbound` | Stream logs |
 | `curl http://localhost:8030/health` | Health check |
+
 
 ## Architecture
 
@@ -15095,6 +15137,7 @@ External Sender → Port 25 → Recipient Check → Spam (Rspamd) → NATS → I
 | **Spam scan** | [spam](/docs/setup/backend/spam) backend scores mail via `/checkv2` |
 | **Forwarding** | Accepted messages published to NATS for inbox, then assigned to the `null` queue |
 | **Receive-only** | No SMTP AUTH, no HTTP inject, no outbound delivery — submission is [smtp](/docs/setup/backend/smtp) only |
+
 
 ## Next
 
@@ -15129,6 +15172,7 @@ Agent Inbox API — mailboxes, threads, and messages from inbound email via NATS
 Run [`bun setup`](/docs/setup) once from the monorepo root. That starts Docker including [inbound](/docs/setup/backend/inbound) for live MX on port `25`.
 </Tip>
 
+
 ## Overview
 
 | Property | Value |
@@ -15139,6 +15183,7 @@ Run [`bun setup`](/docs/setup) once from the monorepo root. That starts Docker i
 | **Swagger UI** | [https://local.reloop.sh/api/inbox/openapi](https://local.reloop.sh/api/inbox/openapi) |
 | **Stack** | ElysiaJS · PostgreSQL · Redis · NATS |
 
+
 ## Quick start
 
 ```bash
@@ -15146,6 +15191,7 @@ bun be:inbox:dev
 ```
 
 Or `bun backend:dev` / `bun dev`.
+
 
 ## Environment
 
@@ -15167,6 +15213,7 @@ NODE_ENV=development
 | `PORT` | **YES** | `8021` |
 | `NATS_URL` | **YES** | `nats://localhost:4222` |
 
+
 ## Commands
 
 | Command | Description |
@@ -15176,6 +15223,7 @@ NODE_ENV=development
 | `bun run --filter=be-inbox start` | Run compiled production build |
 | `bun run --filter=be-inbox check-types` | TypeScript type-check |
 
+
 ## Architecture
 
 | Layer | Detail |
@@ -15183,6 +15231,7 @@ NODE_ENV=development
 | **Inbound flow** | [inbound](/docs/setup/backend/inbound) MTA → NATS → inbox persistence |
 | **Attachments** | File storage via [upload](/docs/setup/backend/upload) (no direct S3 config on inbox) |
 | **Dashboard API** | Mailboxes, threads, and messages at `/api/inbox` |
+
 
 ## Next
 
@@ -15214,6 +15263,7 @@ Event logging and analytics — activity logs and email delivery data in Postgre
 Run [`bun setup`](/docs/setup) once so Postgres is up (`bun docker:up`). Env files come from `bun setup` / `bun env:setup`.
 </Tip>
 
+
 ## Overview
 
 | Property | Value |
@@ -15224,6 +15274,7 @@ Run [`bun setup`](/docs/setup) once so Postgres is up (`bun docker:up`). Env fil
 | **Swagger UI** | [https://local.reloop.sh/api/logs/openapi](https://local.reloop.sh/api/logs/openapi) |
 | **Stack** | ElysiaJS · PostgreSQL · Redis · NATS |
 
+
 ## Quick start
 
 ```bash
@@ -15231,6 +15282,7 @@ bun run --filter=be-logs dev
 ```
 
 Or `bun backend:dev` / `bun dev`.
+
 
 ## Environment
 
@@ -15252,6 +15304,7 @@ NODE_ENV=development
 | `PORT` | **YES** | `8016` |
 | `NATS_URL` | **YES** | `nats://localhost:4222` |
 
+
 ## Commands
 
 | Command | Description |
@@ -15261,6 +15314,7 @@ NODE_ENV=development
 | `bun run --filter=be-logs start` | Run compiled production build |
 | `bun run --filter=be-logs check-types` | TypeScript type-check |
 
+
 ## Architecture
 
 | Layer | Detail |
@@ -15269,6 +15323,7 @@ NODE_ENV=development
 | **Storage** | Writes activity logs to Postgres `activity_log`; email delivery to `email_log` |
 | **Query API** | Powers dashboard activity logs and email delivery analytics |
 | **Schema** | Defined in `packages/db/src/schema/activity-log.ts` |
+
 
 ## Next
 
@@ -15300,6 +15355,7 @@ Outbound transactional email API — send requests, template compilation, tracki
 Run [`bun setup`](/docs/setup) once from the monorepo root. That starts Docker including [SMTP](/docs/setup/backend/smtp). Mailpit captures local outbound mail at [http://localhost:8025](http://localhost:8025).
 </Tip>
 
+
 ## Overview
 
 | Property | Value |
@@ -15310,6 +15366,7 @@ Run [`bun setup`](/docs/setup) once from the monorepo root. That starts Docker i
 | **Swagger UI** | [https://local.reloop.sh/api/mail/openapi](https://local.reloop.sh/api/mail/openapi) |
 | **Stack** | ElysiaJS · PostgreSQL · Redis · NATS · BullMQ |
 
+
 ## Quick start
 
 ```bash
@@ -15317,6 +15374,7 @@ bun be:mail:dev
 ```
 
 Or `bun backend:dev` / `bun dev`.
+
 
 ## Environment
 
@@ -15342,6 +15400,7 @@ NODE_ENV=development
 | `TRACKING_SECRET` | No | Signs tracked link and open-pixel tokens |
 | `NATS_URL` | **YES** | `nats://localhost:4222` |
 
+
 ## Commands
 
 | Command | Description |
@@ -15351,6 +15410,7 @@ NODE_ENV=development
 | `bun run --filter=be-mail start` | Run compiled production build |
 | `bun run --filter=be-mail check-types` | TypeScript type-check |
 
+
 ## Architecture
 
 | Layer | Detail |
@@ -15359,6 +15419,7 @@ NODE_ENV=development
 | **Queues** | BullMQ workers dispatch via Redis (`mail-queue`, `mail-retry-queue`) |
 | **MTA handoff** | Delivers to the [SMTP](/docs/setup/backend/smtp) engine on port `8020` |
 | **Schema** | `email_log` in `packages/db/src/schema/email.ts` |
+
 
 ## Next
 
@@ -15390,6 +15451,7 @@ Outbound KumoMTA engine — accepts mail from [mail](/docs/setup/backend/mail) a
 Run [`bun setup`](/docs/setup) or `bun docker:up` from the monorepo root. SMTP needs free ports `465` / `587`.
 </Tip>
 
+
 ## Overview
 
 | Property | Value |
@@ -15400,6 +15462,7 @@ Run [`bun setup`](/docs/setup) or `bun docker:up` from the monorepo root. SMTP n
 | **HTTP port** | `8020` |
 | **Stack** | KumoMTA · Lua |
 
+
 ## Quick start
 
 ```bash
@@ -15407,6 +15470,7 @@ bun docker:up
 ```
 
 View captured mail at [http://localhost:8025](http://localhost:8025) (Mailpit).
+
 
 ## Configuration
 
@@ -15417,6 +15481,7 @@ Key variables in `local/docker-compose.yml`:
 | `BASE_URL` | `https://local.reloop.sh` |
 | `NATS_URL` | `reloop-nats:4222` |
 
+
 ## Commands
 
 | Command | Description |
@@ -15426,6 +15491,7 @@ Key variables in `local/docker-compose.yml`:
 | `docker logs -f reloop-smtp` | Stream logs |
 | `docker compose -f local/docker-compose.yml stop smtp` | Stop container |
 
+
 ## Architecture
 
 | Layer | Detail |
@@ -15434,6 +15500,7 @@ Key variables in `local/docker-compose.yml`:
 | **Policies** | Lua scripts in `apps/backend/smtp/policy/` handle routing and DKIM |
 | **Local delivery** | Captured by Mailpit at [http://localhost:8025](http://localhost:8025) |
 | **Inbound** | Port `25` MX is handled by [inbound](/docs/setup/backend/inbound), not this service |
+
 
 ## Next
 
@@ -15465,6 +15532,7 @@ Rspamd spam scanner — scores inbound mail for the [inbound](/docs/setup/backen
 Run [`bun setup`](/docs/setup) or `bun docker:up` from the monorepo root. Spam starts with the Compose stack because inbound depends on it.
 </Tip>
 
+
 ## Overview
 
 | Property | Value |
@@ -15474,6 +15542,7 @@ Run [`bun setup`](/docs/setup) or `bun docker:up` from the monorepo root. Spam s
 | **Scan ports** | `11332`, `11333` |
 | **Web UI** | `11334` |
 | **Stack** | Rspamd · Redis |
+
 
 ## Quick start
 
@@ -15488,6 +15557,7 @@ docker compose -f local/docker-compose.yml up -d --build reloop-spam
 ```
 
 Controller / scan endpoint: [http://localhost:11333](http://localhost:11333).
+
 
 ## Configuration
 
@@ -15506,6 +15576,7 @@ Inbound wires to this service with:
 | :--- | :--- |
 | `KUMOMTA_RSPAMD_URL` | `http://reloop-spam:11333/checkv2` |
 
+
 ## Commands
 
 | Command | Description |
@@ -15514,6 +15585,7 @@ Inbound wires to this service with:
 | `docker compose -f local/docker-compose.yml up -d --build reloop-spam` | Rebuild and start spam only |
 | `docker logs -f reloop-spam` | Stream logs |
 | `docker compose -f local/docker-compose.yml stop reloop-spam` | Stop container |
+
 
 ## Architecture
 
@@ -15527,6 +15599,7 @@ Inbound (KumoMTA) → HTTP POST /checkv2 → Spam (Rspamd) → score / action / 
 | **Headers** | Inbound injects `X-Spam-*` from the response for [inbox](/docs/setup/backend/inbox) |
 | **State** | Uses [Redis](/docs/setup) (`reloop-redis`) for learning / fuzzy storage |
 | **Separate deploy** | Not baked into the inbound image — own Dockerfile and CI (`be-spam`) |
+
 
 ## Next
 
@@ -15558,6 +15631,7 @@ Email template CRUD, visual builder storage, and HTML compilation for outbound s
 Run [`bun setup`](/docs/setup) once from the monorepo root. Env files come from `bun setup` / `bun env:setup`.
 </Tip>
 
+
 ## Overview
 
 | Property | Value |
@@ -15568,6 +15642,7 @@ Run [`bun setup`](/docs/setup) once from the monorepo root. Env files come from 
 | **Swagger UI** | [https://local.reloop.sh/api/template/openapi](https://local.reloop.sh/api/template/openapi) |
 | **Stack** | ElysiaJS · PostgreSQL · Redis · NATS |
 
+
 ## Quick start
 
 ```bash
@@ -15575,6 +15650,7 @@ bun be:template:dev
 ```
 
 Or `bun backend:dev` / `bun dev`.
+
 
 ## Environment
 
@@ -15597,6 +15673,7 @@ NODE_ENV=development
 | `BASE_URL` | **YES** | `https://local.reloop.sh` |
 | `NATS_URL` | **YES** | `nats://localhost:4222` |
 
+
 ## Commands
 
 | Command | Description |
@@ -15606,6 +15683,7 @@ NODE_ENV=development
 | `bun run --filter=be-template start` | Run compiled production build |
 | `bun run --filter=be-template check-types` | TypeScript type-check |
 
+
 ## Architecture
 
 | Layer | Detail |
@@ -15613,6 +15691,7 @@ NODE_ENV=development
 | **Builder** | Stores drag-and-drop block JSON from the dashboard editor |
 | **Compilation** | Renders HTML with merge tags for the [mail](/docs/setup/backend/mail) service |
 | **Schema** | `template` and revisions in `packages/db/src/schema/template.ts` |
+
 
 ## Next
 
@@ -15644,6 +15723,7 @@ File uploads — logos, attachments, and assets stored in MinIO/S3.
 Run [`bun setup`](/docs/setup) once so MinIO is up (`bun docker:up`). Env files come from `bun setup` / `bun env:setup`. Console: [http://localhost:9001](http://localhost:9001) (`reloop` / `reloop123`).
 </Tip>
 
+
 ## Overview
 
 | Property | Value |
@@ -15654,6 +15734,7 @@ Run [`bun setup`](/docs/setup) once so MinIO is up (`bun docker:up`). Env files 
 | **Swagger UI** | [https://local.reloop.sh/api/upload/openapi](https://local.reloop.sh/api/upload/openapi) |
 | **Stack** | ElysiaJS · PostgreSQL · MinIO/S3 · NATS |
 
+
 ## Quick start
 
 ```bash
@@ -15661,6 +15742,7 @@ bun be:upload:dev
 ```
 
 Or `bun backend:dev` / `bun dev`.
+
 
 ## Environment
 
@@ -15690,6 +15772,7 @@ NODE_ENV=development
 | `S3_BUCKET` | **YES** | `reloop-uploads` |
 | `PORT` | **YES** | `8018` |
 
+
 ## Commands
 
 | Command | Description |
@@ -15699,6 +15782,7 @@ NODE_ENV=development
 | `bun run --filter=be-upload start` | Run compiled production build |
 | `bun run --filter=be-upload check-types` | TypeScript type-check |
 
+
 ## Architecture
 
 | Layer | Detail |
@@ -15706,6 +15790,7 @@ NODE_ENV=development
 | **Storage** | Files uploaded to MinIO locally (`localhost:9010`), S3 in production |
 | **Metadata** | File index stored in Postgres (`upload` table) |
 | **Signed URLs** | Generates presigned upload/download URLs for the dashboard |
+
 
 ## Next
 
@@ -15737,6 +15822,7 @@ Outbound event webhooks — subscription management, HMAC signing, delivery, and
 Run [`bun setup`](/docs/setup) once from the monorepo root. Env files come from `bun setup` / `bun env:setup`.
 </Tip>
 
+
 ## Overview
 
 | Property | Value |
@@ -15747,6 +15833,7 @@ Run [`bun setup`](/docs/setup) once from the monorepo root. Env files come from 
 | **Swagger UI** | [https://local.reloop.sh/api/webhook/openapi](https://local.reloop.sh/api/webhook/openapi) |
 | **Stack** | ElysiaJS · PostgreSQL · Redis · NATS · BullMQ |
 
+
 ## Quick start
 
 ```bash
@@ -15754,6 +15841,7 @@ bun be:webhook:dev
 ```
 
 Or `bun backend:dev` / `bun dev`.
+
 
 ## Environment
 
@@ -15780,6 +15868,7 @@ NODE_ENV=development
 | `BASE_URL` | **YES** | `https://local.reloop.sh` |
 | `NATS_URL` | **YES** | `nats://localhost:4222` |
 
+
 ## Commands
 
 | Command | Description |
@@ -15788,6 +15877,7 @@ NODE_ENV=development
 | `bun run --filter=be-webhook build` | Compile production bundle |
 | `bun run --filter=be-webhook start` | Run compiled production build |
 | `bun run --filter=be-webhook check-types` | TypeScript type-check |
+
 
 ## Architecture
 
@@ -15799,6 +15889,7 @@ NODE_ENV=development
 | **Retries** | Fixed 7-attempt schedule (5s → 5m → 30m → 2h → 5h → 10h) |
 | **Helpers** | `@reloop/webhook-delivery` (envelope, HMAC, SSRF client) |
 | **Schema** | `packages/db/src/schema/webhook.ts` |
+
 
 ## Next
 
@@ -15830,6 +15921,7 @@ Marketing automation — drip campaigns, delays, and multi-step journeys via Bul
 Run [`bun setup`](/docs/setup) once from the monorepo root. Env files come from `bun setup` / `bun env:setup`.
 </Tip>
 
+
 ## Overview
 
 | Property | Value |
@@ -15841,6 +15933,7 @@ Run [`bun setup`](/docs/setup) once from the monorepo root. Env files come from 
 | **Workbench** | [https://local.reloop.sh/api/workflow/jobs](https://local.reloop.sh/api/workflow/jobs) |
 | **Stack** | ElysiaJS · PostgreSQL · Redis · NATS · BullMQ |
 
+
 ## Quick start
 
 ```bash
@@ -15848,6 +15941,7 @@ bun be:workflow:dev
 ```
 
 Or `bun backend:dev` / `bun dev`.
+
 
 ## Environment
 
@@ -15875,6 +15969,7 @@ NODE_ENV=development
 | `WORKBENCH_USER` | No | empty (open in dev) |
 | `WORKBENCH_PASS` | No | empty (open in dev) |
 
+
 ## Commands
 
 | Command | Description |
@@ -15884,6 +15979,7 @@ NODE_ENV=development
 | `bun run --filter=be-workflow start` | Run compiled production build |
 | `bun run --filter=be-workflow check-types` | TypeScript type-check |
 
+
 ## Architecture
 
 | Layer | Detail |
@@ -15892,6 +15988,7 @@ NODE_ENV=development
 | **Execution** | BullMQ `workflow-queue` handles delayed steps and transitions |
 | **Integrations** | Reads contacts/templates and triggers sends via [mail](/docs/setup/backend/mail) |
 | **Monitoring** | [Workbench](https://getworkbench.dev) UI at `/api/workflow/jobs` |
+
 
 ## Next
 
@@ -15923,6 +16020,7 @@ Main workspace app — campaigns, contacts, templates, analytics, and settings.
 Run [`bun setup`](/docs/setup) once from the monorepo root before starting individual apps. The dashboard needs [auth](/docs/setup/backend/auth) (and usually the rest of `bun backend:dev` or `bun dev`).
 </Tip>
 
+
 ## Overview
 
 | Property | Value |
@@ -15932,6 +16030,7 @@ Run [`bun setup`](/docs/setup) once from the monorepo root before starting indiv
 | **Local URL** | [https://local.reloop.sh/dashboard](https://local.reloop.sh/dashboard) |
 | **Direct URL** | [http://localhost:3001/dashboard](http://localhost:3001/dashboard) |
 | **Stack** | TanStack Start · Vite · React 19 · Tailwind CSS |
+
 
 ## Quick start
 
@@ -15952,6 +16051,7 @@ Vite HMR serves the app on port `3001` with base path `/dashboard`.
 <Warning>
 Open [https://local.reloop.sh/dashboard](https://local.reloop.sh/dashboard), not `localhost:3001`, so session cookies work with [auth](/docs/setup/backend/auth). Local OTP is `888888`.
 </Warning>
+
 
 ## Environment
 
@@ -15977,6 +16077,7 @@ Auth (`@reloop/auth/client`) resolves the public origin as: `NEXT_PUBLIC_URL` / 
 | `NEXT_PUBLIC_URL` / `VITE_PUBLIC_URL` | No | Browser origin (`window.location.origin`) |
 | `NEXT_PUBLIC_WS_URL` | No | Current host (template collaboration WebSocket) |
 
+
 ## Commands
 
 | Command | Description |
@@ -15986,6 +16087,7 @@ Auth (`@reloop/auth/client`) resolves the public origin as: `NEXT_PUBLIC_URL` / 
 | `bun run --filter=fe-dashboard preview` | Preview production build |
 | `bun run --filter=fe-dashboard typecheck` | Run TypeScript checks |
 | `bun run --filter=fe-dashboard test` | Run Vitest |
+
 
 ## Next
 
@@ -16017,6 +16119,7 @@ This documentation site — MDX guides, API reference, and local setup docs.
 Run [`bun setup`](/docs/setup) once from the monorepo root before starting individual apps.
 </Tip>
 
+
 ## Overview
 
 | Property | Value |
@@ -16026,6 +16129,7 @@ Run [`bun setup`](/docs/setup) once from the monorepo root before starting indiv
 | **Local URL** | [https://local.reloop.sh/docs](https://local.reloop.sh/docs) |
 | **Direct URL** | [http://localhost:3003](http://localhost:3003) |
 | **Stack** | Next.js · MDX · Tailwind CSS |
+
 
 ## Quick start
 
@@ -16043,6 +16147,7 @@ bun frontend:dev
 
 Turbopack serves the app on port `3003`. Prefer [https://local.reloop.sh/docs](https://local.reloop.sh/docs) when Caddy is running.
 
+
 ## Environment
 
 Committed local defaults live in `apps/frontend/docs/.env` (and `.env.dev`). Fresh clones already have them; `bun env:setup` / `bun setup` recreate or merge missing keys.
@@ -16055,6 +16160,7 @@ NEXT_PUBLIC_URL=https://local.reloop.sh
 | :--- | :--- | :--- |
 | `NEXT_PUBLIC_URL` | No | `https://reloop.sh` — canonical URLs, OG metadata, and public origin |
 
+
 ## Content structure
 
 | Path | Purpose |
@@ -16062,6 +16168,7 @@ NEXT_PUBLIC_URL=https://local.reloop.sh
 | `content/docs/setup/` | Local development setup guides (this section) |
 | `content/docs/api/` | Auto-generated API reference |
 | `content/docs/**/meta.json` | Sidebar navigation and ordering |
+
 
 ## Commands
 
@@ -16071,6 +16178,7 @@ NEXT_PUBLIC_URL=https://local.reloop.sh
 | `bun run --filter=fe-docs build` | Build and validate all MDX pages |
 | `bun run --filter=fe-docs start` | Run production build |
 | `bun run --filter=fe-docs generate:api-docs` | Regenerate API docs from OpenAPI specs |
+
 
 ## Next
 
@@ -16102,6 +16210,7 @@ Contact preference center, tracked link redirects, and open-tracking pixel proxy
 Run [`bun setup`](/docs/setup) once from the monorepo root before starting individual apps. Preferences need [contacts](/docs/setup/backend/contacts) and [mail](/docs/setup/backend/mail) running (`bun dev` or `bun backend:dev`).
 </Tip>
 
+
 ## Overview
 
 | Property | Value |
@@ -16112,6 +16221,7 @@ Run [`bun setup`](/docs/setup) once from the monorepo root before starting indiv
 | **Redirect** | [https://local.reloop.sh/redirect](https://local.reloop.sh/redirect) |
 | **Open tracking** | [https://local.reloop.sh/api/mail/v1/track/open](https://local.reloop.sh/api/mail/v1/track/open) |
 | **Stack** | Next.js · React 19 · Tailwind CSS |
+
 
 ## Quick start
 
@@ -16132,6 +16242,7 @@ Turbopack serves the app on port `3005`. Prefer the `local.reloop.sh` URLs above
 <Warning>
 Use `https://local.reloop.sh/...`, not `localhost:3005`, so redirects and cookies match production-style hosts.
 </Warning>
+
 
 ## Environment
 
@@ -16158,6 +16269,7 @@ Preferences call [contacts](/docs/setup/backend/contacts) via `INTERNAL_API_URL`
 | `INTERNAL_API_URL` | No | `http://localhost:8014/api/contacts` |
 | `INTERNAL_MAIL_API_URL` | No | Falls back to `{NEXT_PUBLIC_URL}/api/mail` |
 
+
 ## Routes
 
 | Route | Purpose |
@@ -16165,6 +16277,7 @@ Preferences call [contacts](/docs/setup/backend/contacts) via `INTERNAL_API_URL`
 | `/preferences/[token]` | Manage subscription topics and unsubscribe |
 | `/redirect/[token]` | Track clicks and redirect to destination URL |
 | `/api/mail/v1/track/open/[token]` | Proxy open-tracking pixels to the mail service |
+
 
 ## Architecture
 
@@ -16175,6 +16288,7 @@ Preferences call [contacts](/docs/setup/backend/contacts) via `INTERNAL_API_URL`
 | **Open-tracking proxy** | Custom tracking domains CNAME here; pixels proxy to mail when `/api/mail` is not on the tracking host |
 | **Caddy** | Routes `/preferences*` and `/redirect*` to port `3005` |
 
+
 ## Commands
 
 | Command | Description |
@@ -16183,6 +16297,7 @@ Preferences call [contacts](/docs/setup/backend/contacts) via `INTERNAL_API_URL`
 | `bun run --filter=fe-links build` | Compile production bundle |
 | `bun run --filter=fe-links start` | Run production build |
 | `bun run --filter=fe-links lint` | Run ESLint checks |
+
 
 ## Next
 
@@ -16214,6 +16329,7 @@ Public marketing site — landing pages, pricing, and product content.
 Run [`bun setup`](/docs/setup) once from the monorepo root before starting individual apps.
 </Tip>
 
+
 ## Overview
 
 | Property | Value |
@@ -16223,6 +16339,7 @@ Run [`bun setup`](/docs/setup) once from the monorepo root before starting indiv
 | **Local URL** | [https://local.reloop.sh](https://local.reloop.sh) |
 | **Direct URL** | [http://localhost:3000](http://localhost:3000) |
 | **Stack** | Next.js · React 19 · Tailwind CSS |
+
 
 ## Quick start
 
@@ -16244,6 +16361,7 @@ Turbopack serves the app on port `3000`. Prefer [https://local.reloop.sh](https:
 Use `https://local.reloop.sh`, not `localhost:3000`, when testing flows that share cookies or link into the dashboard.
 </Warning>
 
+
 ## Environment
 
 Committed local defaults live in `apps/frontend/web/.env` (and `.env.dev`). Fresh clones already have them; `bun env:setup` / `bun setup` recreate or merge missing keys.
@@ -16259,6 +16377,7 @@ REDIRECT_SECRET=reloop_tracking_secret_default_123
 | `NEXT_PUBLIC_URL` | No | `https://reloop.sh` — canonical site URL for metadata and OG tags |
 | `REDIRECT_SECRET` | No | Shared redirect/tracking secret for local mail links |
 
+
 ## Commands
 
 | Command | Description |
@@ -16267,6 +16386,7 @@ REDIRECT_SECRET=reloop_tracking_secret_default_123
 | `bun run --filter=fe-web build` | Compile production bundle |
 | `bun run --filter=fe-web start` | Run production build |
 | `bun run --filter=fe-web lint` | Run ESLint checks |
+
 
 ## Next
 
@@ -16288,6 +16408,7 @@ Markdown: https://reloop.sh/docs/setup.md
 
 One command from the monorepo root. Full stack at [https://local.reloop.sh](https://local.reloop.sh).
 
+
 ## Prerequisites
 
 | Tool | Notes |
@@ -16296,6 +16417,7 @@ One command from the monorepo root. Full stack at [https://local.reloop.sh](http
 | [Docker Desktop](https://www.docker.com/products/docker-desktop/) | Postgres, Redis, Caddy, NATS, Mailpit |
 | [mkcert](https://github.com/FiloSottile/mkcert) | Local TLS (`brew install mkcert` on macOS) |
 | Git | Clone the repository |
+
 
 ## Quick start
 
@@ -16318,6 +16440,7 @@ bun dev
 </Tabs>
 
 `bun setup` only pauses for sudo (hosts / mkcert trust) or a missing tool.
+
 
 ## After setup
 
@@ -16343,6 +16466,7 @@ Sign up with any email. Local OTP is always `888888`.
 <Warning>
 Open `https://local.reloop.sh` (not `localhost`) so auth cookies work across services.
 </Warning>
+
 
 ## What `bun setup` does
 
@@ -16370,6 +16494,7 @@ Open `https://local.reloop.sh` (not `localhost`) so auth cookies work across ser
   </Step>
 </Steps>
 
+
 ## Flags
 
 | Flag | Effect |
@@ -16379,6 +16504,7 @@ Open `https://local.reloop.sh` (not `localhost`) so auth cookies work across ser
 | `--skip-docker` | Skip Docker and `db:push` |
 | `--skip-hosts` | Skip the `/etc/hosts` entry |
 | `--skip-tls` | Skip cert generation (existing PEMs required) |
+
 
 ## Manual setup
 
@@ -16460,6 +16586,7 @@ bun backend:dev    # backends only
   </Step>
 </Steps>
 
+
 ## Commands
 
 | Command | Description |
@@ -16475,6 +16602,7 @@ bun backend:dev    # backends only
 | `bun db:push` | Apply Drizzle schema |
 | `bun db:studio` | Open Drizzle Studio |
 | `bun run check` | Lint and format |
+
 
 ## Next
 
@@ -16504,6 +16632,7 @@ Reloop is a Bun monorepo — Next.js frontends, ElysiaJS microservices, shared p
 
 Local URL: [https://local.reloop.sh](https://local.reloop.sh). Bootstrap with [`bun setup`](/docs/setup).
 
+
 ## Structure
 
 ```
@@ -16521,6 +16650,7 @@ reloop/
 | `apps/backend/*` | HTTP APIs and mail edge |
 | `packages/*` | Shared libraries |
 | `local/` | Compose stack, Caddy, [`bun setup`](/docs/setup) |
+
 
 ## Frontend apps
 
@@ -16540,6 +16670,7 @@ reloop/
 </CardGroup>
 
 Stack: [Next.js](https://nextjs.org/), [Tailwind CSS](https://tailwindcss.com/), [Radix UI](https://www.radix-ui.com/) via `@reloop/ui`, [SWR](https://swr.vercel.app/).
+
 
 ## Backend services
 
@@ -16593,6 +16724,7 @@ Stack: [Next.js](https://nextjs.org/), [Tailwind CSS](https://tailwindcss.com/),
 
 Stack: [ElysiaJS](https://elysiajs.com/), [Better Auth](https://www.better-auth.com/), [KumoMTA](https://kumomta.com/) for smtp/inbound.
 
+
 ## Data & infrastructure
 
 Started by `bun docker:up` (Postgres, Redis, Caddy, Mailpit, MinIO, NATS, spam, SMTP, inbound).
@@ -16621,6 +16753,7 @@ Started by `bun docker:up` (Postgres, Redis, Caddy, Mailpit, MinIO, NATS, spam, 
   </Card>
 </CardGroup>
 
+
 ## Tooling
 
 <CardGroup cols={2}>
@@ -16638,6 +16771,7 @@ Started by `bun docker:up` (Postgres, Redis, Caddy, Mailpit, MinIO, NATS, spam, 
   </Card>
 </CardGroup>
 
+
 ## Shared packages
 
 | Package | Purpose |
@@ -16651,6 +16785,7 @@ Started by `bun docker:up` (Postgres, Redis, Caddy, Mailpit, MinIO, NATS, spam, 
 | `@reloop/webhook-events` | Webhook event types |
 | `@reloop/tailwind` | Shared Tailwind config |
 | `@reloop/tsconfig` | Shared TypeScript config |
+
 
 ## Next
 
@@ -16688,6 +16823,7 @@ Stop anything already bound before `bun docker:up`.
 Free mail ports (`25`, `465`, `587`) if host mail or another MTA is already bound there.
 </Tip>
 
+
 ## Unified Gateway
 
 | Route | Service | Port |
@@ -16712,6 +16848,7 @@ Free mail ports (`25`, `465`, `587`) if host mail or another MTA is already boun
 | [https://local.reloop.sh/api/credits](https://local.reloop.sh/api/credits) | [Credits](/docs/setup/backend/credits) | `8023` |
 | [https://local.reloop.sh/api/admin](https://local.reloop.sh/api/admin) | Admin | `8024` |
 
+
 ## Frontend
 
 | App | Direct URL | Port |
@@ -16721,6 +16858,7 @@ Free mail ports (`25`, `465`, `587`) if host mail or another MTA is already boun
 | Console | [http://localhost:3002](http://localhost:3002) | `3002` |
 | [Docs](/docs/setup/frontend/docs) | [http://localhost:3003](http://localhost:3003) | `3003` |
 | [Links](/docs/setup/frontend/links) | [http://localhost:3005](http://localhost:3005) | `3005` |
+
 
 ## Backend APIs
 
@@ -16741,6 +16879,7 @@ Free mail ports (`25`, `465`, `587`) if host mail or another MTA is already boun
 | [Credits](/docs/setup/backend/credits) | [`/api/credits`](https://local.reloop.sh/api/credits) | `8023` |
 | Admin | [`/api/admin`](https://local.reloop.sh/api/admin) | `8024` |
 
+
 ## Docker & Mail
 
 | Service | Port | Notes |
@@ -16749,6 +16888,7 @@ Free mail ports (`25`, `465`, `587`) if host mail or another MTA is already boun
 | Mailpit | `8025` | [http://localhost:8025](http://localhost:8025) — captured outbound mail |
 | [SMTP](/docs/setup/backend/smtp) (outbound) | `465`, `587`, `2025`, `2465`, `2587`, `8020` | KumoMTA |
 | [Inbound](/docs/setup/backend/inbound) (MX) | `25`, `8030` | KumoMTA |
+
 
 ## Infrastructure
 

--- a/apps/frontend/web/public/llms-full.txt
+++ b/apps/frontend/web/public/llms-full.txt
@@ -6,7 +6,7 @@
 > Docs index: https://reloop.sh/llms-docs.txt
 > Product skill: https://reloop.sh/skill.md
 
-Generated from 10 pages.
+Generated from 18 pages.
 
 ---
 
@@ -95,7 +95,7 @@ Markdown: https://reloop.sh/pricing.md
 
 ## Self-host
 
-Self-hosting the open-source Reloop stack is free (infrastructure costs are yours).
+Self-hosting the open-source Reloop stack has no Reloop license fee (infrastructure costs are yours). It is not a Reloop Cloud subscription and does not use the hosted Free / Individual / Startup / Enterprise price list.
 See https://reloop.sh/self-host
 
 ## Related
@@ -103,6 +103,507 @@ See https://reloop.sh/self-host
 - Signup: https://reloop.sh/dashboard/signup
 - Docs index: https://reloop.sh/llms-docs.txt
 - Contact sales: https://reloop.sh/contact
+
+
+---
+
+# Reloop vs the competition
+
+Path: /compare
+URL: https://reloop.sh/compare
+Markdown: https://reloop.sh/compare.md
+
+# Reloop vs the competition
+
+> Compare Reloop with Resend, SendGrid, Mailgun, AWS SES, Postmark, Loops, and Mailchimp.
+
+HTML: https://reloop.sh/compare
+Canonical pricing: https://reloop.sh/pricing.md
+
+Reloop is open-source email infrastructure (Apache 2.0): transactional API, SMTP, campaigns, webhooks, and an agent inbox. Hosted Reloop Cloud plans are Free (3,000 emails/month, 200/day), Individual $10/month (25,000), Startup $20/month (50,000), Enterprise custom. Self-host has no Reloop license fee.
+
+## Comparisons
+
+- [Reloop vs Resend](https://reloop.sh/compare/resend) — [markdown](https://reloop.sh/compare/resend.md)
+- [Reloop vs SendGrid](https://reloop.sh/compare/sendgrid) — [markdown](https://reloop.sh/compare/sendgrid.md)
+- [Reloop vs Mailgun](https://reloop.sh/compare/mailgun) — [markdown](https://reloop.sh/compare/mailgun.md)
+- [Reloop vs AWS SES](https://reloop.sh/compare/aws-ses) — [markdown](https://reloop.sh/compare/aws-ses.md)
+- [Reloop vs Postmark](https://reloop.sh/compare/postmark) — [markdown](https://reloop.sh/compare/postmark.md)
+- [Reloop vs Loops](https://reloop.sh/compare/loops) — [markdown](https://reloop.sh/compare/loops.md)
+- [Reloop vs Mailchimp](https://reloop.sh/compare/mailchimp) — [markdown](https://reloop.sh/compare/mailchimp.md)
+
+## Hosted pricing (source of truth)
+
+### What counts as an email?
+
+Each successfully sent email counts toward your monthly quota—transactional messages, campaign sends, and SMTP relay deliveries all use credits the same way.
+
+### Do I need a credit card to start?
+
+No. The Free plan includes 3,000 emails per month and 200 emails per day, with no credit card required. Upgrade when your volume grows.
+
+
+---
+
+# Reloop vs Resend
+
+Path: /compare/resend
+URL: https://reloop.sh/compare/resend
+Markdown: https://reloop.sh/compare/resend.md
+
+# Reloop vs Resend
+
+> Learn how Reloop compares to Resend and why Reloop is an open-source alternative for developer email.
+
+HTML: https://reloop.sh/compare/resend
+Markdown: https://reloop.sh/compare/resend.md
+Canonical pricing: https://reloop.sh/pricing.md
+
+Reloop is email infrastructure you can host or self-host (Apache 2.0, KumoMTA). Resend is a hosted DX layer over Amazon SES. Reloop Free is 3,000 emails/month with a 200/day cap; Individual is $10/month for 25,000 emails with no daily cap. Reloop is not a drop-in Resend proxy.
+
+Reloop is the email service / infrastructure (ESP + MTA). It is not a multi-ESP connector that sits on SendGrid, Mailgun, Resend, or SES.
+
+## Pricing & Email Volume
+
+Reloop Cloud Free is 3,000 emails/month with a 200/day cap. Individual is $10/mo for 25,000 emails with no daily cap. Overage is $0.80 vs Resend's $1.00 per 1,000. Self-hosting Reloop has no Reloop license fee (you pay your own infra).
+
+| Feature | Reloop | Resend |
+| --- | --- | --- |
+| Free monthly emails | 3,000 / mo | 3,000 / mo |
+| Daily send limit (Free tier) | 200 / day (Free also caps at 3,000 / month) | 100 / day (Free tier limited to 100 sends/day) |
+| Entry paid plan | $10 / mo (25,000 emails included) | $20 / mo (50,000 emails included (no $10 tier)) |
+| 50,000 emails / mo plan | $20 / mo | $20 / mo |
+| Overage rate (per 1k emails) | $0.80 / 1k | $1.00 / 1k |
+| Self-hosted email sends | Unlimited (Free open-source software (own infra)) | N/A (Hosted SaaS only; pay per send) |
+
+## Sending & Receiving
+
+Both products support sending and receiving email. Reloop runs its own MTA/MX stack (KumoMTA, Rspamd, two-way agent inbox) and is fully self-hostable, whereas Resend is a hosted DX layer over Amazon SES with webhook-oriented inbound.
+
+| Feature | Reloop | Resend |
+| --- | --- | --- |
+| Agent inbox | Yes | No |
+| Inbox for humans | Yes | No |
+| AI composer | Yes | No |
+| Inbound spam scoring | Yes | — |
+| REST API | Yes | Yes |
+| SMTP relay | Yes | Yes |
+| Official SDKs | Yes | Yes |
+| React Email / HTML templates | Yes | Yes |
+| Batch / broadcast sending | Yes | Yes |
+| Scheduled delivery | Yes | Yes |
+| A/B testing | No | No |
+| MTA | Yes | No |
+| Self-hostable | Yes | No |
+| Open-source | Yes | No |
+| Shared IPs | Yes | Yes |
+| Dedicated IPs | Enterprise | Scale+ |
+
+## Data & analytics
+
+Core delivery telemetry overlaps. We only mark features Reloop implements in product today—no geolocation or client fingerprinting claims.
+
+| Feature | Reloop | Resend |
+| --- | --- | --- |
+| Delivery events | Yes | Yes |
+| Bounce handling | Yes | Yes |
+| Complaint / spam events | Yes | Yes |
+| Open tracking | Yes | Yes |
+| Click tracking | Yes | Yes |
+| Unsubscribe events | Yes | Yes |
+| Dashboard activity / logs | Yes | Yes |
+| Geolocation on opens | No | No |
+| Email client analytics | No | No |
+
+## Reliability
+
+This section is about control plane ownership—not a promise that Reloop is faster or more available than Resend. We do not publish third-party latency benchmarks here.
+
+| Feature | Reloop | Resend |
+| --- | --- | --- |
+| Direct MTA delivery (no SES hop) | Yes | No (Resend’s public sending path goes through Amazon SES) |
+| Public status page | Yes (status.reloop.sh) | Yes |
+| Self-host = your uptime domain | Yes (You operate the stack and SLOs) | No |
+
+## Security
+
+| Feature | Reloop | Resend |
+| --- | --- | --- |
+| SPF | Yes | Yes |
+| DKIM | Yes | Yes |
+| DMARC guidance / records | Yes | Yes |
+| TLS options | Yes (Domain TLS: opportunistic or enforced) | Yes |
+| Webhook signature verification | Yes (HMAC-SHA256 (X-Webhook-Signature)) | Yes (Svix-style signing headers) |
+| Account auth | Email OTP + OAuth (Google / GitHub) | Yes |
+
+## Platform
+
+| Feature | Reloop | Resend |
+| --- | --- | --- |
+| Hosted SaaS | Yes | Yes |
+| Contacts / audiences | Yes (Contacts, groups, channels) | Yes (Audiences on Resend) |
+| Webhook management API | Yes | Yes |
+| Agent / AI inbox product | Yes | No |
+| Vendor lock-in risk | Lower (Source + self-host path; still evaluate license terms) | Higher (Hosted-only proprietary stack) |
+
+## FAQ
+
+### Does Reloop Free have a daily send limit?
+
+Yes. Reloop Free includes 3,000 emails per month and 200 emails per day. Individual ($10/mo), Startup ($20/mo), and Enterprise have no daily cap. Self-hosted Reloop is limited by your own infrastructure, not Reloop Cloud quotas.
+
+### Is Reloop a drop-in Resend API?
+
+No. Reloop is not a Resend proxy. Plan a small client adapter when migrating. Auth uses the x-api-key header with rl_ keys.
+
+### Is Reloop open source?
+
+Yes. Reloop is Apache 2.0 with Reloop Labs use restrictions. Self-host at no Reloop license fee, or use Reloop Cloud.
+
+## Related
+
+- Pricing: https://reloop.sh/pricing.md
+- Compare index: https://reloop.sh/compare.md
+- License (Apache 2.0): https://reloop.sh/license
+
+
+---
+
+# Reloop vs SendGrid
+
+Path: /compare/sendgrid
+URL: https://reloop.sh/compare/sendgrid
+Markdown: https://reloop.sh/compare/sendgrid.md
+
+# Reloop vs SendGrid
+
+> Learn how Reloop compares to SendGrid for transactional and marketing email.
+
+HTML: https://reloop.sh/compare/sendgrid
+Markdown: https://reloop.sh/compare/sendgrid.md
+Canonical pricing: https://reloop.sh/pricing.md
+
+SendGrid bundles transactional APIs, marketing campaigns, and deliverability tooling—often with annual commits. Reloop is API-first, Apache 2.0, and self-hostable, with campaigns and transactional sends in one codebase. Reloop Cloud Free is 3,000 emails/month (200/day).
+
+Reloop is the email service / infrastructure (ESP + MTA). It is not a multi-ESP connector that sits on SendGrid, Mailgun, Resend, or SES.
+
+## Reloop vs SendGrid
+
+| Feature | Reloop | SendGrid |
+| --- | --- | --- |
+| Open-source codebase | Yes (Apache 2.0) | No |
+| Self-hostable | Yes | No |
+| Transactional API | Yes | Yes |
+| Marketing campaigns | Yes | Yes |
+| Template editor | Yes | Yes |
+| SMTP relay | Yes | Yes |
+| Webhooks | Yes | Yes |
+| Agent inbox | Built-in | Not included |
+| Contract flexibility | Monthly tiers + self-host | Often annual enterprise |
+
+## FAQ
+
+### Can Reloop handle SendGrid-scale volume?
+
+Hosted Individual ($10/mo, 25,000 emails), Startup ($20/mo, 50,000 emails), and Enterprise target growing throughput; overage is $0.80 per 1,000. Self-hosted Reloop scales with your Kubernetes or bare-metal footprint.
+
+### What about dedicated IPs?
+
+Dedicated IPs are optional/custom on Reloop Enterprise. Self-hosted deployments can attach your own IPs directly to your MTA layer.
+
+## Related
+
+- Pricing: https://reloop.sh/pricing.md
+- Compare index: https://reloop.sh/compare.md
+- License (Apache 2.0): https://reloop.sh/license
+
+
+---
+
+# Reloop vs Mailgun
+
+Path: /compare/mailgun
+URL: https://reloop.sh/compare/mailgun
+Markdown: https://reloop.sh/compare/mailgun.md
+
+# Reloop vs Mailgun
+
+> Learn how Reloop compares to Mailgun for developer email APIs and SMTP.
+
+HTML: https://reloop.sh/compare/mailgun
+Markdown: https://reloop.sh/compare/mailgun.md
+Canonical pricing: https://reloop.sh/pricing.md
+
+Reloop offers REST + SMTP, inbound agent inbox, and Apache 2.0 self-host. Mailgun is hosted SaaS with inbound routes. Reloop Free is 3,000 emails/month (200/day).
+
+Reloop is the email service / infrastructure (ESP + MTA). It is not a multi-ESP connector that sits on SendGrid, Mailgun, Resend, or SES.
+
+## Reloop vs Mailgun
+
+| Feature | Reloop | Mailgun |
+| --- | --- | --- |
+| Open-source codebase | Yes (Apache 2.0) | No |
+| Self-hostable | Yes | No |
+| REST API | Yes | Yes |
+| SMTP relay | Yes | Yes |
+| Inbound / reply handling | Agent inbox | Inbound routes |
+| Email validation API | Yes | Yes |
+| Marketing campaigns | Yes | Limited |
+| Agent / AI workflows | Yes | No |
+| Free tier | 3,000 emails / month · 200 / day | Trial-based |
+
+## FAQ
+
+### Can Reloop replace Mailgun inbound routes?
+
+Reloop's agent inbox and webhook model cover reply handling and automated triage. Map your existing inbound URLs to Reloop handlers during migration.
+
+### Do we lose deliverability moving off Mailgun?
+
+Deliverability depends on domain reputation, content, and IPs—not the dashboard brand. Self-hosted Reloop lets you own IPs directly; hosted Reloop manages shared pools like other providers.
+
+## Related
+
+- Pricing: https://reloop.sh/pricing.md
+- Compare index: https://reloop.sh/compare.md
+- License (Apache 2.0): https://reloop.sh/license
+
+
+---
+
+# Reloop vs AWS SES
+
+Path: /compare/aws-ses
+URL: https://reloop.sh/compare/aws-ses
+Markdown: https://reloop.sh/compare/aws-ses.md
+
+# Reloop vs AWS SES
+
+> Learn how Reloop compares to Amazon SES as an email platform, not just an SMTP pipe.
+
+HTML: https://reloop.sh/compare/aws-ses
+Markdown: https://reloop.sh/compare/aws-ses.md
+Canonical pricing: https://reloop.sh/pricing.md
+
+SES is raw sending infrastructure. Reloop is a full email platform (API, campaigns, dashboard, agent inbox) that you can host or self-host. SES is often cheaper at extreme volume; Reloop competes on platform TCO, not on being the cheapest SMTP pipe.
+
+Reloop is the email service / infrastructure (ESP + MTA). It is not a multi-ESP connector that sits on SendGrid, Mailgun, Resend, or SES.
+
+## Reloop vs AWS SES
+
+| Feature | Reloop | AWS SES |
+| --- | --- | --- |
+| Open-source platform | Yes (Apache 2.0) | No |
+| Self-host on your AWS account | Yes | SES only |
+| Marketing campaigns UI | Yes | No (DIY) |
+| Transactional API | Yes | Yes |
+| Built-in delivery dashboard | Yes | CloudWatch / DIY |
+| Webhooks | Native | SNS configuration |
+| Template management | Yes | Limited |
+| Agent inbox | Yes | No |
+| Per-email list price | Tier bundles | Very low at scale |
+
+## FAQ
+
+### Is Reloop cheaper than SES at 10M emails/month?
+
+SES raw sending is often cheaper at extreme volume. Reloop competes on platform TCO—engineering time, campaign tooling, support, and unified ops—not on being the cheapest SMTP pipe.
+
+### Can we migrate boto3 sends to Reloop?
+
+Yes. Replace AWS SDK send calls with Reloop REST or SMTP. Map SNS bounce notifications to Reloop webhook endpoints.
+
+### Do we need both SES and Reloop?
+
+Not usually. Self-hosted Reloop includes outbound delivery. Some teams keep SES as an MTA backend during transition—that is an advanced integration, not the default path.
+
+## Related
+
+- Pricing: https://reloop.sh/pricing.md
+- Compare index: https://reloop.sh/compare.md
+- License (Apache 2.0): https://reloop.sh/license
+
+
+---
+
+# Reloop vs Postmark
+
+Path: /compare/postmark
+URL: https://reloop.sh/compare/postmark
+Markdown: https://reloop.sh/compare/postmark.md
+
+# Reloop vs Postmark
+
+> Learn how Reloop compares to Postmark for transactional email.
+
+HTML: https://reloop.sh/compare/postmark
+Markdown: https://reloop.sh/compare/postmark.md
+Canonical pricing: https://reloop.sh/pricing.md
+
+Postmark focuses on transactional delivery with streams. Reloop unifies transactional API sends and campaigns, is Apache 2.0 / self-hostable, and offers an agent inbox. Reloop Free is 3,000 emails/month (200/day).
+
+Reloop is the email service / infrastructure (ESP + MTA). It is not a multi-ESP connector that sits on SendGrid, Mailgun, Resend, or SES.
+
+## Reloop vs Postmark
+
+| Feature | Reloop | Postmark |
+| --- | --- | --- |
+| Open-source codebase | Yes (Apache 2.0) | No |
+| Self-hostable | Yes | No |
+| Transactional API | Yes | Yes |
+| Delivery analytics | Yes | Yes (detailed) |
+| Marketing campaigns | Yes | Limited |
+| SMTP relay | Yes | Yes |
+| Message streams / separation | Domain + campaign types | Streams |
+| Agent inbox | Yes | No |
+| Free tier | 3,000 emails / month · 200 / day | Trial credits |
+
+## FAQ
+
+### Does Reloop match Postmark latency?
+
+Hosted Reloop targets production-grade transactional latency. Self-hosted performance depends on your network and MTA setup—same as any self-managed stack.
+
+### Should we use both for streams?
+
+Reloop can separate transactional API sends from campaign traffic without two vendors. Most Postmark stream use cases map to Reloop domains plus campaign modules.
+
+## Related
+
+- Pricing: https://reloop.sh/pricing.md
+- Compare index: https://reloop.sh/compare.md
+- License (Apache 2.0): https://reloop.sh/license
+
+
+---
+
+# Reloop vs Loops
+
+Path: /compare/loops
+URL: https://reloop.sh/compare/loops
+Markdown: https://reloop.sh/compare/loops.md
+
+# Reloop vs Loops
+
+> Compare Reloop to Loops: send-based pricing vs contact-list pricing, plus transactional API and self-host.
+
+HTML: https://reloop.sh/compare/loops
+Markdown: https://reloop.sh/compare/loops.md
+Canonical pricing: https://reloop.sh/pricing.md
+
+Loops prices by contact list size. Reloop prices by emails sent. Reloop Free is 3,000 emails/month (200/day); Individual is $10/month for 25,000 emails; Startup is $20/month for 50,000 emails. Reloop is the ESP/MTA, not a lifecycle UI on top of another sender.
+
+Reloop is the email service / infrastructure (ESP + MTA). It is not a multi-ESP connector that sits on SendGrid, Mailgun, Resend, or SES.
+
+## Pricing & Economic Model
+
+Loops charges based on your contact list size—penalizing list growth even for inactive subscribers. Reloop charges purely for emails sent (or $0 when self-hosted), ensuring your bill scales with activity, not database size.
+
+| Feature | Reloop | Loops |
+| --- | --- | --- |
+| Pricing basis | Emails sent (Pay for actual volume used) | Contact list size (Bill increases as list grows) |
+| Free monthly tier | 3,000 emails / mo (200 / day cap) | 1,000 contacts |
+| Entry paid plan | $10 / mo (25,000 emails included) | $49 / mo (10k contacts) |
+| 50,000 volume plan | $20 / mo | $199 / mo (50k contacts) |
+| Self-hosted email sends | Unlimited ($0) (Free open-source engine (own infra)) | N/A (Closed SaaS only) |
+
+## Unified Infrastructure & Sending
+
+Loops is designed for product onboarding loops, forcing teams to buy a separate vendor (Resend or Postmark) for transactional emails. Reloop handles transactional API sends, marketing broadcasts, and AI agent inboxes under one unified platform.
+
+| Feature | Reloop | Loops |
+| --- | --- | --- |
+| Transactional REST API | Yes | Limited (Basic event triggers only) |
+| SMTP relay | Yes | No (No raw SMTP interface) |
+| Lifecycle & onboarding campaigns | Yes | Yes (Core focus) |
+| Broadcast / marketing newsletters | Yes | Yes |
+| Agent / AI inbound inbox | Yes | No |
+| React Email / HTML templates | Yes | HTML / Visual editor |
+| Open-source MTA engine | Yes (KumoMTA) | No (Proprietary) |
+| Self-hostable | Yes | No |
+
+## Deliverability & Data Ownership
+
+Reloop owns its delivery engine and allows full data sovereignty, whereas Loops routes through third-party email infrastructure.
+
+| Feature | Reloop | Loops |
+| --- | --- | --- |
+| Direct MTA control | Yes (KumoMTA) | No (Relies on third-party senders) |
+| Domain TLS enforcement | Yes | Yes |
+| Webhook signature verification | Yes (HMAC-SHA256) | Yes |
+| Single sender reputation pool | Yes (Transactional + Marketing unified) | Split (Requires 2nd vendor for transactional) |
+| Data export & sovereignty | Full control (Self-host or export anytime) | CSV export |
+
+## FAQ
+
+### Why should we choose send-based pricing over contact-based pricing?
+
+Contact-based pricing charges you for inactive leads and users who never open your emails. Reloop's send-based pricing charges for emails sent. Free is 3,000 emails/month (200/day); paid overage is $0.80 per 1,000.
+
+### Can Reloop handle both marketing campaigns and transactional APIs?
+
+Yes. Reloop includes transactional API endpoints, SMTP relay, templates, broadcast campaigns, and an agent inbox. Reloop is the email infrastructure, not a connector to another ESP.
+
+### Can we self-host Reloop while migrating from Loops?
+
+Yes. Reloop is Apache 2.0. You can deploy on your own Kubernetes or Docker infrastructure with no Reloop license fee. You still pay for your own servers and IPs.
+
+## Related
+
+- Pricing: https://reloop.sh/pricing.md
+- Compare index: https://reloop.sh/compare.md
+- License (Apache 2.0): https://reloop.sh/license
+
+
+---
+
+# Reloop vs Mailchimp
+
+Path: /compare/mailchimp
+URL: https://reloop.sh/compare/mailchimp
+Markdown: https://reloop.sh/compare/mailchimp.md
+
+# Reloop vs Mailchimp
+
+> Compare Reloop to Mailchimp: send-based developer email vs contact-list marketing SaaS.
+
+HTML: https://reloop.sh/compare/mailchimp
+Markdown: https://reloop.sh/compare/mailchimp.md
+Canonical pricing: https://reloop.sh/pricing.md
+
+Mailchimp is a marketer-first, contact-priced platform. Reloop is developer-first email infrastructure with send-based Reloop Cloud pricing and an Apache 2.0 self-host path. Reloop Free is 3,000 emails/month (200/day).
+
+Reloop is the email service / infrastructure (ESP + MTA). It is not a multi-ESP connector that sits on SendGrid, Mailgun, Resend, or SES.
+
+## Reloop vs Mailchimp
+
+| Feature | Reloop | Mailchimp |
+| --- | --- | --- |
+| Open-source codebase | Yes (Apache 2.0) | No |
+| Self-hostable | Yes | No |
+| Newsletter / campaigns | Yes | Yes (primary) |
+| Transactional API | Yes | Separate product path |
+| SMTP relay | Yes | Limited |
+| Developer API focus | Primary | Secondary |
+| Visual drag-and-drop editor | Yes | Yes (advanced) |
+| Agent inbox | Yes | No |
+| Pricing basis | Emails sent | Contacts stored |
+
+## FAQ
+
+### Can non-technical teammates still send campaigns?
+
+Yes. Reloop includes a campaign builder and template editor. Mailchimp's visual editor is more mature for pure marketer workflows—evaluate with your marketing lead.
+
+### Is Reloop only for developers?
+
+Reloop is developer-first but not developer-only. Teams that want API control and marketer-friendly campaigns fit best. Reloop is an ESP/email infrastructure product, not a multi-provider email router.
+
+## Related
+
+- Pricing: https://reloop.sh/pricing.md
+- Compare index: https://reloop.sh/compare.md
+- License (Apache 2.0): https://reloop.sh/license
 
 
 ---
@@ -117,11 +618,31 @@ Markdown: https://reloop.sh/index.md
 
 > High-performance, open-source email infrastructure—the same service as proprietary platforms. Use Reloop hosted or deploy it yourself.
 
-Reloop is email infrastructure for developers: transactional and marketing email, real-time webhooks, inbound processing, analytics, and an agent-ready API.
+Reloop is email infrastructure for developers: transactional and marketing email, real-time webhooks, inbound processing, analytics, and an agent-ready API. Reloop **is** the ESP/MTA (KumoMTA), not a connector that routes through SendGrid, Mailgun, Resend, or SES.
+
+## What Reloop is not
+
+- Not a multi-provider email router
+- Not MIT-licensed (Apache 2.0 with Reloop Labs use restrictions)
+- Not a contact-list ESP (Reloop Cloud bills by emails sent)
+- Self-host is not a paid Reloop Cloud SKU
+
+## Who it is for
+
+Developers, startups, and agent products that need transactional + campaign email, optional self-host, and machine-readable docs.
+
+## Hosted pricing (Reloop Cloud)
+
+Canonical data: https://reloop.sh/pricing.md
+
+- Free — $0, 3,000 emails / month, **200 / day**
+- Individual — $10 / month, 25,000 emails, no daily cap, overage $0.80 / 1k
+- Startup — $20 / month, 50,000 emails, no daily cap
+- Enterprise — custom volume and billing
 
 ## Why Reloop
 
-- **Open source** — same product you can self-host or use hosted
+- **Open source** — same product you can self-host or use hosted (Apache 2.0)
 - **Developer-first** — REST API, SMTP relay, official SDKs, CLI, MCP
 - **Agent-ready** — API keys, inbound agent inbox, docs as markdown / llms.txt
 
@@ -131,6 +652,7 @@ Reloop is email infrastructure for developers: transactional and marketing email
 - Pricing: https://reloop.sh/pricing.md
 - Documentation index: https://reloop.sh/llms-docs.txt
 - API keys guide: https://reloop.sh/docs/learn/ai/api-keys.md
+- Compare: https://reloop.sh/compare.md
 - GitHub: https://github.com/reloop-labs/reloop
 
 ## Product surfaces
@@ -143,6 +665,46 @@ Reloop is email infrastructure for developers: transactional and marketing email
 | Compare | https://reloop.sh/compare |
 | Glossary | https://reloop.sh/glossary |
 | Changelog | https://reloop.sh/changelog |
+
+
+---
+
+# About Reloop
+
+Path: /about
+URL: https://reloop.sh/about
+Markdown: https://reloop.sh/about.md
+
+# About Reloop
+
+Reloop Labs builds open-source email infrastructure for developers and AI agents. Reloop **is** the email platform (ESP + MTA). It is **not** a multi-ESP connector.
+
+## What we build
+
+- Hosted Reloop Cloud (email API and SMTP) at reloop.sh
+- Self-hostable Apache 2.0 stack (no Reloop license fee; you pay your infra)
+- Agent skills, MCP server, and agent-friendly documentation
+
+## Who it is for
+
+Solo developers, startups, and teams that want transactional + marketing email without lock-in, plus inbound email for agents.
+
+## What Reloop is not
+
+- Not MIT-licensed
+- Not a SendGrid/Mailgun/Resend/SES proxy
+- Not priced by stored contacts on Reloop Cloud
+
+## Links
+
+- Site: https://reloop.sh
+- Pricing: https://reloop.sh/pricing.md
+- Docs index: https://reloop.sh/llms-docs.txt
+- Compare: https://reloop.sh/compare.md
+- Careers: https://reloop.sh/careers
+- Contact: https://reloop.sh/contact
+- GitHub: https://github.com/reloop-labs/reloop
+- License: https://reloop.sh/license
 
 
 ---
@@ -178,33 +740,6 @@ Reloop is built for developers who need reliable transactional email, webhooks, 
 npx -y reloop-mcp
 # env: RELOOP_API_KEY=rl_...
 ```
-
-
----
-
-# About Reloop
-
-Path: /about
-URL: https://reloop.sh/about
-Markdown: https://reloop.sh/about.md
-
-# About Reloop
-
-Reloop Labs builds open-source email infrastructure for developers and AI agents.
-
-## What we build
-
-- Hosted email API and SMTP relay at reloop.sh
-- Self-hostable open-source stack
-- Agent skills, MCP server, and agent-friendly documentation
-
-## Links
-
-- Site: https://reloop.sh
-- Docs index: https://reloop.sh/llms-docs.txt
-- Careers: https://reloop.sh/careers
-- Contact: https://reloop.sh/contact
-- GitHub: https://github.com/reloop-labs/reloop
 
 
 ---
@@ -284,6 +819,169 @@ We're early, shipping in public, and still at the stage where your feedback bend
 
 ---
 
+# IP Warming Schedule Guide: How to Build Sender Reputation (2026)
+
+Path: /blog/ip-warming-guide
+URL: https://reloop.sh/blog/ip-warming-guide
+Markdown: https://reloop.sh/blog/ip-warming-guide.md
+
+A comprehensive, practical guide to warming new sending IP addresses — with an exact week-by-week volume ramp schedule, recipient segmentation strategy, throttle limits, and deliverability monitoring.
+
+**Sending high-volume email traffic from a cold, un-warmed IP address is the single fastest way to get throttled, deferred, or permanently blacklisted by mailbox providers.**
+
+When an Internet Service Provider (such as Gmail, Microsoft 365, or Yahoo) detects sudden spikes of outbound email originating from an unfamiliar IP address, anti-abuse algorithms immediately assume the server is a compromised host or a spam botnet. 
+
+**IP warm-up is the disciplined process of gradually ramping up sending volume over 4 to 6 weeks to establish positive, trusted reputation signals with major mailbox algorithms.**
+
+Whether you are configuring a dedicated IP on [Reloop Cloud](/pricing) or deploying [self-hosted Reloop on your own VPS or bare metal](/self-host), this guide provides the exact week-by-week volume schedules, recipient segmentation techniques, and diagnostic tools required to warm your sending IPs safely.
+
+---
+
+## Shared pools vs. dedicated IPs: Who actually needs to warm up?
+
+Before starting, it is essential to understand whether your setup requires manual IP warming:
+
+1. **Reloop Cloud Shared Pools (No Warm-Up Needed)**: If you send via standard [Reloop Cloud plans](/pricing), your traffic routes through pre-warmed, continuously monitored shared IP pools with established reputation. You can ship production transactional mail immediately.
+2. **Dedicated Sending IPs (Warm-Up Required)**: If your organization provisions dedicated IPs for high-volume isolation, enterprise compliance, or [self-hosted Reloop deployments](/blog/self-hosted-email-infrastructure), **you must execute a structured warm-up schedule before routing 100% of your production traffic**.
+3. **Dormant IP Addresses (Re-Warming Required)**: If a previously warmed dedicated IP sits idle for **30 consecutive days or more**, ISPs decay its reputation score back to neutral, requiring a fresh warm-up cycle.
+
+---
+
+##  Prerequisites before sending email #1
+
+**Warming an IP with broken authentication or dirty recipient lists will permanently destroy the IP's reputation before you finish Week 1.** Complete this checklist first:
+
+- [ ] **SPF, DKIM, and DMARC fully validated**: Your sending domain must have strict DNS records published with proper identifier alignment. Follow our [complete SPF, DKIM, and DMARC setup guide](/blog/spf-dkim-dmarc-setup-guide).
+- [ ] **Reverse DNS (rDNS / PTR Record) configured**: The PTR record of your sending IP must match your sending hostname (e.g. `mail.yourdomain.com`), and that hostname must resolve back to the IP (Forward-Confirmed reverse DNS).
+- [ ] **Clean suppression lists**: Ensure your suppression database contains zero historical hard bounces or spam complaints (see [email bounce processing automation](/blog/email-bounce-processing-automation)).
+- [ ] **Domain age over 30 days**: Brand-new domain names registered within the last 30 days carry an elevated risk profile in spam filter heuristics.
+- [ ] **One-Click Unsubscribe headers configured**: Ensure all non-essential notifications include `List-Unsubscribe` and `List-Unsubscribe-Post` headers per RFC 8058.
+
+---
+
+## The 6-week IP warming schedule
+
+The following schedule outlines conservative daily volume targets per sending IP address across all destination mailbox providers.
+
+| Phase | Daily Sends | Cumulative Total | Target Recipient Segment |
+| :--- | :--- | :--- | :--- |
+| **Week 1** | **50 – 200 / day** | ~1,000 | **High-intent transactional only** (password resets, 2FA OTPs, purchase receipts). |
+| **Week 2** | **200 – 500 / day** | ~3,500 | Active daily users and transactional notifications. |
+| **Week 3** | **500 – 1,000 / day** | ~10,500 | Weekly digests, invoice alerts, and active subscribers. |
+| **Week 4** | **1,000 – 2,500 / day** | ~24,500 | Product announcements to users active in the last 30 days. |
+| **Week 5** | **2,500 – 5,000 / day** | ~59,500 | Broad notifications; monitor spam rates rigorously. |
+| **Week 6+** | **5,000 – 10,000+ / day** | ~129,500+ | Full production volume with established reputation baseline. |
+
+### Per-ISP daily volume distribution
+
+Major mailbox providers evaluate IP reputation independently. When warming an IP, **distribute your daily volume evenly across destination domains**:
+
+| Mailbox Provider / ISP | Volume Share | Target Sends (Example: 400 total/day) | Deliverability Focus |
+| :--- | :--- | :--- | :--- |
+| **Gmail / Google Workspace** | **~40%** | **~160 sends** | Track Domain & IP Reputation on Google Postmaster Tools. |
+| **Microsoft / Outlook / O365** | **~30%** | **~120 sends** | Prone to `451` rate-limit deferrals during early ramp-up. |
+| **Yahoo / AOL / Verizon** | **~15%** | **~60 sends** | Strict spam complaint monitoring (enforces < 0.10% threshold). |
+| **Apple Mail & Other Domains** | **~15%** | **~60 sends** | Custom corporate and private mail servers. |
+
+If you send 2,000 emails in a single day but all 2,000 hit Gmail at once, Gmail's inbound filters will trigger rate limits even if your overall server volume appears moderate.
+
+---
+
+## Recipient segmentation: The secret to accelerating IP trust
+
+**Volume alone does not build reputation—positive recipient engagement is what signals to ISPs that your emails are legitimate and wanted.**
+
+Mailbox algorithms treat user interactions as mathematical multipliers:
+* **Positive Signals (+)**: Opening messages, clicking links, moving emails from Spam to Inbox ("Not Spam"), and adding the sender to address books.
+* **Negative Signals (-)**: Marking messages as Spam, deleting without opening, and hard bouncing.
+
+| Priority Tier | Timing | Qualifying User Criteria | Purpose |
+| :--- | :--- | :--- | :--- |
+| **Tier 1: High-Priority** | **Week 1 – 2** | Password resets, 2FA codes, account signups, invoices. | Near-100% open rate, zero spam complaints. |
+| **Tier 2: Engaged Users** | **Week 3 – 4** | Users who logged in or opened an email in the last 14 days. | Strong positive interaction signals. |
+| **Tier 3: Active Users** | **Week 5 – 6** | Users who engaged with product/email in the last 60 days. | Safely scales daily volume. |
+| **Tier 4: Cold Segments** | **Post Warm-Up** | Inactive users (> 90 days without opens/clicks). | Re-engagement only after reputation is solid. |
+
+**Never send re-engagement campaigns or cold outreach during an IP warm-up window.** Reserve the warm-up period exclusively for your highest-intent, most active users.
+
+---
+
+## Critical deliverability metrics & red flags
+
+Throughout the warm-up cycle, monitor your delivery logs inside [Reloop Analytics](/features/email-analytics) and watch for these hard thresholds:
+
+### 1. Spam Complaint Rate (Threshold: < 0.10%)
+- **Google & Yahoo Warning Threshold**: **0.10%** (1 complaint per 1,000 delivered emails).
+- **Hard Penalty Threshold**: **0.30%** (3 complaints per 1,000 delivered emails).
+- **Action**: If complaints exceed 0.10%, pause volume increases immediately and audit your recipient targeting.
+
+### 2. Hard Bounce Rate (Threshold: < 2.0%)
+- **Healthy Baseline**: Strictly below **1.0%**.
+- **Warning Level**: **2.0% – 5.0%**.
+- **Critical Failure**: Above **5.0%**.
+- **Action**: Hard bounces indicate stale, invalid, or disposable email data. **Reloop automatically suppresses hard-bounced addresses so they are never retried**, protecting your domain and IP reputation. To eliminate bounce spikes before sending, verify that incoming signups are valid and not temporary throwaway addresses using our free [Email Validator tool](/tools/email-validator) (and review our guide on [why emails land in spam and how to fix it](/blog/why-emails-land-in-spam-fix)).
+
+### 3. SMTP Deferral Codes (`421` and `451`)
+- **`421 4.7.0 [IP] Deferred - Connection rate limit exceeded`**: The receiving ISP is asking your server to slow down.
+- **`451 4.7.650 Deferred - Service temporarily unavailable`**: Typical Microsoft rate-limiting during early warm-up.
+- **Action**: Reloop's [KumoMTA sending engine](/features/deliverability) automatically manages backoff queues using intelligent retry logic so deferred emails are retried without dropping packets (see [how we built our queue engine with BullMQ](/blog/how-we-built-email-delivery-queue-bullmq)).
+
+---
+
+## How Reloop simplifies deliverability management
+
+Reloop combines high-performance MTA engineering with modern developer ergonomics:
+
+```typescript
+
+const reloop = new Reloop({
+  apiKey: process.env.RELOOP_API_KEY,
+});
+
+// Dispatch transactional notification with structured metadata
+const response = await reloop.emails.send({
+  from: "Reloop Security <security@yourdomain.com>",
+  to: "user@example.com",
+  subject: "Your login verification code",
+  html: "<p>Your security code is <strong>888888</strong>.</p>",
+  headers: {
+    "X-Entity-Ref-ID": "auth-otp-92841",
+  },
+});
+```
+
+### Reloop's built-in deliverability architecture:
+
+1. **Automated Cryptographic Signing**: Dedicated RSA-2048 [DKIM key generation](/blog/spf-dkim-dmarc-setup-guide) signed at line-rate via KumoMTA.
+2. **Intelligent Queue Management**: Outbound queues powered by BullMQ handle backoff retries when destination ISPs return temporary `4xx` deferrals.
+3. **Real-Time Event Stream**: Webhooks dispatch immediate `delivered`, `opened`, `clicked`, `bounced`, and `complained` payloads to your backend (explore [webhook features](/features/webhooks)).
+4. **Automated Suppression Protection**: Hard bounces and spam complaints are instantly isolated to protect your sending IP from repeated reputation penalties.
+5. **AI Agent Inbox Support**: Dedicated routing and Model Context Protocol (MCP) integrations for autonomous agent workflows (see [email infrastructure for AI agents](/blog/email-infrastructure-for-ai-agents) and the [AI agent inbox use case](/use-cases/ai-agent-inbox)).
+
+---
+
+## What to do if an ISP throttles your warm-up
+
+If you encounter deliverability issues during warm-up, follow this 4-step recovery protocol:
+
+1. **Do not increase volume**: Freeze daily send volume at the current tier or drop back to the previous week's volume.
+2. **Audit Google Postmaster Tools**: Check [Google Postmaster Tools](https://postmaster.google.com) for sudden drops in Domain or IP Reputation and inspect the authentication success tab.
+3. **Inspect DNSBL Blacklists**: Query your sending IP on [MXToolbox Blacklist Check](https://mxtoolbox.com/blacklists.aspx) to ensure the IP hasn't been listed on Spamhaus or Barracuda.
+4. **Isolate transactional streams**: Ensure your marketing updates are strictly isolated from mission-critical authentication mail (see [transactional email best practices](/blog/transactional-email-best-practices)).
+
+Once metrics stabilize for 5 to 7 consecutive days, resume the volume schedule.
+
+---
+
+## Where to go from here
+
+- **[SPF, DKIM, and DMARC Complete Setup Guide](/blog/spf-dkim-dmarc-setup-guide)**: Publish and verify the three essential authentication records.
+- **[Why Emails Land in Spam & How to Fix It](/blog/why-emails-land-in-spam-fix)**: A complete diagnostic checklist for ISP-specific delivery failures.
+- **[Self-Host Reloop for $5/Month](/blog/self-host-email-5-dollars)**: Deploy production-ready email infrastructure on Fly.io, Coolify, or your own VPS.
+- **[Why We Open-Sourced Our Email Infrastructure](/blog/why-we-open-sourced-email-infrastructure)**: The architectural vision and philosophy behind Reloop.
+
+---
+
 # How to Send Email in Next.js App Router (2026)
 
 Path: /blog/send-email-nextjs-app-router
@@ -352,12 +1050,11 @@ Rules that matter:
 One client file keeps Server Actions and Route Handlers identical.
 
 ```typescript
-// lib/reloop.ts
+// lib/reloop.ts
 
 if (!process.env.RELOOP_API_KEY) {
   throw new Error("Missing RELOOP_API_KEY");
-}
-
+}
   apiKey: process.env.RELOOP_API_KEY,
 });
 ```
@@ -378,11 +1075,9 @@ Initialize with an object: `{ apiKey: string }`. Optional: `baseUrl` if you [sel
 
 ```typescript
 // app/actions/send-welcome-email.ts
-"use server";
-
+"use server";
   | { ok: true; messageId?: string }
-  | { ok: false; error: string };
-
+  | { ok: false; error: string };
   email: string,
   name?: string,
 ): Promise<SendWelcomeResult> {
@@ -427,8 +1122,7 @@ Notes:
 
 ```tsx
 // app/signup/welcome-form.tsx
-"use client";
-
+"use client";
   const [message, setMessage] = useState<string | null>(null);
   const [pending, startTransition] = useTransition();
 
@@ -469,14 +1163,13 @@ Notes:
 You can also bind the action directly:
 
 ```tsx
-// app/contact/page.tsx
+// app/contact/page.tsx
 
 async function contactAction(formData: FormData) {
   "use server";
   const email = String(formData.get("email") ?? "");
   await sendWelcomeEmail(email);
-}
-
+}
   return (
     <form action={contactAction}>
       <input name="email" type="email" required />
@@ -502,7 +1195,7 @@ Server Actions work for same-origin app flows. For external HTTP callers, use a 
 ### Route Handler
 
 ```typescript
-// app/api/send-email/route.ts
+// app/api/send-email/route.ts
 
 type Body = {
   to?: string;
@@ -510,8 +1203,7 @@ type Body = {
   html?: string;
   text?: string;
   name?: string;
-};
-
+};
   let body: Body;
 
   try {
@@ -663,8 +1355,7 @@ Always send both `html` and `text` when you can — better deliverability and cl
 - Edge Runtime is a restricted environment. If you must run on Edge, call Reloop’s **HTTP API** with `fetch` instead of relying on Node-only modules — same idea as the [Cloudflare Workers guide](/blog/send-email-cloudflare-workers).
 
 ```typescript
-// Edge-friendly alternative (no SDK)
-
+// Edge-friendly alternative (no SDK)
   const body = await request.json();
 
   const res = await fetch("https://reloop.sh/api/mail/v1/send", {
@@ -766,247 +1457,6 @@ Details: [Vercel + Reloop](/docs/integrations/vercel).
 - [Send mail API](/docs/api/mail/post-api-mail-v1send) — full payload
 - [Vercel AI SDK + Reloop](/blog/vercel-ai-sdk-reloop-notifications) — tool-calling notifications
 - Sibling guides: [SvelteKit](/blog/send-email-sveltekit) · [Remix](/blog/send-email-remix) · [Cloudflare Workers](/blog/send-email-cloudflare-workers)
-
----
-
-# Why Your Emails Land In Spam & How to Fix It
-
-Path: /blog/why-emails-land-in-spam-fix
-URL: https://reloop.sh/blog/why-emails-land-in-spam-fix
-Markdown: https://reloop.sh/blog/why-emails-land-in-spam-fix.md
-
-The definitive guide to diagnosing and fixing email spam folder placement — covering authentication, content, reputation, list hygiene, and ISP-specific issues.
-
-**Email deliverability does not fail with an HTTP 404 error or a readable stack trace—it fails silently by routing your mission-critical messages into the recipient's spam folder.**
-
-When auth tokens, password reset links, invoices, and user notifications land in spam, your business is effectively down for those users. Because SMTP technically completes message handoff without an error code, deliverability regressions are notoriously difficult to detect and debug without a systematic methodology.
-
-This guide walks you through every major root cause of spam folder placement, provides exact CLI commands and tools to diagnose your sending path, and details the concrete steps required to fix each issue permanently.
-
-## Start with a spam score baseline
-
-**Before debugging individual infrastructure components, establish an objective spam score baseline.**
-
-Send a test email from your production or staging environment to [mail-tester.com](https://mail-tester.com). The service executes automated SpamAssassin heuristics, analyzes message MIME structure, and checks DNSBL blacklists to return a score from 0 to 10.
-
-- **Score 9.0 to 10.0**: **Optimal deliverability baseline** required for transactional infrastructure.
-- **Score 7.0 to 8.9**: **Active deliverability risks**—minor configuration warnings, missing headers, or slight content penalties.
-- **Score Below 7.0**: **Severe deliverability failure**—failing authentication, blacklisted IP, or broken MIME structure.
-
-In parallel, register your sending domain with [Google Postmaster Tools](https://postmaster.google.com). It provides proprietary Gmail telemetry directly from Google—including **domain reputation**, **IP reputation**, **spam complaint rates**, and **authentication success rates**.
-
-## Cause 1: Missing or broken email authentication
-
-**Probability: Very High. Over 70% of inbox placement failures stem from authentication misconfigurations.**
-
-Major mailbox providers ([Google, Yahoo, and Microsoft](https://blog.google/products/gmail/gmail-security-authentication-spam-protection/)) enforce mandatory authentication for all senders. If your messages fail or lack [SPF, DKIM, or DMARC](/blog/spf-dkim-dmarc-setup-guide), inbox providers will aggressively route your traffic to spam or drop it at the SMTP handshake.
-
-### How to diagnose authentication in DNS
-
-Verify that your DNS records are active and resolving across public resolvers:
-
-```bash
-# 1. Verify SPF record
-dig TXT yourdomain.com +short | grep spf
-
-# 2. Verify DKIM record (Reloop uses the 'reloop' selector)
-dig TXT reloop._domainkey.yourdomain.com +short
-
-# 3. Verify DMARC record
-dig TXT _dmarc.yourdomain.com +short
-```
-
-You can also paste raw message headers into the [MXToolbox Email Header Analyzer](https://mxtoolbox.com/EmailHeaders.aspx) to inspect how receiving mail transfer agents evaluate your records.
-
-### What healthy authentication headers look like
-
-Inspect the `Authentication-Results` header inside a delivered email:
-
-```http
-Authentication-Results: mx.google.com;
-  spf=pass (google.com: domain of notifications@yourdomain.com designates 1.2.3.4 as permitted sender) smtp.mailfrom=notifications@yourdomain.com;
-  dkim=pass header.i=@yourdomain.com header.s=reloop;
-  dmarc=pass (p=REJECT) header.from=yourdomain.com
-```
-
-**If any authentication check shows `fail` or `softfail`, resolve authentication before investigating any other deliverability factor.** See our step-by-step [SPF, DKIM, and DMARC complete setup guide](/blog/spf-dkim-dmarc-setup-guide).
-
-### The DMARC alignment trap
-
-**An email can pass SPF and DKIM individually while still failing DMARC due to identifier misalignment.**
-
-DMARC requires that the domain in the user-visible `From:` header matches either:
-1. The domain in the envelope sender `Return-Path` (**SPF Alignment**)
-2. The domain specified in the `d=` tag of a valid `DKIM-Signature` (**DKIM Alignment**)
-
-If you send from `auth@yourdomain.com` but your DKIM signature is signed under a third-party vendor domain without custom domain alignment, DMARC evaluation will fail.
-
-## Cause 2: Sending from a new IP with no reputation
-
-**Probability: High for freshly provisioned servers and new infrastructure.**
-
-Internet Service Providers (ISPs) maintain rolling reputation scores for every sending IP address. **A brand new IP starts with neutral reputation, which anti-abuse filters treat with heightened suspicion.** Jumping immediately to high sending volume from a cold IP triggers automated rate-limiting, temporary deferrals (`421` / `451` SMTP codes), and spam placement.
-
-### Indicators of an IP reputation issue
-
-- Deliverability was flawless on previous infrastructure before migrating to a new server.
-- You recently provisioned a dedicated IP address or switched email infrastructure providers.
-- [Google Postmaster Tools](https://postmaster.google.com) reports **"Low"** or **"Bad"** IP reputation.
-
-### How to fix it: Structured IP warming
-
-**IP warming is the process of gradually scaling outbound volume over 4 to 6 weeks to establish trusted sender reputation.**
-
-| Week | Recommended Daily Sends | Primary Focus |
-| :--- | :--- | :--- |
-| **Week 1** | **50 – 200 emails/day** | High-intent transactional mail (password resets, welcome emails). |
-| **Week 2** | **200 – 500 emails/day** | Active daily users and transactional notifications. |
-| **Week 3** | **500 – 1,000 emails/day** | Expand to weekly summaries and invoice dispatches. |
-| **Week 4** | **1,000 – 2,500 emails/day** | Begin rolling out product updates to engaged segments. |
-| **Week 5** | **2,500 – 5,000 emails/day** | Monitor spam complaint rate; ensure complaints remain < 0.05%. |
-| **Week 6+** | **5,000 – 10,000+ emails/day** | Full production capacity with established reputation. |
-
-**During the initial warm-up window, send exclusively to your most engaged recipients.** High open rates and user engagement accelerate positive reputation scoring with mailbox algorithms. Follow our detailed [IP warming schedule guide](/blog/ip-warming-guide).
-
-## Cause 3: High bounce rate
-
-**Probability: Moderate to High, particularly after user imports or list migrations.**
-
-**A bounce rate exceeding 2% is an immediate warning signal to ISPs; a bounce rate over 5% triggers automated throttling or domain blacklisting.** High bounce rates indicate that a sender is not validating email addresses at collection or is sending to stale, unverified databases.
-
-### Distinguishing Hard vs. Soft Bounces
-
-- **Hard Bounces (5xx SMTP errors)**: Permanent delivery failures (e.g. `550 5.1.1 User unknown`, invalid mailbox, nonexistent domain).
-- **Soft Bounces (4xx SMTP errors)**: Temporary delivery failures (e.g. `452 Mailbox full`, server busy, transient network timeout).
-
-### How to eliminate bounce penalties
-
-1. **Automatically suppress hard-bounced addresses**: Never retry sending to a hard bounce. [Reloop's delivery engine](/features/deliverability) automatically suppresses hard bounces to protect your domain reputation (see our guide on [email bounce processing automation](/blog/email-bounce-processing-automation)).
-2. **Verify addresses in real-time at signup**: Prevent typos and invalid domains directly at your registration form:
-   ```typescript
-
-     // Basic format validation
-     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-     if (!emailRegex.test(email)) return false;
-
-     // Verify domain has active MX records
-     const domain = email.split("@")[1];
-     try {
-       const mxRecords = await resolver.resolveMx(domain);
-       return mxRecords && mxRecords.length > 0;
-     } catch {
-       return false;
-     }
-   }
-   ```
-3. **Never purchase or scrape email lists**: Third-party lists contain spam traps (honeypot addresses maintained by anti-spam organizations) that immediately ruin domain reputation.
-
-## Cause 4: High spam complaint rate
-
-**Probability: High for mixed transactional and notification streams.**
-
-A spam complaint occurs whenever a recipient clicks "Report Spam" or "Mark as Spam" in Gmail, Apple Mail, or Outlook.
-
-- **Google & Yahoo Warning Threshold**: **0.10%** (1 complaint per 1,000 delivered emails).
-- **Enforcement & Blocking Threshold**: **0.30%** (3 complaints per 1,000 delivered emails).
-
-**Exceeding 0.30% spam complaints will cause mailbox providers to route all subsequent domain traffic directly to the spam folder.**
-
-### How to reduce spam complaints
-
-1. **Isolate transactional from promotional sending**: **Never send marketing blasts from your primary transactional domain.** Isolate critical auth tokens and receipts on a dedicated subdomain (e.g. `auth.yourdomain.com` or `mail.yourdomain.com`) as detailed in our [transactional email best practices](/blog/transactional-email-best-practices).
-2. **Implement RFC 8058 One-Click Unsubscribe**: Gmail and Yahoo require one-click unsubscribe headers for non-transactional messages:
-   ```typescript
-
-   const reloop = new Reloop({ apiKey: process.env.RELOOP_API_KEY });
-
-   await reloop.emails.send({
-     from: "notifications@yourdomain.com",
-     to: user.email,
-     subject: "Your weekly analytics digest",
-     headers: {
-       "List-Unsubscribe": `<https://yourdomain.com/unsubscribe?token=${user.token}>`,
-       "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
-     },
-     html: "<p>Your weekly digest content...</p>",
-   });
-   ```
-3. **Sunset inactive recipients**: Implement sunset policies for non-essential notifications. If a user has not opened an email in 90 days, reduce sending frequency or require explicit re-opt-in.
-
-## Cause 5: Content triggering Bayesian spam filters
-
-**Probability: Low for standard transactional receipts; Moderate for notification templates.**
-
-Modern spam filters use natural language processing and Bayesian analysis to evaluate message payloads. While keywords alone rarely cause spam placement, poor HTML formatting combined with aggressive promotional phrasing will penalize your delivery score.
-
-### Content practices that degrade inbox placement
-
-- **Missing `text/plain` multipart MIME**: Sending an HTML-only email without an accompanying plain text alternative is a strong spam signal. Reloop automatically generates plain text fallbacks for all outgoing messages.
-- **Extreme Image-to-Text Ratio**: Single large promotional images with little or no accompanying text mimic phishing campaigns.
-- **Link Text vs. Href Domain Mismatches**: If your link anchor text displays `https://yourdomain.com/login` but the underlying `href` points to an unbranded tracking redirect, filters flag the discrepancy as a potential phishing attempt.
-- **Spam Trigger Patterns**: Excessive capitalization in subject lines (`URGENT: RESET NOW`), repetitive punctuation (`$$$`, `!!!`), and deceptive urgency triggers.
-
-## Cause 6: Sending from unmonitored `noreply@` addresses
-
-**Probability: Measurable impact on recipient engagement signals.**
-
-Using `noreply@yourdomain.com` harms deliverability in two distinct ways:
-1. **Machine Learning Heuristics**: Mailbox algorithms associate `noreply@` with low-engagement bulk blasts.
-2. **Missed Engagement Signals**: When recipients reply to an email (e.g. "Thanks!" or asking a question), mailbox algorithms register that interaction as a strong positive reputation signal. A `noreply@` address blocks this positive feedback loop.
-
-**Best Practice**: Use a recognizable sender address such as `notifications@yourdomain.com` or `team@yourdomain.com`, and set a monitored `Reply-To` header to route inbound responses to your support inbox:
-
-```typescript
-await reloop.emails.send({
-  from: "Acme Support <notifications@yourdomain.com>",
-  replyTo: "support@yourdomain.com",
-  to: user.email,
-  subject: "Your order confirmation",
-  html: "<p>Thank you for your purchase...</p>",
-});
-```
-
-## Cause 7: Sending IP or domain listed on a DNSBL blacklist
-
-**Probability: High if credentials were leaked, sending servers were compromised, or list hygiene was neglected.**
-
-DNSBLs (DNS-based Blackhole Lists) are shared databases of IP addresses and domains flagged for spam transmission or compromised SMTP servers. If your IP or domain appears on an authoritative blocklist (such as **Spamhaus**, **Barracuda**, or **Spamcop**), major ISPs will reject or spam-folder your mail immediately.
-
-### How to check blacklist status
-
-Run an automated scan across all major DNSBL registries using the [MXToolbox Blacklist Checker](https://mxtoolbox.com/blacklists.aspx). Enter your sending IP address and sending domain.
-
-### How to request delisting
-
-1. **Isolate and fix the root cause**: Identify and patch the compromised SMTP credential, stop the rogue sending loop, or purge the failing email list.
-2. **Submit a removal request**: Visit the specific blacklist removal portal (e.g. the [Spamhaus Blocklist Removal Center](https://www.spamhaus.org/removal/)) and provide proof of remediation.
-3. **Monitor clearance**: Most reputable blocklists clear listings within 24 to 48 hours once remediation is verified.
-
-## Cause 8: ISP-specific filtering (Gmail, Microsoft 365, Apple)
-
-Each major mailbox provider utilizes proprietary filtering algorithms beyond baseline standards:
-
-### 1. Google (Gmail)
-- **Primary Tool**: Monitor [Google Postmaster Tools](https://postmaster.google.com).
-- **Tab Placement vs. Spam**: If transactional emails route to the **Promotions** tab instead of **Primary**, this is a classification issue rather than a spam penalty. Keep transactional templates lightweight and free from promotional banners to help Gmail route them to Primary.
-- **BIMI Brand Logo**: Implement [BIMI (Brand Indicators for Message Identification)](/blog/bimi-email-setup-guide) with a valid DMARC enforcement policy (`p=quarantine` or `p=reject`) to display your verified company avatar in Gmail inboxes.
-
-### 2. Microsoft (Outlook / Office 365)
-- Microsoft maintains stringent IP reputation filtering and relies heavily on [Smart Network Data Services (SNDS)](https://sendersupport.olc.protection.outlook.com/snds/).
-- Microsoft frequently returns `550 5.7.1` error codes when an IP reputation drops below acceptable thresholds.
-
-## The 8-Step Deliverability Diagnostic Checklist
-
-When emails are landing in spam, work through this diagnostic sequence in order:
-
-1. **Run a [mail-tester.com](https://mail-tester.com) scan (target score ≥ 9/10)** — Identifies broken MIME syntax, missing DNS tags, and Bayesian spam keyword flags before you touch infrastructure.
-2. **Audit raw authentication headers** — Inspect received headers in an actual test inbox to confirm `SPF: PASS`, `DKIM: PASS`, and `DMARC: PASS` with identifier alignment.
-3. **Check [Google Postmaster Tools](https://postmaster.google.com) telemetry** — Verify that your Domain Reputation is "Good" or "High" and inspect Gmail-specific spam rates.
-4. **Check DNSBL blacklists on [MXToolbox](https://mxtoolbox.com/blacklists.aspx)** — Confirm neither your sending IP nor domain is listed on Spamhaus, Barracuda, or Spamcop.
-5. **Review real-time bounce rates in [Reloop Analytics](/features/email-analytics)** — Confirm that your 30-day hard bounce rate is strictly **below 2%** and that auto-suppression is active.
-6. **Review your spam complaint rate** — Ensure complaints remain strictly **below 0.10%** (1 per 1,000 sends) to prevent algorithmic ISP filtering.
-7. **Audit MIME structure & plain text fallback** — Verify that every outgoing template includes both a valid `text/plain` part and a balanced HTML payload without broken tracking URLs.
-8. **Verify ISP-specific routing & tab placement** — Check whether messages are routing to Gmail's Promotions tab vs. spam, and isolate transactional subdomains from promotional lists.
 
 ---
 
@@ -1236,6 +1686,246 @@ Email authentication establishes your domain identity, but **it does not replace
 
 ---
 
+# Why Your Emails Land In Spam & How to Fix It
+
+Path: /blog/why-emails-land-in-spam-fix
+URL: https://reloop.sh/blog/why-emails-land-in-spam-fix
+Markdown: https://reloop.sh/blog/why-emails-land-in-spam-fix.md
+
+The definitive guide to diagnosing and fixing email spam folder placement — covering authentication, content, reputation, list hygiene, and ISP-specific issues.
+
+**Email deliverability does not fail with an HTTP 404 error or a readable stack trace—it fails silently by routing your mission-critical messages into the recipient's spam folder.**
+
+When auth tokens, password reset links, invoices, and user notifications land in spam, your business is effectively down for those users. Because SMTP technically completes message handoff without an error code, deliverability regressions are notoriously difficult to detect and debug without a systematic methodology.
+
+This guide walks you through every major root cause of spam folder placement, provides exact CLI commands and tools to diagnose your sending path, and details the concrete steps required to fix each issue permanently.
+
+## Start with a spam score baseline
+
+**Before debugging individual infrastructure components, establish an objective spam score baseline.**
+
+Send a test email from your production or staging environment to [mail-tester.com](https://mail-tester.com). The service executes automated SpamAssassin heuristics, analyzes message MIME structure, and checks DNSBL blacklists to return a score from 0 to 10.
+
+- **Score 9.0 to 10.0**: **Optimal deliverability baseline** required for transactional infrastructure.
+- **Score 7.0 to 8.9**: **Active deliverability risks**—minor configuration warnings, missing headers, or slight content penalties.
+- **Score Below 7.0**: **Severe deliverability failure**—failing authentication, blacklisted IP, or broken MIME structure.
+
+In parallel, register your sending domain with [Google Postmaster Tools](https://postmaster.google.com). It provides proprietary Gmail telemetry directly from Google—including **domain reputation**, **IP reputation**, **spam complaint rates**, and **authentication success rates**.
+
+## Cause 1: Missing or broken email authentication
+
+**Probability: Very High. Over 70% of inbox placement failures stem from authentication misconfigurations.**
+
+Major mailbox providers ([Google, Yahoo, and Microsoft](https://blog.google/products/gmail/gmail-security-authentication-spam-protection/)) enforce mandatory authentication for all senders. If your messages fail or lack [SPF, DKIM, or DMARC](/blog/spf-dkim-dmarc-setup-guide), inbox providers will aggressively route your traffic to spam or drop it at the SMTP handshake.
+
+### How to diagnose authentication in DNS
+
+Verify that your DNS records are active and resolving across public resolvers:
+
+```bash
+# 1. Verify SPF record
+dig TXT yourdomain.com +short | grep spf
+
+# 2. Verify DKIM record (Reloop uses the 'reloop' selector)
+dig TXT reloop._domainkey.yourdomain.com +short
+
+# 3. Verify DMARC record
+dig TXT _dmarc.yourdomain.com +short
+```
+
+You can also paste raw message headers into the [MXToolbox Email Header Analyzer](https://mxtoolbox.com/EmailHeaders.aspx) to inspect how receiving mail transfer agents evaluate your records.
+
+### What healthy authentication headers look like
+
+Inspect the `Authentication-Results` header inside a delivered email:
+
+```http
+Authentication-Results: mx.google.com;
+  spf=pass (google.com: domain of notifications@yourdomain.com designates 1.2.3.4 as permitted sender) smtp.mailfrom=notifications@yourdomain.com;
+  dkim=pass header.i=@yourdomain.com header.s=reloop;
+  dmarc=pass (p=REJECT) header.from=yourdomain.com
+```
+
+**If any authentication check shows `fail` or `softfail`, resolve authentication before investigating any other deliverability factor.** See our step-by-step [SPF, DKIM, and DMARC complete setup guide](/blog/spf-dkim-dmarc-setup-guide).
+
+### The DMARC alignment trap
+
+**An email can pass SPF and DKIM individually while still failing DMARC due to identifier misalignment.**
+
+DMARC requires that the domain in the user-visible `From:` header matches either:
+1. The domain in the envelope sender `Return-Path` (**SPF Alignment**)
+2. The domain specified in the `d=` tag of a valid `DKIM-Signature` (**DKIM Alignment**)
+
+If you send from `auth@yourdomain.com` but your DKIM signature is signed under a third-party vendor domain without custom domain alignment, DMARC evaluation will fail.
+
+## Cause 2: Sending from a new IP with no reputation
+
+**Probability: High for freshly provisioned servers and new infrastructure.**
+
+Internet Service Providers (ISPs) maintain rolling reputation scores for every sending IP address. **A brand new IP starts with neutral reputation, which anti-abuse filters treat with heightened suspicion.** Jumping immediately to high sending volume from a cold IP triggers automated rate-limiting, temporary deferrals (`421` / `451` SMTP codes), and spam placement.
+
+### Indicators of an IP reputation issue
+
+- Deliverability was flawless on previous infrastructure before migrating to a new server.
+- You recently provisioned a dedicated IP address or switched email infrastructure providers.
+- [Google Postmaster Tools](https://postmaster.google.com) reports **"Low"** or **"Bad"** IP reputation.
+
+### How to fix it: Structured IP warming
+
+**IP warming is the process of gradually scaling outbound volume over 4 to 6 weeks to establish trusted sender reputation.**
+
+| Week | Recommended Daily Sends | Primary Focus |
+| :--- | :--- | :--- |
+| **Week 1** | **50 – 200 emails/day** | High-intent transactional mail (password resets, welcome emails). |
+| **Week 2** | **200 – 500 emails/day** | Active daily users and transactional notifications. |
+| **Week 3** | **500 – 1,000 emails/day** | Expand to weekly summaries and invoice dispatches. |
+| **Week 4** | **1,000 – 2,500 emails/day** | Begin rolling out product updates to engaged segments. |
+| **Week 5** | **2,500 – 5,000 emails/day** | Monitor spam complaint rate; ensure complaints remain < 0.05%. |
+| **Week 6+** | **5,000 – 10,000+ emails/day** | Full production capacity with established reputation. |
+
+**During the initial warm-up window, send exclusively to your most engaged recipients.** High open rates and user engagement accelerate positive reputation scoring with mailbox algorithms. Follow our detailed [IP warming schedule guide](/blog/ip-warming-guide).
+
+## Cause 3: High bounce rate
+
+**Probability: Moderate to High, particularly after user imports or list migrations.**
+
+**A bounce rate exceeding 2% is an immediate warning signal to ISPs; a bounce rate over 5% triggers automated throttling or domain blacklisting.** High bounce rates indicate that a sender is not validating email addresses at collection or is sending to stale, unverified databases.
+
+### Distinguishing Hard vs. Soft Bounces
+
+- **Hard Bounces (5xx SMTP errors)**: Permanent delivery failures (e.g. `550 5.1.1 User unknown`, invalid mailbox, nonexistent domain).
+- **Soft Bounces (4xx SMTP errors)**: Temporary delivery failures (e.g. `452 Mailbox full`, server busy, transient network timeout).
+
+### How to eliminate bounce penalties
+
+1. **Automatically suppress hard-bounced addresses**: Never retry sending to a hard bounce. [Reloop's delivery engine](/features/deliverability) automatically suppresses hard bounces to protect your domain reputation (see our guide on [email bounce processing automation](/blog/email-bounce-processing-automation)).
+2. **Verify addresses in real-time at signup**: Prevent typos and invalid domains directly at your registration form:
+   ```typescript
+     // Basic format validation
+     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+     if (!emailRegex.test(email)) return false;
+
+     // Verify domain has active MX records
+     const domain = email.split("@")[1];
+     try {
+       const mxRecords = await resolver.resolveMx(domain);
+       return mxRecords && mxRecords.length > 0;
+     } catch {
+       return false;
+     }
+   }
+   ```
+3. **Never purchase or scrape email lists**: Third-party lists contain spam traps (honeypot addresses maintained by anti-spam organizations) that immediately ruin domain reputation.
+
+## Cause 4: High spam complaint rate
+
+**Probability: High for mixed transactional and notification streams.**
+
+A spam complaint occurs whenever a recipient clicks "Report Spam" or "Mark as Spam" in Gmail, Apple Mail, or Outlook.
+
+- **Google & Yahoo Warning Threshold**: **0.10%** (1 complaint per 1,000 delivered emails).
+- **Enforcement & Blocking Threshold**: **0.30%** (3 complaints per 1,000 delivered emails).
+
+**Exceeding 0.30% spam complaints will cause mailbox providers to route all subsequent domain traffic directly to the spam folder.**
+
+### How to reduce spam complaints
+
+1. **Isolate transactional from promotional sending**: **Never send marketing blasts from your primary transactional domain.** Isolate critical auth tokens and receipts on a dedicated subdomain (e.g. `auth.yourdomain.com` or `mail.yourdomain.com`) as detailed in our [transactional email best practices](/blog/transactional-email-best-practices).
+2. **Implement RFC 8058 One-Click Unsubscribe**: Gmail and Yahoo require one-click unsubscribe headers for non-transactional messages:
+   ```typescript
+
+   const reloop = new Reloop({ apiKey: process.env.RELOOP_API_KEY });
+
+   await reloop.emails.send({
+     from: "notifications@yourdomain.com",
+     to: user.email,
+     subject: "Your weekly analytics digest",
+     headers: {
+       "List-Unsubscribe": `<https://yourdomain.com/unsubscribe?token=${user.token}>`,
+       "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+     },
+     html: "<p>Your weekly digest content...</p>",
+   });
+   ```
+3. **Sunset inactive recipients**: Implement sunset policies for non-essential notifications. If a user has not opened an email in 90 days, reduce sending frequency or require explicit re-opt-in.
+
+## Cause 5: Content triggering Bayesian spam filters
+
+**Probability: Low for standard transactional receipts; Moderate for notification templates.**
+
+Modern spam filters use natural language processing and Bayesian analysis to evaluate message payloads. While keywords alone rarely cause spam placement, poor HTML formatting combined with aggressive promotional phrasing will penalize your delivery score.
+
+### Content practices that degrade inbox placement
+
+- **Missing `text/plain` multipart MIME**: Sending an HTML-only email without an accompanying plain text alternative is a strong spam signal. Reloop automatically generates plain text fallbacks for all outgoing messages.
+- **Extreme Image-to-Text Ratio**: Single large promotional images with little or no accompanying text mimic phishing campaigns.
+- **Link Text vs. Href Domain Mismatches**: If your link anchor text displays `https://yourdomain.com/login` but the underlying `href` points to an unbranded tracking redirect, filters flag the discrepancy as a potential phishing attempt.
+- **Spam Trigger Patterns**: Excessive capitalization in subject lines (`URGENT: RESET NOW`), repetitive punctuation (`$$$`, `!!!`), and deceptive urgency triggers.
+
+## Cause 6: Sending from unmonitored `noreply@` addresses
+
+**Probability: Measurable impact on recipient engagement signals.**
+
+Using `noreply@yourdomain.com` harms deliverability in two distinct ways:
+1. **Machine Learning Heuristics**: Mailbox algorithms associate `noreply@` with low-engagement bulk blasts.
+2. **Missed Engagement Signals**: When recipients reply to an email (e.g. "Thanks!" or asking a question), mailbox algorithms register that interaction as a strong positive reputation signal. A `noreply@` address blocks this positive feedback loop.
+
+**Best Practice**: Use a recognizable sender address such as `notifications@yourdomain.com` or `team@yourdomain.com`, and set a monitored `Reply-To` header to route inbound responses to your support inbox:
+
+```typescript
+await reloop.emails.send({
+  from: "Acme Support <notifications@yourdomain.com>",
+  replyTo: "support@yourdomain.com",
+  to: user.email,
+  subject: "Your order confirmation",
+  html: "<p>Thank you for your purchase...</p>",
+});
+```
+
+## Cause 7: Sending IP or domain listed on a DNSBL blacklist
+
+**Probability: High if credentials were leaked, sending servers were compromised, or list hygiene was neglected.**
+
+DNSBLs (DNS-based Blackhole Lists) are shared databases of IP addresses and domains flagged for spam transmission or compromised SMTP servers. If your IP or domain appears on an authoritative blocklist (such as **Spamhaus**, **Barracuda**, or **Spamcop**), major ISPs will reject or spam-folder your mail immediately.
+
+### How to check blacklist status
+
+Run an automated scan across all major DNSBL registries using the [MXToolbox Blacklist Checker](https://mxtoolbox.com/blacklists.aspx). Enter your sending IP address and sending domain.
+
+### How to request delisting
+
+1. **Isolate and fix the root cause**: Identify and patch the compromised SMTP credential, stop the rogue sending loop, or purge the failing email list.
+2. **Submit a removal request**: Visit the specific blacklist removal portal (e.g. the [Spamhaus Blocklist Removal Center](https://www.spamhaus.org/removal/)) and provide proof of remediation.
+3. **Monitor clearance**: Most reputable blocklists clear listings within 24 to 48 hours once remediation is verified.
+
+## Cause 8: ISP-specific filtering (Gmail, Microsoft 365, Apple)
+
+Each major mailbox provider utilizes proprietary filtering algorithms beyond baseline standards:
+
+### 1. Google (Gmail)
+- **Primary Tool**: Monitor [Google Postmaster Tools](https://postmaster.google.com).
+- **Tab Placement vs. Spam**: If transactional emails route to the **Promotions** tab instead of **Primary**, this is a classification issue rather than a spam penalty. Keep transactional templates lightweight and free from promotional banners to help Gmail route them to Primary.
+- **BIMI Brand Logo**: Implement [BIMI (Brand Indicators for Message Identification)](/blog/bimi-email-setup-guide) with a valid DMARC enforcement policy (`p=quarantine` or `p=reject`) to display your verified company avatar in Gmail inboxes.
+
+### 2. Microsoft (Outlook / Office 365)
+- Microsoft maintains stringent IP reputation filtering and relies heavily on [Smart Network Data Services (SNDS)](https://sendersupport.olc.protection.outlook.com/snds/).
+- Microsoft frequently returns `550 5.7.1` error codes when an IP reputation drops below acceptable thresholds.
+
+## The 8-Step Deliverability Diagnostic Checklist
+
+When emails are landing in spam, work through this diagnostic sequence in order:
+
+1. **Run a [mail-tester.com](https://mail-tester.com) scan (target score ≥ 9/10)** — Identifies broken MIME syntax, missing DNS tags, and Bayesian spam keyword flags before you touch infrastructure.
+2. **Audit raw authentication headers** — Inspect received headers in an actual test inbox to confirm `SPF: PASS`, `DKIM: PASS`, and `DMARC: PASS` with identifier alignment.
+3. **Check [Google Postmaster Tools](https://postmaster.google.com) telemetry** — Verify that your Domain Reputation is "Good" or "High" and inspect Gmail-specific spam rates.
+4. **Check DNSBL blacklists on [MXToolbox](https://mxtoolbox.com/blacklists.aspx)** — Confirm neither your sending IP nor domain is listed on Spamhaus, Barracuda, or Spamcop.
+5. **Review real-time bounce rates in [Reloop Analytics](/features/email-analytics)** — Confirm that your 30-day hard bounce rate is strictly **below 2%** and that auto-suppression is active.
+6. **Review your spam complaint rate** — Ensure complaints remain strictly **below 0.10%** (1 per 1,000 sends) to prevent algorithmic ISP filtering.
+7. **Audit MIME structure & plain text fallback** — Verify that every outgoing template includes both a valid `text/plain` part and a balanced HTML payload without broken tracking URLs.
+8. **Verify ISP-specific routing & tab placement** — Check whether messages are routing to Gmail's Promotions tab vs. spam, and isolate transactional subdomains from promotional lists.
+
+---
+
 # Why We Open-Sourced Our Email Infrastructure
 
 Path: /blog/why-we-open-sourced-email-infrastructure
@@ -1328,166 +2018,3 @@ Whether you are an indie hacker shipping your first app, a high-growth startup o
 - **Star and explore the repository**: [github.com/reloop-labs/reloop](https://github.com/reloop-labs/reloop)
 - **Start sending on Reloop Cloud**: [reloop.sh/dashboard/signup](https://reloop.sh/dashboard/signup)
 - **Browse the documentation**: [Reloop Docs](/docs) · [Self-Host Guide](/self-host) · [Pricing](/pricing) · [Provider Comparisons](/compare)
-
----
-
-# IP Warming Schedule Guide: How to Build Sender Reputation (2026)
-
-Path: /blog/ip-warming-guide
-URL: https://reloop.sh/blog/ip-warming-guide
-Markdown: https://reloop.sh/blog/ip-warming-guide.md
-
-A comprehensive, practical guide to warming new sending IP addresses — with an exact week-by-week volume ramp schedule, recipient segmentation strategy, throttle limits, and deliverability monitoring.
-
-**Sending high-volume email traffic from a cold, un-warmed IP address is the single fastest way to get throttled, deferred, or permanently blacklisted by mailbox providers.**
-
-When an Internet Service Provider (such as Gmail, Microsoft 365, or Yahoo) detects sudden spikes of outbound email originating from an unfamiliar IP address, anti-abuse algorithms immediately assume the server is a compromised host or a spam botnet. 
-
-**IP warm-up is the disciplined process of gradually ramping up sending volume over 4 to 6 weeks to establish positive, trusted reputation signals with major mailbox algorithms.**
-
-Whether you are configuring a dedicated IP on [Reloop Cloud](/pricing) or deploying [self-hosted Reloop on your own VPS or bare metal](/self-host), this guide provides the exact week-by-week volume schedules, recipient segmentation techniques, and diagnostic tools required to warm your sending IPs safely.
-
----
-
-## Shared pools vs. dedicated IPs: Who actually needs to warm up?
-
-Before starting, it is essential to understand whether your setup requires manual IP warming:
-
-1. **Reloop Cloud Shared Pools (No Warm-Up Needed)**: If you send via standard [Reloop Cloud plans](/pricing), your traffic routes through pre-warmed, continuously monitored shared IP pools with established reputation. You can ship production transactional mail immediately.
-2. **Dedicated Sending IPs (Warm-Up Required)**: If your organization provisions dedicated IPs for high-volume isolation, enterprise compliance, or [self-hosted Reloop deployments](/blog/self-hosted-email-infrastructure), **you must execute a structured warm-up schedule before routing 100% of your production traffic**.
-3. **Dormant IP Addresses (Re-Warming Required)**: If a previously warmed dedicated IP sits idle for **30 consecutive days or more**, ISPs decay its reputation score back to neutral, requiring a fresh warm-up cycle.
-
----
-
-##  Prerequisites before sending email #1
-
-**Warming an IP with broken authentication or dirty recipient lists will permanently destroy the IP's reputation before you finish Week 1.** Complete this checklist first:
-
-- [ ] **SPF, DKIM, and DMARC fully validated**: Your sending domain must have strict DNS records published with proper identifier alignment. Follow our [complete SPF, DKIM, and DMARC setup guide](/blog/spf-dkim-dmarc-setup-guide).
-- [ ] **Reverse DNS (rDNS / PTR Record) configured**: The PTR record of your sending IP must match your sending hostname (e.g. `mail.yourdomain.com`), and that hostname must resolve back to the IP (Forward-Confirmed reverse DNS).
-- [ ] **Clean suppression lists**: Ensure your suppression database contains zero historical hard bounces or spam complaints (see [email bounce processing automation](/blog/email-bounce-processing-automation)).
-- [ ] **Domain age over 30 days**: Brand-new domain names registered within the last 30 days carry an elevated risk profile in spam filter heuristics.
-- [ ] **One-Click Unsubscribe headers configured**: Ensure all non-essential notifications include `List-Unsubscribe` and `List-Unsubscribe-Post` headers per RFC 8058.
-
----
-
-## The 6-week IP warming schedule
-
-The following schedule outlines conservative daily volume targets per sending IP address across all destination mailbox providers.
-
-| Phase | Daily Sends | Cumulative Total | Target Recipient Segment |
-| :--- | :--- | :--- | :--- |
-| **Week 1** | **50 – 200 / day** | ~1,000 | **High-intent transactional only** (password resets, 2FA OTPs, purchase receipts). |
-| **Week 2** | **200 – 500 / day** | ~3,500 | Active daily users and transactional notifications. |
-| **Week 3** | **500 – 1,000 / day** | ~10,500 | Weekly digests, invoice alerts, and active subscribers. |
-| **Week 4** | **1,000 – 2,500 / day** | ~24,500 | Product announcements to users active in the last 30 days. |
-| **Week 5** | **2,500 – 5,000 / day** | ~59,500 | Broad notifications; monitor spam rates rigorously. |
-| **Week 6+** | **5,000 – 10,000+ / day** | ~129,500+ | Full production volume with established reputation baseline. |
-
-### Per-ISP daily volume distribution
-
-Major mailbox providers evaluate IP reputation independently. When warming an IP, **distribute your daily volume evenly across destination domains**:
-
-| Mailbox Provider / ISP | Volume Share | Target Sends (Example: 400 total/day) | Deliverability Focus |
-| :--- | :--- | :--- | :--- |
-| **Gmail / Google Workspace** | **~40%** | **~160 sends** | Track Domain & IP Reputation on Google Postmaster Tools. |
-| **Microsoft / Outlook / O365** | **~30%** | **~120 sends** | Prone to `451` rate-limit deferrals during early ramp-up. |
-| **Yahoo / AOL / Verizon** | **~15%** | **~60 sends** | Strict spam complaint monitoring (enforces < 0.10% threshold). |
-| **Apple Mail & Other Domains** | **~15%** | **~60 sends** | Custom corporate and private mail servers. |
-
-If you send 2,000 emails in a single day but all 2,000 hit Gmail at once, Gmail's inbound filters will trigger rate limits even if your overall server volume appears moderate.
-
----
-
-## Recipient segmentation: The secret to accelerating IP trust
-
-**Volume alone does not build reputation—positive recipient engagement is what signals to ISPs that your emails are legitimate and wanted.**
-
-Mailbox algorithms treat user interactions as mathematical multipliers:
-* **Positive Signals (+)**: Opening messages, clicking links, moving emails from Spam to Inbox ("Not Spam"), and adding the sender to address books.
-* **Negative Signals (-)**: Marking messages as Spam, deleting without opening, and hard bouncing.
-
-| Priority Tier | Timing | Qualifying User Criteria | Purpose |
-| :--- | :--- | :--- | :--- |
-| **Tier 1: High-Priority** | **Week 1 – 2** | Password resets, 2FA codes, account signups, invoices. | Near-100% open rate, zero spam complaints. |
-| **Tier 2: Engaged Users** | **Week 3 – 4** | Users who logged in or opened an email in the last 14 days. | Strong positive interaction signals. |
-| **Tier 3: Active Users** | **Week 5 – 6** | Users who engaged with product/email in the last 60 days. | Safely scales daily volume. |
-| **Tier 4: Cold Segments** | **Post Warm-Up** | Inactive users (> 90 days without opens/clicks). | Re-engagement only after reputation is solid. |
-
-**Never send re-engagement campaigns or cold outreach during an IP warm-up window.** Reserve the warm-up period exclusively for your highest-intent, most active users.
-
----
-
-## Critical deliverability metrics & red flags
-
-Throughout the warm-up cycle, monitor your delivery logs inside [Reloop Analytics](/features/email-analytics) and watch for these hard thresholds:
-
-### 1. Spam Complaint Rate (Threshold: < 0.10%)
-- **Google & Yahoo Warning Threshold**: **0.10%** (1 complaint per 1,000 delivered emails).
-- **Hard Penalty Threshold**: **0.30%** (3 complaints per 1,000 delivered emails).
-- **Action**: If complaints exceed 0.10%, pause volume increases immediately and audit your recipient targeting.
-
-### 2. Hard Bounce Rate (Threshold: < 2.0%)
-- **Healthy Baseline**: Strictly below **1.0%**.
-- **Warning Level**: **2.0% – 5.0%**.
-- **Critical Failure**: Above **5.0%**.
-- **Action**: Hard bounces indicate stale, invalid, or disposable email data. **Reloop automatically suppresses hard-bounced addresses so they are never retried**, protecting your domain and IP reputation. To eliminate bounce spikes before sending, verify that incoming signups are valid and not temporary throwaway addresses using our free [Email Validator tool](/tools/email-validator) (and review our guide on [why emails land in spam and how to fix it](/blog/why-emails-land-in-spam-fix)).
-
-### 3. SMTP Deferral Codes (`421` and `451`)
-- **`421 4.7.0 [IP] Deferred - Connection rate limit exceeded`**: The receiving ISP is asking your server to slow down.
-- **`451 4.7.650 Deferred - Service temporarily unavailable`**: Typical Microsoft rate-limiting during early warm-up.
-- **Action**: Reloop's [KumoMTA sending engine](/features/deliverability) automatically manages backoff queues using intelligent retry logic so deferred emails are retried without dropping packets (see [how we built our queue engine with BullMQ](/blog/how-we-built-email-delivery-queue-bullmq)).
-
----
-
-## How Reloop simplifies deliverability management
-
-Reloop combines high-performance MTA engineering with modern developer ergonomics:
-
-```typescript
-
-const reloop = new Reloop({
-  apiKey: process.env.RELOOP_API_KEY,
-});
-
-// Dispatch transactional notification with structured metadata
-const response = await reloop.emails.send({
-  from: "Reloop Security <security@yourdomain.com>",
-  to: "user@example.com",
-  subject: "Your login verification code",
-  html: "<p>Your security code is <strong>888888</strong>.</p>",
-  headers: {
-    "X-Entity-Ref-ID": "auth-otp-92841",
-  },
-});
-```
-
-### Reloop's built-in deliverability architecture:
-
-1. **Automated Cryptographic Signing**: Dedicated RSA-2048 [DKIM key generation](/blog/spf-dkim-dmarc-setup-guide) signed at line-rate via KumoMTA.
-2. **Intelligent Queue Management**: Outbound queues powered by BullMQ handle backoff retries when destination ISPs return temporary `4xx` deferrals.
-3. **Real-Time Event Stream**: Webhooks dispatch immediate `delivered`, `opened`, `clicked`, `bounced`, and `complained` payloads to your backend (explore [webhook features](/features/webhooks)).
-4. **Automated Suppression Protection**: Hard bounces and spam complaints are instantly isolated to protect your sending IP from repeated reputation penalties.
-5. **AI Agent Inbox Support**: Dedicated routing and Model Context Protocol (MCP) integrations for autonomous agent workflows (see [email infrastructure for AI agents](/blog/email-infrastructure-for-ai-agents) and the [AI agent inbox use case](/use-cases/ai-agent-inbox)).
-
----
-
-## What to do if an ISP throttles your warm-up
-
-If you encounter deliverability issues during warm-up, follow this 4-step recovery protocol:
-
-1. **Do not increase volume**: Freeze daily send volume at the current tier or drop back to the previous week's volume.
-2. **Audit Google Postmaster Tools**: Check [Google Postmaster Tools](https://postmaster.google.com) for sudden drops in Domain or IP Reputation and inspect the authentication success tab.
-3. **Inspect DNSBL Blacklists**: Query your sending IP on [MXToolbox Blacklist Check](https://mxtoolbox.com/blacklists.aspx) to ensure the IP hasn't been listed on Spamhaus or Barracuda.
-4. **Isolate transactional streams**: Ensure your marketing updates are strictly isolated from mission-critical authentication mail (see [transactional email best practices](/blog/transactional-email-best-practices)).
-
-Once metrics stabilize for 5 to 7 consecutive days, resume the volume schedule.
-
----
-
-## Where to go from here
-
-- **[SPF, DKIM, and DMARC Complete Setup Guide](/blog/spf-dkim-dmarc-setup-guide)**: Publish and verify the three essential authentication records.
-- **[Why Emails Land in Spam & How to Fix It](/blog/why-emails-land-in-spam-fix)**: A complete diagnostic checklist for ISP-specific delivery failures.
-- **[Self-Host Reloop for $5/Month](/blog/self-host-email-5-dollars)**: Deploy production-ready email infrastructure on Fly.io, Coolify, or your own VPS.
-- **[Why We Open-Sourced Our Email Infrastructure](/blog/why-we-open-sourced-email-infrastructure)**: The architectural vision and philosophy behind Reloop.

--- a/apps/frontend/web/public/llms-full.txt
+++ b/apps/frontend/web/public/llms-full.txt
@@ -165,7 +165,7 @@ Reloop is the email service / infrastructure (ESP + MTA). It is not a multi-ESP 
 
 ## Pricing & Email Volume
 
-Reloop Cloud Free is 3,000 emails/month with a 200/day cap. Individual is $10/mo for 25,000 emails with no daily cap. Overage is $0.80 vs Resend's $1.00 per 1,000. Self-hosting Reloop has no Reloop license fee (you pay your own infra).
+Reloop Cloud Free is 3,000 emails/month with a 200/day cap. Individual is $10/mo for 25,000 emails with no daily cap. Overage is $0.80 vs Resend's $0.90 per 1,000. Self-hosting Reloop has no Reloop license fee (you pay your own infra).
 
 | Feature | Reloop | Resend |
 | --- | --- | --- |
@@ -173,7 +173,7 @@ Reloop Cloud Free is 3,000 emails/month with a 200/day cap. Individual is $10/mo
 | Daily send limit (Free tier) | 200 / day (Free also caps at 3,000 / month) | 100 / day (Free tier limited to 100 sends/day) |
 | Entry paid plan | $10 / mo (25,000 emails included) | $20 / mo (50,000 emails included (no $10 tier)) |
 | 50,000 emails / mo plan | $20 / mo | $20 / mo |
-| Overage rate (per 1k emails) | $0.80 / 1k | $1.00 / 1k |
+| Overage rate (per 1k emails) | $0.80 / 1k | $0.90 / 1k |
 | Self-hosted email sends | Unlimited (Free open-source software (own infra)) | N/A (Hosted SaaS only; pay per send) |
 
 ## Sending & Receiving
@@ -258,7 +258,7 @@ No. Reloop is not a Resend proxy. Plan a small client adapter when migrating. Au
 
 ### Is Reloop open source?
 
-Yes. Reloop is Apache 2.0 with Reloop Labs use restrictions. Self-host at no Reloop license fee, or use Reloop Cloud.
+Yes. Reloop is licensed under Apache License 2.0 plus additional Reloop Labs terms: personal and internal self-host is allowed; commercial redistribution, third-party hosted services, and competing products are not. See https://reloop.sh/license. Reloop Cloud is the official hosted service.
 
 ## Related
 
@@ -618,7 +618,7 @@ Markdown: https://reloop.sh/index.md
 
 > High-performance, open-source email infrastructure—the same service as proprietary platforms. Use Reloop hosted or deploy it yourself.
 
-Reloop is email infrastructure for developers: transactional and marketing email, real-time webhooks, inbound processing, analytics, and an agent-ready API. Reloop **is** the ESP/MTA (KumoMTA), not a connector that routes through SendGrid, Mailgun, Resend, or SES.
+Reloop is email infrastructure for developers: transactional and marketing email, real-time webhooks, inbound processing, analytics, and an agent-ready API. Reloop **is** the ESP; it runs an in-house MTA (KumoMTA), not a connector that routes through SendGrid, Mailgun, Resend, or SES.
 
 ## What Reloop is not
 
@@ -636,8 +636,8 @@ Developers, startups, and agent products that need transactional + campaign emai
 Canonical data: https://reloop.sh/pricing.md
 
 - Free — $0, 3,000 emails / month, **200 / day**
-- Individual — $10 / month, 25,000 emails, no daily cap, overage $0.80 / 1k
-- Startup — $20 / month, 50,000 emails, no daily cap
+- Individual — $10 / month, 25,000 emails / month, no daily cap, overage $0.80 / 1,000
+- Startup — $20 / month, 50,000 emails / month, no daily cap, overage $0.80 / 1,000
 - Enterprise — custom volume and billing
 
 ## Why Reloop
@@ -682,7 +682,7 @@ Reloop Labs builds open-source email infrastructure for developers and AI agents
 ## What we build
 
 - Hosted Reloop Cloud (email API and SMTP) at reloop.sh
-- Self-hostable Apache 2.0 stack (no Reloop license fee; you pay your infra)
+- Self-hostable Apache License 2.0 stack plus Reloop Labs additional restrictions: personal and internal use allowed; no commercial redistribution, hosted services, or competing products. No Reloop license fee; you pay your infra. See https://reloop.sh/license
 - Agent skills, MCP server, and agent-friendly documentation
 
 ## Who it is for

--- a/apps/frontend/web/public/llms.txt
+++ b/apps/frontend/web/public/llms.txt
@@ -1,18 +1,69 @@
 # Reloop
 
-> Reloop is high-performance, open-source email infrastructure for developers—transactional and marketing email, SMTP, webhooks, analytics, and agent-ready APIs. Use Reloop hosted or self-host.
+> Reloop is high-performance, open-source email infrastructure for developers—transactional and marketing email, SMTP, webhooks, analytics, and agent-ready APIs. Use Reloop hosted (Reloop Cloud) or self-host.
 
 Important notes:
 
 - Authentication uses the `x-api-key` header with API keys prefixed with `rl_`
-- Prefer markdown: append `.md` where available (blog, pricing, docs)
+- Prefer markdown: append `.md` where available (blog, pricing, compare, docs)
 - **All agent discovery files are hosted on this site (web)** — not under the docs app
 - Product HTML docs still live under `/docs/*` with `.md` twins for page content
+- Canonical hosted pricing: [pricing.md](https://reloop.sh/pricing.md) (generated from `@reloop/pricing`)
+- License: Apache 2.0 with Reloop Labs use restrictions — not MIT
+
+## What Reloop is
+
+Reloop is the email service / infrastructure (ESP + MTA). It sends and receives mail over REST and SMTP, runs its own MTA (KumoMTA), verifies domains (SPF/DKIM/DMARC), delivers webhooks, and includes an agent inbox for inbound mail.
+
+## What Reloop is not
+
+- Not a multi-ESP connector or router that sits on SendGrid, Mailgun, Resend, or Amazon SES
+- Not a contact-list marketing tool that bills by stored subscribers (pricing is send-based on Reloop Cloud)
+- Not MIT-licensed
+- Not a paid self-host SaaS SKU — self-host is the Apache 2.0 codebase; you pay your own servers, not Reloop Cloud tiers
+
+## Who it is for (ICP)
+
+- Developers and startups sending transactional email (auth, receipts, alerts) plus campaigns from one API
+- Teams that want to self-host or keep a credible exit from a hosted ESP
+- Agent / AI products that need inbound email (agent inbox) and machine-readable docs (llms.txt, MCP, `.md` twins)
+- Teams comparing Reloop to Resend, SendGrid, Mailgun, Postmark, AWS SES, Loops, or Mailchimp
+
+## Differentiators
+
+- Apache 2.0 codebase, same product hosted or self-hosted
+- Own MTA (KumoMTA) rather than a DX layer over another ESP
+- Send-based Reloop Cloud pricing (not contact-list pricing)
+- Agent inbox + MCP + markdown corpora for coding agents
+
+## Hosted pricing snapshot (Reloop Cloud)
+
+| Plan | Price | Volume | Daily cap |
+|------|-------|--------|-----------|
+| Free | $0 | 3,000 emails / month | 200 / day |
+| Individual | $10 / month | 25,000 emails / month | None |
+| Startup | $20 / month | 50,000 emails / month | None |
+| Enterprise | Custom | Custom | None |
+
+Paid overage: $0.80 / 1,000 emails. Self-host: no Reloop license fee. Full tables: [pricing.md](https://reloop.sh/pricing.md)
+
+## Competitors (compare pages)
+
+Prefer `.md` twins. Reloop Free is **3,000 / month and 200 / day** — do not cite “no daily limit” for Free.
+
+- [Reloop vs Resend](https://reloop.sh/compare/resend.md)
+- [Reloop vs SendGrid](https://reloop.sh/compare/sendgrid.md)
+- [Reloop vs Mailgun](https://reloop.sh/compare/mailgun.md)
+- [Reloop vs AWS SES](https://reloop.sh/compare/aws-ses.md)
+- [Reloop vs Postmark](https://reloop.sh/compare/postmark.md)
+- [Reloop vs Loops](https://reloop.sh/compare/loops.md)
+- [Reloop vs Mailchimp](https://reloop.sh/compare/mailchimp.md)
+- [Compare index](https://reloop.sh/compare.md)
 
 ## Agent discovery (source of truth)
 
 - [Site index](https://reloop.sh/llms.txt): This file
-- [Marketing corpus](https://reloop.sh/llms-full.txt): Home, pricing, agent pages, published blog
+- [Marketing corpus](https://reloop.sh/llms-full.txt): Home, pricing, compare, agent pages, published blog
 - [Docs index](https://reloop.sh/llms-docs.txt): Curated API, learn, and integration map
 - [Docs full corpus](https://reloop.sh/llms-full-docs.txt): Full documentation snapshot
 - [Product skill](https://reloop.sh/skill.md): Capabilities, auth, constraints
@@ -31,18 +82,22 @@ Important notes:
 - [Features](https://reloop.sh/features)
 - [Blog](https://reloop.sh/blog)
 - [Changelog](https://reloop.sh/changelog)
-- [Compare](https://reloop.sh/compare)
+- [Compare](https://reloop.sh/compare) · [markdown](https://reloop.sh/compare.md)
 - [Glossary](https://reloop.sh/glossary)
 - [Contact](https://reloop.sh/contact)
+- [License](https://reloop.sh/license)
 
 ## Product documentation (HTML + .md under /docs)
 
-Prefer [llms-docs.txt](https://reloop.sh/llms-docs.txt) for the full map. High-signal entry points:
+Prefer [llms-docs.txt](https://reloop.sh/llms-docs.txt) for the full map. Hosted plans live on the marketing site, not in the generic docs pricing stub.
+
+High-signal entry points:
 
 - [API Keys (agent)](https://reloop.sh/docs/learn/ai/api-keys.md)
 - [Introduction](https://reloop.sh/docs/introduction.md)
 - [API reference](https://reloop.sh/docs/api.md)
 - [MCP server guide](https://reloop.sh/docs/integrations/ai-tools/mcp-server)
+- [Docs pricing (points at canonical plans)](https://reloop.sh/docs/guides/pricing.md)
 
 ## Blog (published; prefer `/blog/<slug>.md`)
 

--- a/apps/frontend/web/public/pricing.md
+++ b/apps/frontend/web/public/pricing.md
@@ -79,7 +79,7 @@
 
 ## Self-host
 
-Self-hosting the open-source Reloop stack is free (infrastructure costs are yours).
+Self-hosting the open-source Reloop stack has no Reloop license fee (infrastructure costs are yours). It is not a Reloop Cloud subscription and does not use the hosted Free / Individual / Startup / Enterprise price list.
 See https://reloop.sh/self-host
 
 ## Related

--- a/apps/frontend/web/public/skill.md
+++ b/apps/frontend/web/public/skill.md
@@ -5,7 +5,7 @@ description: >
   send mail, manage API keys, domains, contacts, webhooks, and templates.
   Use when integrating Reloop, creating or rotating API keys, or sending
   transactional email via API or SMTP.
-license: Apache-2.0
+license: "Apache-2.0 plus Reloop Labs restrictions (personal/internal use; no commercial redistribution, hosted services, or competing products). See https://reloop.sh/license"
 metadata:
   author: reloop-labs
   docs: https://reloop.sh/docs

--- a/apps/frontend/web/public/skill.md
+++ b/apps/frontend/web/public/skill.md
@@ -5,7 +5,7 @@ description: >
   send mail, manage API keys, domains, contacts, webhooks, and templates.
   Use when integrating Reloop, creating or rotating API keys, or sending
   transactional email via API or SMTP.
-license: MIT
+license: Apache-2.0
 metadata:
   author: reloop-labs
   docs: https://reloop.sh/docs
@@ -18,6 +18,8 @@ metadata:
 # Reloop
 
 Reloop is email infrastructure for developers: transactional and marketing email, real-time webhooks, inbound processing, and analytics. SDKs cover Node.js, Python, PHP, Ruby, Go, Rust, Java, .NET, and a CLI.
+
+License: Apache 2.0 with Reloop Labs use restrictions (not MIT). Canonical hosted pricing: https://reloop.sh/pricing.md
 
 ## Documentation index
 

--- a/apps/frontend/web/src/app/(home)/components/convictions.tsx
+++ b/apps/frontend/web/src/app/(home)/components/convictions.tsx
@@ -190,7 +190,7 @@ const values = [
 	{
 		icon: "graph-up",
 		title: "Cost Efficiency",
-		description: "Send-based hosted pricing from $10 / 25k emails; $0.80 / 1k overage.",
+		description: "Send-based hosted pricing from $10/month for 25k emails/month; $0.80 per 1k emails.",
 		widget: <MicroCost />,
 	},
 	{

--- a/apps/frontend/web/src/app/(home)/components/convictions.tsx
+++ b/apps/frontend/web/src/app/(home)/components/convictions.tsx
@@ -190,7 +190,7 @@ const values = [
 	{
 		icon: "graph-up",
 		title: "Cost Efficiency",
-		description: "10x lower volume cost vs legacy email providers.",
+		description: "Send-based hosted pricing from $10 / 25k emails; $0.80 / 1k overage.",
 		widget: <MicroCost />,
 	},
 	{

--- a/apps/frontend/web/src/app/(home)/page.tsx
+++ b/apps/frontend/web/src/app/(home)/page.tsx
@@ -1,4 +1,5 @@
 import { JsonLd } from "@reloop/web/components/json-ld";
+import { pricingSoftwareApplicationJsonLd } from "@reloop/web/lib/schema";
 import {
 	defaultOgImage,
 	getSiteUrl,
@@ -37,19 +38,7 @@ const homeSchema = [
 		logo: `${siteUrl}${defaultOgImage}`,
 		sameAs: [socialProfiles.github, socialProfiles.x, socialProfiles.discord],
 	},
-	{
-		"@context": "https://schema.org" as const,
-		"@type": "SoftwareApplication" as const,
-		name: siteName,
-		operatingSystem: "All",
-		applicationCategory: "DeveloperApplication",
-		description: siteDescription,
-		offers: {
-			"@type": "Offer" as const,
-			price: "0",
-			priceCurrency: "USD",
-		},
-	},
+	pricingSoftwareApplicationJsonLd(siteUrl),
 ];
 
 export default function Home() {

--- a/apps/frontend/web/src/app/compare/aws-ses/page.tsx
+++ b/apps/frontend/web/src/app/compare/aws-ses/page.tsx
@@ -1,8 +1,10 @@
 import { FaqSection } from "@reloop/web/components/faq-section";
 import { PageSection, SectionHeading } from "@reloop/web/components/page-shell";
+import { awsSesFeatures, getComparePage } from "@reloop/web/lib/compare-content";
 import { getSiteUrl } from "@reloop/web/lib/site";
 import type { Metadata } from "next";
 import Link from "next/link";
+import { ComparePageJsonLd } from "../components/compare-json-ld";
 import { CompareOtherLinks } from "../components/compare-other-links";
 import { ComparisonPageShell } from "../components/comparison-page-shell";
 import { ComparisonTable } from "../components/comparison-table";
@@ -43,12 +45,15 @@ export const metadata: Metadata = {
 };
 
 const AwsSesComparisonPage = () => {
+	const compare = getComparePage("aws-ses");
 	return (
-		<ComparisonPageShell
-			pagePath={pagePath}
-			titleLines={["Reloop vs AWS SES"]}
-			description="Learn how Reloop compares to Amazon SES and why Reloop is the best SES alternative for all your email delivery and platform needs."
-		>
+		<>
+			<ComparePageJsonLd slug="aws-ses" />
+			<ComparisonPageShell
+				pagePath={pagePath}
+				titleLines={["Reloop vs AWS SES"]}
+				description="Learn how Reloop compares to Amazon SES and why Reloop is the best SES alternative for all your email delivery and platform needs."
+			>
 			<PageSection flushTop narrow>
 				<div className="mx-auto max-w-3xl space-y-6 text-[15px] text-text-sub-600 leading-7 sm:text-[17px] dark:text-white/50">
 					<p>
@@ -109,45 +114,7 @@ const AwsSesComparisonPage = () => {
 				<SectionHeading title="SES vs Reloop capabilities" compact />
 				<ComparisonTable
 					competitorName="AWS SES"
-					features={[
-						{
-							label: "Open-source platform",
-							reloop: "Yes (Apache 2.0)",
-							competitor: "No",
-						},
-						{
-							label: "Self-host on your AWS account",
-							reloop: "Yes",
-							competitor: "SES only",
-						},
-						{
-							label: "Marketing campaigns UI",
-							reloop: "Yes",
-							competitor: "No (DIY)",
-						},
-						{ label: "Transactional API", reloop: "Yes", competitor: "Yes" },
-						{
-							label: "Built-in delivery dashboard",
-							reloop: "Yes",
-							competitor: "CloudWatch / DIY",
-						},
-						{
-							label: "Webhooks",
-							reloop: "Native",
-							competitor: "SNS configuration",
-						},
-						{
-							label: "Template management",
-							reloop: "Yes",
-							competitor: "Limited",
-						},
-						{ label: "Agent inbox", reloop: "Yes", competitor: "No" },
-						{
-							label: "Per-email list price",
-							reloop: "Tier bundles",
-							competitor: "Very low at scale",
-						},
-					]}
+					features={awsSesFeatures}
 				/>
 			</PageSection>
 
@@ -174,23 +141,7 @@ const AwsSesComparisonPage = () => {
 			<FaqSection
 				id="compare-aws-ses-faq"
 				title="AWS SES vs Reloop FAQ"
-				items={[
-					{
-						question: "Is Reloop cheaper than SES at 10M emails/month?",
-						answer:
-							"SES raw sending is often cheaper at extreme volume. Reloop competes on platform TCO—engineering time, campaign tooling, support, and unified ops—not on being the cheapest SMTP pipe.",
-					},
-					{
-						question: "Can we migrate boto3 sends to Reloop?",
-						answer:
-							"Yes. Replace AWS SDK send calls with Reloop REST or SMTP. Map SNS bounce notifications to Reloop webhook endpoints.",
-					},
-					{
-						question: "Do we need both SES and Reloop?",
-						answer:
-							"Not usually. Self-hosted Reloop includes outbound delivery. Some teams keep SES as an MTA backend during transition—that is an advanced integration, not the default path.",
-					},
-				]}
+				items={compare?.faqs ?? []}
 				compact
 			/>
 
@@ -198,6 +149,7 @@ const AwsSesComparisonPage = () => {
 				<CompareOtherLinks currentHref={pagePath} />
 			</PageSection>
 		</ComparisonPageShell>
+		</>
 	);
 };
 

--- a/apps/frontend/web/src/app/compare/compare-types.ts
+++ b/apps/frontend/web/src/app/compare/compare-types.ts
@@ -1,0 +1,28 @@
+export type ComparisonCell =
+	| string
+	| {
+			value: string;
+			note?: string;
+	  };
+
+export interface ComparisonFeatureRow {
+	label: string;
+	icon?: string;
+	reloop: ComparisonCell;
+	competitor: ComparisonCell;
+}
+
+export type ComparisonCategory = {
+	id: string;
+	label: string;
+	icon?: string;
+	intro?: string;
+	features: ComparisonFeatureRow[];
+};
+
+export function comparisonCellText(cell: ComparisonCell): string {
+	if (typeof cell === "string") {
+		return cell;
+	}
+	return cell.note ? `${cell.value} (${cell.note})` : cell.value;
+}

--- a/apps/frontend/web/src/app/compare/components/compare-calculator.tsx
+++ b/apps/frontend/web/src/app/compare/components/compare-calculator.tsx
@@ -4,6 +4,7 @@ import { cn } from "@reloop/ui/cn";
 import { Logo } from "@reloop/ui/logo";
 import Link from "next/link";
 import { useState } from "react";
+import { hostedMonthlyUsdForVolume } from "@reloop/web/lib/pricing";
 import { competitorBrands } from "../competitor-brands";
 import { BrandIcon } from "./brand-icon";
 
@@ -35,9 +36,7 @@ interface CostsResult {
 }
 
 function calculateTransactionalCost(emails: number): CostsResult {
-	// Reloop Cloud ($0 up to 10k, $0.10 per 1,000 emails after)
-	const reloopCloud =
-		emails <= 10000 ? 0 : Math.round(((emails - 10000) / 1000) * 0.1);
+	const reloopCloud = hostedMonthlyUsdForVolume(emails);
 	const reloopSelfHosted = 0;
 
 	// Resend Transactional Tiers
@@ -84,11 +83,7 @@ function calculateMarketingCost(contacts: number): CostsResult {
 	// Average sending cadence: ~2 broadcasts/mo to the audience contact list
 	const monthlySends = contacts * 2;
 
-	// Reloop charges $0 contact storage fee. Pure pay-per-send ($0.10/1k sends)
-	const reloopCloud =
-		monthlySends <= 10000
-			? 0
-			: Math.round(((monthlySends - 10000) / 1000) * 0.1);
+	const reloopCloud = hostedMonthlyUsdForVolume(monthlySends);
 	const reloopSelfHosted = 0;
 
 	// Resend Audiences & Contacts Tiered Pricing

--- a/apps/frontend/web/src/app/compare/components/compare-hero-header.tsx
+++ b/apps/frontend/web/src/app/compare/components/compare-hero-header.tsx
@@ -9,9 +9,9 @@ export function CompareHeroHeader() {
 				</h1>
 
 				<p className="mt-4 max-w-2xl text-[15px] text-text-sub-600 leading-relaxed sm:text-[16px] dark:text-white/60">
-					Compare Reloop against leading email service providers. Learn how
-					Reloop delivers 10x lower costs, open-source transparency, and unified
-					email infrastructure.
+					Compare Reloop against leading email service providers. Reloop is
+					open-source email infrastructure with send-based Reloop Cloud pricing
+					and a self-host path.
 				</p>
 			</div>
 

--- a/apps/frontend/web/src/app/compare/components/compare-interactive-spotlight.tsx
+++ b/apps/frontend/web/src/app/compare/components/compare-interactive-spotlight.tsx
@@ -25,12 +25,12 @@ const SPOTLIGHT_DATA: Record<string, ProviderSnapshot> = {
 		href: "/compare/resend",
 		tagline: "Modern UI email API, but proprietary & gets expensive at scale",
 		keyDiff:
-			"Reloop provides open-source transparency (KumoMTA engine), 10x lower volume cost, and built-in AI agent inboxes.",
+			"Reloop provides open-source transparency (KumoMTA), send-based Reloop Cloud pricing, and a built-in agent inbox.",
 		reloopAdvantages: [
 			"100% Open source core (KumoMTA)",
 			"Built-in AI agent inbox & email parsing",
 			"Self-host anywhere or use Reloop Cloud",
-			"10x lower overage costs at high volume",
+			"Overage $0.80 / 1k vs Resend $1.00 / 1k",
 		],
 		competitorDrawbacks: [
 			"Closed-source proprietary backend",
@@ -38,7 +38,10 @@ const SPOTLIGHT_DATA: Record<string, ProviderSnapshot> = {
 			"Costs escalate rapidly above 100k emails/mo",
 			"Requires third-party tools for inbound AI logic",
 		],
-		freeTier: { reloop: "10,000 emails / mo", competitor: "3,000 emails / mo" },
+		freeTier: {
+			reloop: "3,000 / mo · 200 / day",
+			competitor: "3,000 emails / mo",
+		},
 		openSource: {
 			reloop: "Yes (KumoMTA Engine)",
 			competitor: "No (Proprietary)",
@@ -63,7 +66,10 @@ const SPOTLIGHT_DATA: Record<string, ProviderSnapshot> = {
 			"Strict account locks & slow support",
 			"Expensive dedicated IP add-ons",
 		],
-		freeTier: { reloop: "10,000 emails / mo", competitor: "100 emails / day" },
+		freeTier: {
+			reloop: "3,000 / mo · 200 / day",
+			competitor: "100 emails / day",
+		},
 		openSource: {
 			reloop: "Yes (KumoMTA Engine)",
 			competitor: "No (Closed Source)",
@@ -88,7 +94,7 @@ const SPOTLIGHT_DATA: Record<string, ProviderSnapshot> = {
 			"Separate tools needed for marketing campaigns",
 			"No open source option",
 		],
-		freeTier: { reloop: "10,000 emails / mo", competitor: "Trial only" },
+		freeTier: { reloop: "3,000 / mo · 200 / day", competitor: "Trial only" },
 		openSource: { reloop: "Yes (KumoMTA Engine)", competitor: "No" },
 		inboundAi: { reloop: "Built-in Agent Inbox", competitor: "Basic Routes" },
 	},
@@ -110,7 +116,10 @@ const SPOTLIGHT_DATA: Record<string, ProviderSnapshot> = {
 			"Zero built-in AI agent inbox capabilities",
 			"No out-of-the-box marketing campaign tools",
 		],
-		freeTier: { reloop: "10,000 emails / mo", competitor: "62k/mo (EC2 only)" },
+		freeTier: {
+			reloop: "3,000 / mo · 200 / day",
+			competitor: "62k/mo (EC2 only)",
+		},
 		openSource: { reloop: "Yes (KumoMTA Engine)", competitor: "No" },
 		inboundAi: {
 			reloop: "Built-in Agent Inbox",
@@ -135,7 +144,10 @@ const SPOTLIGHT_DATA: Record<string, ProviderSnapshot> = {
 			"No open-source options",
 			"No native AI capabilities",
 		],
-		freeTier: { reloop: "10,000 emails / mo", competitor: "100 emails / mo" },
+		freeTier: {
+			reloop: "3,000 / mo · 200 / day",
+			competitor: "100 emails / mo",
+		},
 		openSource: { reloop: "Yes (KumoMTA Engine)", competitor: "No" },
 		inboundAi: { reloop: "Built-in Agent Inbox", competitor: "Basic Webhooks" },
 	},
@@ -157,7 +169,7 @@ const SPOTLIGHT_DATA: Record<string, ProviderSnapshot> = {
 			"No self-hosting or data sovereignty options",
 			"Gets expensive quickly for high contact volume",
 		],
-		freeTier: { reloop: "10,000 emails / mo", competitor: "1,000 contacts" },
+		freeTier: { reloop: "3,000 / mo · 200 / day", competitor: "1,000 contacts" },
 		openSource: { reloop: "Yes (KumoMTA Engine)", competitor: "No" },
 		inboundAi: { reloop: "Built-in Agent Inbox", competitor: "No" },
 	},
@@ -180,7 +192,7 @@ const SPOTLIGHT_DATA: Record<string, ProviderSnapshot> = {
 			"Expensive monthly contact tier locks",
 		],
 		freeTier: {
-			reloop: "10,000 emails / mo",
+			reloop: "3,000 / mo · 200 / day",
 			competitor: "500 contacts limit",
 		},
 		openSource: { reloop: "Yes (KumoMTA Engine)", competitor: "No" },

--- a/apps/frontend/web/src/app/compare/components/compare-interactive-spotlight.tsx
+++ b/apps/frontend/web/src/app/compare/components/compare-interactive-spotlight.tsx
@@ -30,7 +30,7 @@ const SPOTLIGHT_DATA: Record<string, ProviderSnapshot> = {
 			"100% Open source core (KumoMTA)",
 			"Built-in AI agent inbox & email parsing",
 			"Self-host anywhere or use Reloop Cloud",
-			"Overage $0.80 / 1k vs Resend $1.00 / 1k",
+			"Overage $0.80 / 1k vs Resend $0.90 / 1k",
 		],
 		competitorDrawbacks: [
 			"Closed-source proprietary backend",
@@ -40,7 +40,7 @@ const SPOTLIGHT_DATA: Record<string, ProviderSnapshot> = {
 		],
 		freeTier: {
 			reloop: "3,000 / mo · 200 / day",
-			competitor: "3,000 emails / mo",
+			competitor: "3,000 emails / mo · 100 / day",
 		},
 		openSource: {
 			reloop: "Yes (KumoMTA Engine)",

--- a/apps/frontend/web/src/app/compare/components/compare-json-ld.tsx
+++ b/apps/frontend/web/src/app/compare/components/compare-json-ld.tsx
@@ -1,0 +1,32 @@
+import { JsonLd } from "@reloop/web/components/json-ld";
+import {
+	buildCompareJsonLd,
+	getComparePage,
+} from "@reloop/web/lib/compare-content";
+import { pricingProductJsonLd } from "@reloop/web/lib/schema";
+import { getSiteUrl } from "@reloop/web/lib/site";
+
+export function ComparePageJsonLd({ slug }: { slug: string }) {
+	const page = getComparePage(slug);
+	if (!page) return null;
+	return <JsonLd data={buildCompareJsonLd(page)} />;
+}
+
+export function CompareIndexJsonLd() {
+	const siteUrl = getSiteUrl();
+	return (
+		<JsonLd
+			data={[
+				{
+					"@context": "https://schema.org",
+					"@type": "CollectionPage",
+					name: "Reloop vs the competition",
+					description:
+						"Compare Reloop with Resend, SendGrid, Mailgun, AWS SES, Postmark, Loops, and Mailchimp.",
+					url: `${siteUrl}/compare`,
+				},
+				pricingProductJsonLd(siteUrl),
+			]}
+		/>
+	);
+}

--- a/apps/frontend/web/src/app/compare/components/compare-master-matrix.tsx
+++ b/apps/frontend/web/src/app/compare/components/compare-master-matrix.tsx
@@ -112,7 +112,7 @@ const MASTER_CATEGORIES: MatrixCategory[] = [
 			{
 				feature: "Free Tier Allowance",
 				detail: "Free monthly sending credit",
-				reloop: "10,000 / mo",
+				reloop: "3,000 / mo · 200 / day",
 				resend: "3,000 / mo",
 				sendgrid: "100 / day",
 				postmark: "100 / mo",
@@ -120,8 +120,8 @@ const MASTER_CATEGORIES: MatrixCategory[] = [
 			},
 			{
 				feature: "Cost per 100,000 Emails",
-				detail: "Standard cloud sending cost",
-				reloop: "$9.00",
+				detail: "Hosted Reloop Startup ($20) + $0.80/1k overage",
+				reloop: "$60",
 				resend: "$90.00",
 				sendgrid: "$89.95",
 				postmark: "$115.00",
@@ -130,7 +130,7 @@ const MASTER_CATEGORIES: MatrixCategory[] = [
 			{
 				feature: "Dedicated IP Pricing",
 				detail: "Monthly dedicated IP cost",
-				reloop: "Included on Pro",
+				reloop: "Enterprise (optional)",
 				resend: "$30 / mo",
 				sendgrid: "$30 / mo",
 				postmark: "$50 / mo",

--- a/apps/frontend/web/src/app/compare/components/comparison-grid.tsx
+++ b/apps/frontend/web/src/app/compare/components/comparison-grid.tsx
@@ -17,7 +17,7 @@ function isDarkBrandHex(hex: string) {
 
 const BRAND_DESCRIPTIONS: Record<string, string> = {
 	Resend:
-		"10x lower volume costs, 100% open-source engine, and built-in AI agent inboxes.",
+		"Apache 2.0 engine, send-based Reloop Cloud pricing, and a built-in agent inbox.",
 	SendGrid:
 		"Modern React/JSX templates and fast developer UI without legacy enterprise clutter.",
 	Mailgun:

--- a/apps/frontend/web/src/app/compare/loops/comparison-data.ts
+++ b/apps/frontend/web/src/app/compare/loops/comparison-data.ts
@@ -1,4 +1,4 @@
-import type { ComparisonCategory } from "../components/comparison-matrix";
+import type { ComparisonCategory } from "../compare-types";
 
 /**
  * Feature matrix for Reloop vs Loops.
@@ -27,13 +27,19 @@ export const loopsComparisonCategories: ComparisonCategory[] = [
 			{
 				label: "Free monthly tier",
 				icon: "send-2",
-				reloop: "10,000 emails / mo",
+				reloop: {
+					value: "3,000 emails / mo",
+					note: "200 / day cap",
+				},
 				competitor: "1,000 contacts",
 			},
 			{
-				label: "10,000 volume plan",
+				label: "Entry paid plan",
 				icon: "invoice",
-				reloop: "$10 / mo",
+				reloop: {
+					value: "$10 / mo",
+					note: "25,000 emails included",
+				},
 				competitor: "$49 / mo (10k contacts)",
 			},
 			{

--- a/apps/frontend/web/src/app/compare/loops/loops-cost-calculator.tsx
+++ b/apps/frontend/web/src/app/compare/loops/loops-cost-calculator.tsx
@@ -3,24 +3,26 @@
 import { cn } from "@reloop/ui/cn";
 import { Logo } from "@reloop/ui/logo";
 import { useState } from "react";
+import { hostedMonthlyUsdForVolume } from "@reloop/web/lib/pricing";
 import { competitorBrands } from "../competitor-brands";
 import { BrandIcon } from "../components/brand-icon";
 
 const CONTACT_TIERS = [
-	{ contacts: 5000, loops: 49, reloop: 10, emailsSentEstimate: 15000 },
-	{ contacts: 10000, loops: 49, reloop: 10, emailsSentEstimate: 25000 },
-	{ contacts: 25000, loops: 99, reloop: 20, emailsSentEstimate: 50000 },
-	{ contacts: 50000, loops: 199, reloop: 20, emailsSentEstimate: 75000 },
-	{ contacts: 100000, loops: 399, reloop: 45, emailsSentEstimate: 150000 },
+	{ contacts: 5000, loops: 49, emailsSentEstimate: 15000 },
+	{ contacts: 10000, loops: 49, emailsSentEstimate: 25000 },
+	{ contacts: 25000, loops: 99, emailsSentEstimate: 50000 },
+	{ contacts: 50000, loops: 199, emailsSentEstimate: 75000 },
+	{ contacts: 100000, loops: 399, emailsSentEstimate: 150000 },
 ];
 
 export function LoopsCostCalculator() {
 	const [selectedTierIndex, setSelectedTierIndex] = useState<number>(2); // Default 25k contacts
 
 	const current = CONTACT_TIERS[selectedTierIndex] ?? CONTACT_TIERS[2]!;
+	const reloopCost = hostedMonthlyUsdForVolume(current.emailsSentEstimate);
 	const loopsIcon = competitorBrands.find((b) => b.name === "Loops")?.icon;
 
-	const annualSavings = (current.loops - current.reloop) * 12;
+	const annualSavings = (current.loops - reloopCost) * 12;
 	const formatNum = (n: number) => new Intl.NumberFormat("en-US").format(n);
 
 	return (
@@ -101,7 +103,7 @@ export function LoopsCostCalculator() {
 							</div>
 							<div className="text-right">
 								<span className="font-bold font-mono text-[2rem] text-text-strong-950 dark:text-white">
-									${current.reloop}
+									${reloopCost}
 								</span>
 								<span className="text-[12px] text-text-sub-600 dark:text-white/40">
 									/mo

--- a/apps/frontend/web/src/app/compare/loops/page.tsx
+++ b/apps/frontend/web/src/app/compare/loops/page.tsx
@@ -1,9 +1,11 @@
 import { FaqSection } from "@reloop/web/components/faq-section";
+import { getComparePage } from "@reloop/web/lib/compare-content";
 import { getSiteUrl } from "@reloop/web/lib/site";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { competitorBrands } from "../competitor-brands";
 import { CompareHeroStatStrip } from "../components/compare-hero-stat-strip";
+import { ComparePageJsonLd } from "../components/compare-json-ld";
 import { CompareMigrate } from "../components/compare-migrate";
 import { CompareOtherLinks } from "../components/compare-other-links";
 import { CompareSection } from "../components/compare-section";
@@ -73,21 +75,24 @@ const loopsStats = [
 
 const LoopsComparisonPage = () => {
 	const loopsBrand = competitorBrands.find((b) => b.name === "Loops");
+	const compare = getComparePage("loops");
 
 	return (
-		<ComparisonPageShell
-			pagePath={pagePath}
-			titleLines={["Reloop vs Loops"]}
-			description="Loops is great for simple onboarding loops—until engineering needs password resets, billing receipts, and raw API sends. Reloop unifies product email and transactional infrastructure into one open-source platform."
-			primaryCta={{
-				label: "Get Started ",
-				href: "/dashboard/signup",
-			}}
-			secondaryCta={{
-				label: "Migrate from Loops",
-				href: "/compare/loops#migrate",
-			}}
-		>
+		<>
+			<ComparePageJsonLd slug="loops" />
+			<ComparisonPageShell
+				pagePath={pagePath}
+				titleLines={["Reloop vs Loops"]}
+				description="Loops is great for simple onboarding loops—until engineering needs password resets, billing receipts, and raw API sends. Reloop unifies product email and transactional infrastructure into one open-source platform."
+				primaryCta={{
+					label: "Get Started ",
+					href: "/dashboard/signup",
+				}}
+				secondaryCta={{
+					label: "Migrate from Loops",
+					href: "/compare/loops#migrate",
+				}}
+			>
 			{/* Metric Stat Strip */}
 			<CompareSection flushTop maxWidth="full">
 				<CompareHeroStatStrip stats={loopsStats} />
@@ -210,25 +215,7 @@ const LoopsComparisonPage = () => {
 				<FaqSection
 					id="compare-loops-faq"
 					title="Loops vs Reloop FAQ"
-					items={[
-						{
-							question:
-								"Why should we choose send-based pricing over contact-based pricing?",
-							answer:
-								"Contact-based pricing charges you for inactive leads and users who never open your emails. Reloop's send-based pricing ensures you only pay when emails are delivered.",
-						},
-						{
-							question:
-								"Can Reloop handle both marketing campaigns and transactional APIs?",
-							answer:
-								"Yes! Reloop includes transactional API endpoints, SMTP relays, drag-and-drop/JSX email template builders, broadcast campaigns, and AI agent inboxes under one unified platform.",
-						},
-						{
-							question: "Can we self-host Reloop while migrating from Loops?",
-							answer:
-								"Absolutely. Reloop is 100% open source (KumoMTA engine). You can deploy Reloop on your own Kubernetes or Docker infrastructure with $0 software license fees.",
-						},
-					]}
+					items={compare?.faqs ?? []}
 					compact
 				/>
 			</CompareSection>
@@ -237,6 +224,7 @@ const LoopsComparisonPage = () => {
 				<CompareOtherLinks currentHref={pagePath} />
 			</CompareSection>
 		</ComparisonPageShell>
+		</>
 	);
 };
 

--- a/apps/frontend/web/src/app/compare/mailchimp/page.tsx
+++ b/apps/frontend/web/src/app/compare/mailchimp/page.tsx
@@ -1,8 +1,13 @@
 import { FaqSection } from "@reloop/web/components/faq-section";
 import { PageSection, SectionHeading } from "@reloop/web/components/page-shell";
+import {
+	getComparePage,
+	mailchimpFeatures,
+} from "@reloop/web/lib/compare-content";
 import { getSiteUrl } from "@reloop/web/lib/site";
 import type { Metadata } from "next";
 import Link from "next/link";
+import { ComparePageJsonLd } from "../components/compare-json-ld";
 import { CompareOtherLinks } from "../components/compare-other-links";
 import { ComparisonPageShell } from "../components/comparison-page-shell";
 import { ComparisonTable } from "../components/comparison-table";
@@ -43,12 +48,15 @@ export const metadata: Metadata = {
 };
 
 const MailchimpComparisonPage = () => {
+	const compare = getComparePage("mailchimp");
 	return (
-		<ComparisonPageShell
-			pagePath={pagePath}
-			titleLines={["Reloop vs Mailchimp"]}
-			description="Learn how Reloop compares to Mailchimp and why Reloop is the best Mailchimp alternative for all your product and marketing email needs."
-		>
+		<>
+			<ComparePageJsonLd slug="mailchimp" />
+			<ComparisonPageShell
+				pagePath={pagePath}
+				titleLines={["Reloop vs Mailchimp"]}
+				description="Learn how Reloop compares to Mailchimp and why Reloop is the best Mailchimp alternative for all your product and marketing email needs."
+			>
 			<PageSection flushTop narrow>
 				<div className="mx-auto max-w-3xl space-y-6 text-[15px] text-text-sub-600 leading-7 sm:text-[17px] dark:text-white/50">
 					<p>
@@ -91,9 +99,9 @@ const MailchimpComparisonPage = () => {
 							Reloop model
 						</h3>
 						<p className="mt-3 text-[14px] text-text-sub-600 leading-relaxed dark:text-white/60">
-							3,000 emails free, then tiers by monthly sends (50k, 250k,
-							custom). Store contacts for segmentation without audience-based
-							surcharges. See{" "}
+							3,000 emails free (200/day), then Individual $10/mo (25,000),
+							Startup $20/mo (50,000), Enterprise custom. Store contacts for
+							segmentation without audience-based surcharges. See{" "}
 							<Link href="/pricing" className="font-semibold text-primary-base">
 								pricing details
 							</Link>
@@ -106,41 +114,7 @@ const MailchimpComparisonPage = () => {
 			<PageSection alt>
 				<ComparisonTable
 					competitorName="Mailchimp"
-					features={[
-						{
-							label: "Open-source codebase",
-							reloop: "Yes (Apache 2.0)",
-							competitor: "No",
-						},
-						{ label: "Self-hostable", reloop: "Yes", competitor: "No" },
-						{
-							label: "Newsletter / campaigns",
-							reloop: "Yes",
-							competitor: "Yes (primary)",
-						},
-						{
-							label: "Transactional API",
-							reloop: "Yes",
-							competitor: "Separate product path",
-						},
-						{ label: "SMTP relay", reloop: "Yes", competitor: "Limited" },
-						{
-							label: "Developer API focus",
-							reloop: "Primary",
-							competitor: "Secondary",
-						},
-						{
-							label: "Visual drag-and-drop editor",
-							reloop: "Yes",
-							competitor: "Yes (advanced)",
-						},
-						{ label: "Agent inbox", reloop: "Yes", competitor: "No" },
-						{
-							label: "Pricing basis",
-							reloop: "Emails sent",
-							competitor: "Contacts stored",
-						},
-					]}
+					features={mailchimpFeatures}
 				/>
 			</PageSection>
 
@@ -178,18 +152,7 @@ const MailchimpComparisonPage = () => {
 			<FaqSection
 				id="compare-mailchimp-faq"
 				title="Mailchimp vs Reloop FAQ"
-				items={[
-					{
-						question: "Can non-technical teammates still send campaigns?",
-						answer:
-							"Yes. Reloop includes a campaign builder and template editor. Mailchimp's visual editor is more mature for pure marketer workflows—evaluate with your marketing lead.",
-					},
-					{
-						question: "Is Reloop only for developers?",
-						answer:
-							"Reloop is developer-first but not developer-only. Teams that want API control and marketer-friendly campaigns fit best.",
-					},
-				]}
+				items={compare?.faqs ?? []}
 				compact
 			/>
 
@@ -197,6 +160,7 @@ const MailchimpComparisonPage = () => {
 				<CompareOtherLinks currentHref={pagePath} />
 			</PageSection>
 		</ComparisonPageShell>
+		</>
 	);
 };
 

--- a/apps/frontend/web/src/app/compare/mailgun/page.tsx
+++ b/apps/frontend/web/src/app/compare/mailgun/page.tsx
@@ -1,8 +1,10 @@
 import { FaqSection } from "@reloop/web/components/faq-section";
 import { PageSection, SectionHeading } from "@reloop/web/components/page-shell";
+import { getComparePage, mailgunFeatures } from "@reloop/web/lib/compare-content";
 import { getSiteUrl } from "@reloop/web/lib/site";
 import type { Metadata } from "next";
 import Link from "next/link";
+import { ComparePageJsonLd } from "../components/compare-json-ld";
 import { CompareOtherLinks } from "../components/compare-other-links";
 import { ComparisonPageShell } from "../components/comparison-page-shell";
 import { ComparisonTable } from "../components/comparison-table";
@@ -43,12 +45,15 @@ export const metadata: Metadata = {
 };
 
 const MailgunComparisonPage = () => {
+	const compare = getComparePage("mailgun");
 	return (
-		<ComparisonPageShell
-			pagePath={pagePath}
-			titleLines={["Reloop vs Mailgun"]}
-			description="Learn how Reloop compares to Mailgun and why Reloop is the best Mailgun alternative for all your developer email API needs."
-		>
+		<>
+			<ComparePageJsonLd slug="mailgun" />
+			<ComparisonPageShell
+				pagePath={pagePath}
+				titleLines={["Reloop vs Mailgun"]}
+				description="Learn how Reloop compares to Mailgun and why Reloop is the best Mailgun alternative for all your developer email API needs."
+			>
 			<PageSection flushTop narrow>
 				<div className="mx-auto max-w-3xl space-y-6 text-[15px] text-text-sub-600 leading-7 sm:text-[17px] dark:text-white/50">
 					<p>
@@ -114,33 +119,7 @@ const MailgunComparisonPage = () => {
 				<SectionHeading title="Capability matrix" compact />
 				<ComparisonTable
 					competitorName="Mailgun"
-					features={[
-						{
-							label: "Open-source codebase",
-							reloop: "Yes (Apache 2.0)",
-							competitor: "No",
-						},
-						{ label: "Self-hostable", reloop: "Yes", competitor: "No" },
-						{ label: "REST API", reloop: "Yes", competitor: "Yes" },
-						{ label: "SMTP relay", reloop: "Yes", competitor: "Yes" },
-						{
-							label: "Inbound / reply handling",
-							reloop: "Agent inbox",
-							competitor: "Inbound routes",
-						},
-						{ label: "Email validation API", reloop: "Yes", competitor: "Yes" },
-						{
-							label: "Marketing campaigns",
-							reloop: "Yes",
-							competitor: "Limited",
-						},
-						{ label: "Agent / AI workflows", reloop: "Yes", competitor: "No" },
-						{
-							label: "Free tier",
-							reloop: "3,000 emails / month",
-							competitor: "Trial-based",
-						},
-					]}
+					features={mailgunFeatures}
 				/>
 			</PageSection>
 
@@ -198,18 +177,7 @@ const MailgunComparisonPage = () => {
 			<FaqSection
 				id="compare-mailgun-faq"
 				title="Mailgun vs Reloop FAQ"
-				items={[
-					{
-						question: "Can Reloop replace Mailgun inbound routes?",
-						answer:
-							"Reloop's agent inbox and webhook model cover reply handling and automated triage. Map your existing inbound URLs to Reloop handlers during migration.",
-					},
-					{
-						question: "Do we lose deliverability moving off Mailgun?",
-						answer:
-							"Deliverability depends on domain reputation, content, and IPs—not the dashboard brand. Self-hosted Reloop lets you own IPs directly; hosted Reloop manages shared pools like other providers.",
-					},
-				]}
+				items={compare?.faqs ?? []}
 				compact
 			/>
 
@@ -217,6 +185,7 @@ const MailgunComparisonPage = () => {
 				<CompareOtherLinks currentHref={pagePath} />
 			</PageSection>
 		</ComparisonPageShell>
+		</>
 	);
 };
 

--- a/apps/frontend/web/src/app/compare/page.tsx
+++ b/apps/frontend/web/src/app/compare/page.tsx
@@ -2,8 +2,8 @@ import { BlogCta } from "@reloop/web/components/landing/blog/blog-cta";
 import { getSiteUrl } from "@reloop/web/lib/site";
 import type { Metadata } from "next";
 import { CompareCalculator } from "./components/compare-calculator";
-
 import { CompareHeroHeader } from "./components/compare-hero-header";
+import { CompareIndexJsonLd } from "./components/compare-json-ld";
 import { CompareMasterMatrix } from "./components/compare-master-matrix";
 import { ComparisonGrid } from "./components/comparison-grid";
 
@@ -52,6 +52,7 @@ export const metadata: Metadata = {
 const CompareIndexPage = () => {
 	return (
 		<>
+			<CompareIndexJsonLd />
 			<div className="mx-auto flex w-full max-w-5xl flex-col border-stroke-soft-200 border-x md:max-w-7xl dark:border-white/10">
 				{/* Top Hero Header */}
 				<CompareHeroHeader />
@@ -74,7 +75,7 @@ const CompareIndexPage = () => {
 			<BlogCta
 				category="Comparison"
 				headline="Ready to switch to Reloop?"
-				sub="10x lower volume costs, 100% open-source engine, and drop-in SMTP + REST APIs. No lock-in, no rewrite later."
+				sub="Apache 2.0 engine, send-based Reloop Cloud pricing, SMTP + REST APIs, and a self-host path. No lock-in."
 				primaryLabel="Get started free"
 				secondaryLabel="Documentation"
 			/>

--- a/apps/frontend/web/src/app/compare/postmark/page.tsx
+++ b/apps/frontend/web/src/app/compare/postmark/page.tsx
@@ -1,7 +1,9 @@
 import { FaqSection } from "@reloop/web/components/faq-section";
 import { PageSection, SectionHeading } from "@reloop/web/components/page-shell";
+import { getComparePage, postmarkFeatures } from "@reloop/web/lib/compare-content";
 import { getSiteUrl } from "@reloop/web/lib/site";
 import type { Metadata } from "next";
+import { ComparePageJsonLd } from "../components/compare-json-ld";
 import { CompareOtherLinks } from "../components/compare-other-links";
 import { ComparisonPageShell } from "../components/comparison-page-shell";
 import { ComparisonTable } from "../components/comparison-table";
@@ -42,12 +44,15 @@ export const metadata: Metadata = {
 };
 
 const PostmarkComparisonPage = () => {
+	const compare = getComparePage("postmark");
 	return (
-		<ComparisonPageShell
-			pagePath={pagePath}
-			titleLines={["Reloop vs Postmark"]}
-			description="Learn how Reloop compares to Postmark and why Reloop is the best Postmark alternative for all your transactional email needs."
-		>
+		<>
+			<ComparePageJsonLd slug="postmark" />
+			<ComparisonPageShell
+				pagePath={pagePath}
+				titleLines={["Reloop vs Postmark"]}
+				description="Learn how Reloop compares to Postmark and why Reloop is the best Postmark alternative for all your transactional email needs."
+			>
 			<PageSection flushTop narrow>
 				<p className="mx-auto max-w-3xl text-center text-[15px] text-text-sub-600 leading-7 sm:text-[17px] dark:text-white/50">
 					Postmark is deliberately focused: transactional messages, excellent
@@ -98,37 +103,7 @@ const PostmarkComparisonPage = () => {
 			<PageSection alt>
 				<ComparisonTable
 					competitorName="Postmark"
-					features={[
-						{
-							label: "Open-source codebase",
-							reloop: "Yes (Apache 2.0)",
-							competitor: "No",
-						},
-						{ label: "Self-hostable", reloop: "Yes", competitor: "No" },
-						{ label: "Transactional API", reloop: "Yes", competitor: "Yes" },
-						{
-							label: "Delivery analytics",
-							reloop: "Yes",
-							competitor: "Yes (detailed)",
-						},
-						{
-							label: "Marketing campaigns",
-							reloop: "Yes",
-							competitor: "Limited",
-						},
-						{ label: "SMTP relay", reloop: "Yes", competitor: "Yes" },
-						{
-							label: "Message streams / separation",
-							reloop: "Domain + campaign types",
-							competitor: "Streams",
-						},
-						{ label: "Agent inbox", reloop: "Yes", competitor: "No" },
-						{
-							label: "Free tier",
-							reloop: "3,000 emails / month",
-							competitor: "Trial credits",
-						},
-					]}
+					features={postmarkFeatures}
 				/>
 			</PageSection>
 
@@ -151,18 +126,7 @@ const PostmarkComparisonPage = () => {
 			<FaqSection
 				id="compare-postmark-faq"
 				title="Postmark vs Reloop FAQ"
-				items={[
-					{
-						question: "Does Reloop match Postmark latency?",
-						answer:
-							"Hosted Reloop targets production-grade transactional latency. Self-hosted performance depends on your network and MTA setup—same as any self-managed stack.",
-					},
-					{
-						question: "Should we use both for streams?",
-						answer:
-							"Reloop can separate transactional API sends from campaign traffic without two vendors. Most Postmark stream use cases map to Reloop domains plus campaign modules.",
-					},
-				]}
+				items={compare?.faqs ?? []}
 				compact
 			/>
 
@@ -170,6 +134,7 @@ const PostmarkComparisonPage = () => {
 				<CompareOtherLinks currentHref={pagePath} />
 			</PageSection>
 		</ComparisonPageShell>
+		</>
 	);
 };
 

--- a/apps/frontend/web/src/app/compare/resend/comparison-data.ts
+++ b/apps/frontend/web/src/app/compare/resend/comparison-data.ts
@@ -1,4 +1,4 @@
-import type { ComparisonCategory } from "../components/comparison-matrix";
+import type { ComparisonCategory } from "../compare-types";
 
 /**
  * Feature matrix for Reloop vs Resend.
@@ -11,7 +11,7 @@ export const resendComparisonCategories: ComparisonCategory[] = [
 		label: "Pricing & Email Volume",
 		icon: "invoice",
 		intro:
-			"Reloop offers transparent email pricing starting with 3,000 free monthly emails with no daily caps, an entry tier at $10/mo for 25,000 emails, cheaper overages ($0.80 vs $1.00 / 1,000), and unlimited free sends when self-hosting.",
+			"Reloop Cloud Free is 3,000 emails/month with a 200/day cap. Individual is $10/mo for 25,000 emails with no daily cap. Overage is $0.80 vs Resend's $1.00 per 1,000. Self-hosting Reloop has no Reloop license fee (you pay your own infra).",
 		features: [
 			{
 				label: "Free monthly emails",
@@ -23,8 +23,8 @@ export const resendComparisonCategories: ComparisonCategory[] = [
 				label: "Daily send limit (Free tier)",
 				icon: "calendar",
 				reloop: {
-					value: "No daily limit",
-					note: "Use full monthly quota anytime",
+					value: "200 / day",
+					note: "Free also caps at 3,000 / month",
 				},
 				competitor: {
 					value: "100 / day",

--- a/apps/frontend/web/src/app/compare/resend/comparison-data.ts
+++ b/apps/frontend/web/src/app/compare/resend/comparison-data.ts
@@ -11,7 +11,7 @@ export const resendComparisonCategories: ComparisonCategory[] = [
 		label: "Pricing & Email Volume",
 		icon: "invoice",
 		intro:
-			"Reloop Cloud Free is 3,000 emails/month with a 200/day cap. Individual is $10/mo for 25,000 emails with no daily cap. Overage is $0.80 vs Resend's $1.00 per 1,000. Self-hosting Reloop has no Reloop license fee (you pay your own infra).",
+			"Reloop Cloud Free is 3,000 emails/month with a 200/day cap. Individual is $10/mo for 25,000 emails with no daily cap. Overage is $0.80 vs Resend's $0.90 per 1,000. Self-hosting Reloop has no Reloop license fee (you pay your own infra).",
 		features: [
 			{
 				label: "Free monthly emails",
@@ -53,7 +53,7 @@ export const resendComparisonCategories: ComparisonCategory[] = [
 				label: "Overage rate (per 1k emails)",
 				icon: "arrow-swap",
 				reloop: "$0.80 / 1k",
-				competitor: "$1.00 / 1k",
+				competitor: "$0.90 / 1k",
 			},
 			{
 				label: "Self-hosted email sends",

--- a/apps/frontend/web/src/app/compare/resend/page.tsx
+++ b/apps/frontend/web/src/app/compare/resend/page.tsx
@@ -1,7 +1,10 @@
+import { FaqSection } from "@reloop/web/components/faq-section";
+import { getComparePage } from "@reloop/web/lib/compare-content";
 import { getSiteUrl } from "@reloop/web/lib/site";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { competitorBrands } from "../competitor-brands";
+import { ComparePageJsonLd } from "../components/compare-json-ld";
 import { CompareMigrate } from "../components/compare-migrate";
 import { CompareOtherLinks } from "../components/compare-other-links";
 import { CompareSection } from "../components/compare-section";
@@ -48,21 +51,24 @@ export const metadata: Metadata = {
 
 const ResendComparisonPage = () => {
 	const resendBrand = competitorBrands.find((b) => b.name === "Resend");
+	const compare = getComparePage("resend");
 
 	return (
-		<ComparisonPageShell
-			pagePath={pagePath}
-			titleLines={["Reloop vs Resend"]}
-			description="Learn how Reloop compares to Resend and why Reloop is the best Resend alternative for all your developer email needs."
-			primaryCta={{
-				label: "Get Started ",
-				href: "/dashboard/signup",
-			}}
-			secondaryCta={{
-				label: "Migrate from Resend",
-				href: "/compare/resend#migrate",
-			}}
-		>
+		<>
+			<ComparePageJsonLd slug="resend" />
+			<ComparisonPageShell
+				pagePath={pagePath}
+				titleLines={["Reloop vs Resend"]}
+				description="Learn how Reloop compares to Resend and why Reloop is the best Resend alternative for all your developer email needs."
+				primaryCta={{
+					label: "Get Started ",
+					href: "/dashboard/signup",
+				}}
+				secondaryCta={{
+					label: "Migrate from Resend",
+					href: "/compare/resend#migrate",
+				}}
+			>
 			{/* Feature matrix */}
 			<CompareSection maxWidth="full" flushX>
 				<div className="mb-10 text-center">
@@ -115,10 +121,20 @@ const ResendComparisonPage = () => {
 				</p>
 			</CompareSection>
 
+			<CompareSection maxWidth="3xl">
+				<FaqSection
+					id="compare-resend-faq"
+					title="Reloop vs Resend FAQ"
+					items={compare?.faqs ?? []}
+					compact
+				/>
+			</CompareSection>
+
 			<CompareSection maxWidth="full" noDivider>
 				<CompareOtherLinks currentHref={pagePath} />
 			</CompareSection>
 		</ComparisonPageShell>
+		</>
 	);
 };
 

--- a/apps/frontend/web/src/app/compare/sendgrid/page.tsx
+++ b/apps/frontend/web/src/app/compare/sendgrid/page.tsx
@@ -1,7 +1,9 @@
 import { FaqSection } from "@reloop/web/components/faq-section";
 import { PageSection, SectionHeading } from "@reloop/web/components/page-shell";
+import { sendgridFeatures, getComparePage } from "@reloop/web/lib/compare-content";
 import { getSiteUrl } from "@reloop/web/lib/site";
 import type { Metadata } from "next";
+import { ComparePageJsonLd } from "../components/compare-json-ld";
 import { CompareOtherLinks } from "../components/compare-other-links";
 import { ComparisonPageShell } from "../components/comparison-page-shell";
 import { ComparisonTable } from "../components/comparison-table";
@@ -42,12 +44,15 @@ export const metadata: Metadata = {
 };
 
 const SendGridComparisonPage = () => {
+	const compare = getComparePage("sendgrid");
 	return (
-		<ComparisonPageShell
-			pagePath={pagePath}
-			titleLines={["Reloop vs SendGrid"]}
-			description="Learn how Reloop compares to SendGrid and why Reloop is the best SendGrid alternative for all your transactional and marketing email needs."
-		>
+		<>
+			<ComparePageJsonLd slug="sendgrid" />
+			<ComparisonPageShell
+				pagePath={pagePath}
+				titleLines={["Reloop vs SendGrid"]}
+				description="Learn how Reloop compares to SendGrid and why Reloop is the best SendGrid alternative for all your transactional and marketing email needs."
+			>
 			<PageSection flushTop narrow>
 				<p className="mx-auto max-w-3xl text-center text-[15px] text-text-sub-600 leading-7 sm:text-[17px] dark:text-white/50">
 					SendGrid bundles transactional APIs, marketing campaigns, templates,
@@ -113,29 +118,7 @@ const SendGridComparisonPage = () => {
 				<SectionHeading title="SendGrid vs Reloop" compact />
 				<ComparisonTable
 					competitorName="SendGrid"
-					features={[
-						{
-							label: "Open-source codebase",
-							reloop: "Yes (Apache 2.0)",
-							competitor: "No",
-						},
-						{ label: "Self-hostable", reloop: "Yes", competitor: "No" },
-						{ label: "Transactional API", reloop: "Yes", competitor: "Yes" },
-						{ label: "Marketing campaigns", reloop: "Yes", competitor: "Yes" },
-						{ label: "Template editor", reloop: "Yes", competitor: "Yes" },
-						{ label: "SMTP relay", reloop: "Yes", competitor: "Yes" },
-						{ label: "Webhooks", reloop: "Yes", competitor: "Yes" },
-						{
-							label: "Agent inbox",
-							reloop: "Built-in",
-							competitor: "Not included",
-						},
-						{
-							label: "Contract flexibility",
-							reloop: "Monthly tiers + self-host",
-							competitor: "Often annual enterprise",
-						},
-					]}
+					features={sendgridFeatures}
 				/>
 			</PageSection>
 
@@ -172,18 +155,7 @@ const SendGridComparisonPage = () => {
 			<FaqSection
 				id="compare-sendgrid-faq"
 				title="SendGrid vs Reloop FAQ"
-				items={[
-					{
-						question: "Can Reloop handle SendGrid-scale volume?",
-						answer:
-							"Yes. Hosted Individual, Startup, and Enterprise tiers target high throughput; self-hosted Reloop scales with your Kubernetes or bare-metal footprint.",
-					},
-					{
-						question: "What about dedicated IPs?",
-						answer:
-							"Enterprise Reloop supports dedicated IP requirements. Self-hosted deployments can attach your own IPs directly to your MTA layer.",
-					},
-				]}
+				items={compare?.faqs ?? []}
 				compact
 			/>
 
@@ -191,6 +163,7 @@ const SendGridComparisonPage = () => {
 				<CompareOtherLinks currentHref={pagePath} />
 			</PageSection>
 		</ComparisonPageShell>
+		</>
 	);
 };
 

--- a/apps/frontend/web/src/app/home/page.tsx
+++ b/apps/frontend/web/src/app/home/page.tsx
@@ -1,4 +1,5 @@
 import { JsonLd } from "@reloop/web/components/json-ld";
+import { pricingSoftwareApplicationJsonLd } from "@reloop/web/lib/schema";
 import {
 	defaultOgImage,
 	getSiteUrl,
@@ -57,19 +58,7 @@ const homeSchema = [
 		logo: `${siteUrl}${defaultOgImage}`,
 		sameAs: [socialProfiles.github, socialProfiles.x, socialProfiles.discord],
 	},
-	{
-		"@context": "https://schema.org" as const,
-		"@type": "SoftwareApplication" as const,
-		name: siteName,
-		operatingSystem: "All",
-		applicationCategory: "DeveloperApplication",
-		description: siteDescription,
-		offers: {
-			"@type": "Offer" as const,
-			price: "0",
-			priceCurrency: "USD",
-		},
-	},
+	pricingSoftwareApplicationJsonLd(siteUrl),
 ];
 
 export default function HomePage() {

--- a/apps/frontend/web/src/app/pricing/components/pricing-faq.tsx
+++ b/apps/frontend/web/src/app/pricing/components/pricing-faq.tsx
@@ -1,37 +1,5 @@
 import { FaqSection } from "@reloop/web/components/faq-section";
-
-const pricingFaqItems = [
-	{
-		question: "What counts as an email?",
-		answer:
-			"Each successfully sent email counts toward your monthly quota—transactional messages, campaign sends, and SMTP relay deliveries all use credits the same way.",
-	},
-	{
-		question: "Do I need a credit card to start?",
-		answer:
-			"No. The Free plan includes 3,000 emails per month with no credit card required. Upgrade when your volume grows.",
-	},
-	{
-		question: "What happens if I exceed my monthly limit?",
-		answer:
-			"On paid plans, overage emails are billed at the per-thousand rate listed for your tier. On the Free plan, sending pauses until the next billing period unless you upgrade.",
-	},
-	{
-		question: "Is self-hosting really free?",
-		answer:
-			"Yes. Reloop is open source under Apache 2.0 with Reloop Labs use restrictions. You can deploy on your own infrastructure at no license cost—you pay only for your servers and email delivery infrastructure.",
-	},
-	{
-		question: "Is hosted pricing different from self-hosted?",
-		answer:
-			"We believe in pricing parity: the same transparent tiers apply whether Reloop hosts your stack or you run it yourself. No hidden platform fees for choosing one deployment path over the other.",
-	},
-	{
-		question: "Can I switch plans at any time?",
-		answer:
-			"Yes. Upgrade or downgrade from your dashboard. Plan changes apply to the current billing period according to your subscription settings.",
-	},
-];
+import { pricingFaqItems } from "@reloop/web/lib/pricing-faq";
 
 export function PricingFaq() {
 	return <FaqSection items={pricingFaqItems} id="pricing-faq" compact />;

--- a/apps/frontend/web/src/app/pricing/page.tsx
+++ b/apps/frontend/web/src/app/pricing/page.tsx
@@ -3,6 +3,8 @@ import {
 	MarketingPageShell,
 	PageSection,
 } from "@reloop/web/components/page-shell";
+import { pricingFaqItems } from "@reloop/web/lib/pricing-faq";
+import { faqPageJsonLd, pricingProductJsonLd } from "@reloop/web/lib/schema";
 import { getSiteUrl } from "@reloop/web/lib/site";
 import type { Metadata } from "next";
 import { PricingFaq } from "./components/pricing-faq";
@@ -14,11 +16,12 @@ export const instant = false;
 
 const siteUrl = getSiteUrl();
 const pricingPageUrl = `${siteUrl}/pricing`;
+const pricingDescription =
+	"Scale your email, control your costs. Start free with 3,000 emails per month (200/day). Upgrade to Individual $10, Startup $20, or Enterprise—or self-host with no Reloop license fee.";
 
 export const metadata: Metadata = {
 	title: "Pricing | Reloop",
-	description:
-		"Scale your Email, control your costs. Start free with 3,000 emails per month. Upgrade to Individual, Startup, or Enterprise—hosted or self-hosted.",
+	description: pricingDescription,
 	keywords: [
 		"email pricing",
 		"email API pricing",
@@ -30,8 +33,7 @@ export const metadata: Metadata = {
 	],
 	openGraph: {
 		title: "Pricing | Reloop",
-		description:
-			"Scale your Email, control your costs. Start free with 3,000 emails per month.",
+		description: pricingDescription,
 		type: "website",
 		url: pricingPageUrl,
 		siteName: "Reloop",
@@ -39,8 +41,7 @@ export const metadata: Metadata = {
 	twitter: {
 		card: "summary_large_image",
 		title: "Pricing | Reloop",
-		description:
-			"Scale your Email, control your costs. Start free with 3,000 emails per month.",
+		description: pricingDescription,
 	},
 	alternates: {
 		canonical: pricingPageUrl,
@@ -48,119 +49,8 @@ export const metadata: Metadata = {
 };
 
 const pricingSchema = [
-	{
-		"@context": "https://schema.org" as const,
-		"@type": "Product" as const,
-		name: "Reloop Subscription",
-		image: `${siteUrl}/web-app-manifest-512x512.png`,
-		description:
-			"Simple, transparent email pricing. Start free with 3,000 emails per month. Upgrade to Essentials or Enterprise—hosted or self-hosted.",
-		brand: {
-			"@type": "Brand" as const,
-			name: "Reloop Labs",
-		},
-		offers: [
-			{
-				"@type": "Offer" as const,
-				name: "Free Plan",
-				price: "0",
-				priceCurrency: "USD",
-				priceSpecification: {
-					"@type": "UnitPriceSpecification" as const,
-					price: "0",
-					priceCurrency: "USD",
-					unitText: "MONTH",
-				},
-			},
-			{
-				"@type": "Offer" as const,
-				name: "Essentials Plan",
-				price: "9",
-				priceCurrency: "USD",
-				priceSpecification: {
-					"@type": "UnitPriceSpecification" as const,
-					price: "9",
-					priceCurrency: "USD",
-					unitText: "MONTH",
-				},
-			},
-		],
-		aggregateRating: {
-			"@type": "AggregateRating" as const,
-			ratingValue: "4.9",
-			reviewCount: "24",
-		},
-		review: [
-			{
-				"@type": "Review" as const,
-				author: {
-					"@type": "Person" as const,
-					name: "Sarah Chen",
-				},
-				datePublished: "2026-03-15",
-				reviewBody:
-					"Extremely robust and easy to self-host. Reloop gives us complete control over our transactional emails without any vendor lock-in.",
-				reviewRating: {
-					"@type": "Rating" as const,
-					ratingValue: "5",
-				},
-			},
-		],
-	},
-	{
-		"@context": "https://schema.org" as const,
-		"@type": "FAQPage" as const,
-		mainEntity: [
-			{
-				"@type": "Question" as const,
-				name: "What counts as an email?",
-				acceptedAnswer: {
-					"@type": "Answer" as const,
-					text: "Each successfully sent email counts toward your monthly quota—transactional messages, campaign sends, and SMTP relay deliveries all use credits the same way.",
-				},
-			},
-			{
-				"@type": "Question" as const,
-				name: "Do I need a credit card to start?",
-				acceptedAnswer: {
-					"@type": "Answer" as const,
-					text: "No. The Free plan includes 3,000 emails per month with no credit card required. Upgrade when your volume grows.",
-				},
-			},
-			{
-				"@type": "Question" as const,
-				name: "What happens if I exceed my monthly limit?",
-				acceptedAnswer: {
-					"@type": "Answer" as const,
-					text: "On paid plans, overage emails are billed at the per-thousand rate listed for your tier. On the Free plan, sending pauses until the next billing period unless you upgrade.",
-				},
-			},
-			{
-				"@type": "Question" as const,
-				name: "Is self-hosting really free?",
-				acceptedAnswer: {
-					"@type": "Answer" as const,
-					text: "Yes. Reloop is open source under Apache 2.0 with Reloop Labs use restrictions. You can deploy on your own infrastructure at no license cost—you pay only for your servers and email delivery infrastructure.",
-				},
-			},
-			{
-				"@type": "Question" as const,
-				name: "Is hosted pricing different from self-hosted?",
-				acceptedAnswer: {
-					"@type": "Answer" as const,
-					text: "We believe in pricing parity: the same transparent tiers apply whether Reloop hosts your stack or you run it yourself. No hidden platform fees for choosing one deployment path over the other.",
-				},
-			},
-			{
-				"@type": "Question" as const,
-				name: "Can I switch plans at any time?",
-				acceptedAnswer: {
-					"@type": "Answer" as const,
-					text: "Yes. Upgrade or downgrade from your dashboard. Plan changes apply to the current billing period according to your subscription settings.",
-				},
-			},
-		],
-	},
+	pricingProductJsonLd(siteUrl),
+	faqPageJsonLd(pricingFaqItems),
 ];
 
 const PricingPage = () => {

--- a/apps/frontend/web/src/app/robots.ts
+++ b/apps/frontend/web/src/app/robots.ts
@@ -5,11 +5,27 @@ export default function robots(): MetadataRoute.Robots {
 	const siteUrl = getSiteUrl();
 
 	return {
-		rules: {
-			userAgent: "*",
-			allow: "/",
-			disallow: ["/api/", "/preferences/", "/redirect/", "/twitter", "/home"],
-		},
+		rules: [
+			{
+				userAgent: "*",
+				allow: "/",
+				disallow: ["/api/", "/preferences/", "/redirect/", "/twitter", "/home"],
+			},
+			{
+				userAgent: [
+					"GPTBot",
+					"ChatGPT-User",
+					"OAI-SearchBot",
+					"ClaudeBot",
+					"anthropic-ai",
+					"Applebot-Extended",
+					"Google-Extended",
+					"PerplexityBot",
+					"Bytespider",
+				],
+				allow: "/",
+			},
+		],
 		// Main site map + glossary-specific map for term pages
 		sitemap: [`${siteUrl}/sitemap.xml`, `${siteUrl}/glossary/sitemap.xml`],
 	};

--- a/apps/frontend/web/src/components/landing/blog/blog-cta.tsx
+++ b/apps/frontend/web/src/components/landing/blog/blog-cta.tsx
@@ -53,7 +53,7 @@ const CATEGORY_VARIANTS: Record<string, CategoryVariant> = {
 	},
 	"Open Source": {
 		headline: "Ready to contribute?",
-		sub: "Reloop is MIT-licensed, community-driven, and free to self-host. Star us on GitHub or start on the hosted tier.",
+		sub: "Reloop is Apache 2.0, community-driven, and free to self-host. Star us on GitHub or start on the hosted tier.",
 		primaryLabel: "Get started free",
 	},
 	Migration: {

--- a/apps/frontend/web/src/components/landing/feature-highlights.tsx
+++ b/apps/frontend/web/src/components/landing/feature-highlights.tsx
@@ -15,7 +15,7 @@ export const featureHighlights: FeatureHighlight[] = [
 		id: "cost-efficiency",
 		icon: "graph-up",
 		title: "Cost Efficiency",
-		description: "10x lower volume cost vs legacy email providers.",
+		description: "Send-based hosted pricing from $10 / 25k emails; $0.80 / 1k overage.",
 	},
 	{
 		id: "open-source",

--- a/apps/frontend/web/src/components/landing/feature-highlights.tsx
+++ b/apps/frontend/web/src/components/landing/feature-highlights.tsx
@@ -15,7 +15,7 @@ export const featureHighlights: FeatureHighlight[] = [
 		id: "cost-efficiency",
 		icon: "graph-up",
 		title: "Cost Efficiency",
-		description: "Send-based hosted pricing from $10 / 25k emails; $0.80 / 1k overage.",
+		description: "Send-based hosted pricing from $10/month for 25k emails/month; $0.80 per 1k emails.",
 	},
 	{
 		id: "open-source",

--- a/apps/frontend/web/src/lib/agent-content.ts
+++ b/apps/frontend/web/src/lib/agent-content.ts
@@ -1,5 +1,10 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
+import {
+	buildCompareIndexMarkdown,
+	buildCompareMarkdown,
+	listComparePages,
+} from "@reloop/web/lib/compare-content";
 import { buildPricingMarkdown } from "@reloop/web/lib/pricing-md";
 import { getSiteUrl, siteDescription, siteName } from "@reloop/web/lib/site";
 import matter from "gray-matter";
@@ -98,6 +103,16 @@ export function resolveMarketingMarkdown(path: string): string | null {
 
 	if (normalized === "/pricing" || normalized === "pricing") {
 		return injectMarkdownAgentDirective(buildPricingMarkdown());
+	}
+
+	if (normalized === "/compare" || normalized === "compare") {
+		return injectMarkdownAgentDirective(buildCompareIndexMarkdown());
+	}
+
+	const compareMatch = normalized.match(/^\/?compare\/([^/]+)$/);
+	if (compareMatch?.[1]) {
+		const md = buildCompareMarkdown(compareMatch[1]);
+		if (md) return injectMarkdownAgentDirective(md);
 	}
 
 	if (normalized === "/" || normalized === "" || normalized === "/index") {
@@ -212,6 +227,22 @@ export function loadMarketingCorpus(): SearchablePage[] {
 		path: "/pricing",
 		body: buildPricingMarkdown(),
 	});
+
+	pages.push({
+		title: "Reloop vs the competition",
+		path: "/compare",
+		body: buildCompareIndexMarkdown(),
+	});
+
+	for (const page of listComparePages()) {
+		const body = buildCompareMarkdown(page.slug);
+		if (!body) continue;
+		pages.push({
+			title: page.title,
+			path: `/compare/${page.slug}`,
+			body,
+		});
+	}
 
 	const home = readAgentPage("home.md") ?? buildHomeMarkdown();
 	pages.push({ title: siteName, path: "/", body: home });

--- a/apps/frontend/web/src/lib/compare-content.ts
+++ b/apps/frontend/web/src/lib/compare-content.ts
@@ -1,0 +1,498 @@
+import { resendComparisonCategories } from "@reloop/web/app/compare/resend/comparison-data";
+import { loopsComparisonCategories } from "@reloop/web/app/compare/loops/comparison-data";
+import {
+	comparisonCellText,
+	type ComparisonCategory,
+	type ComparisonFeatureRow,
+} from "@reloop/web/app/compare/compare-types";
+import { pricingFaqItems } from "@reloop/web/lib/pricing-faq";
+import {
+	faqPageJsonLd,
+	pricingProductJsonLd,
+	type FaqEntry,
+} from "@reloop/web/lib/schema";
+import { getSiteUrl } from "@reloop/web/lib/site";
+
+export type ComparePageContent = {
+	slug: string;
+	competitor: string;
+	title: string;
+	description: string;
+	summary: string;
+	categories?: ComparisonCategory[];
+	features?: ComparisonFeatureRow[];
+	faqs: FaqEntry[];
+};
+
+const sendgridFeatures: ComparisonFeatureRow[] = [
+	{
+		label: "Open-source codebase",
+		reloop: "Yes (Apache 2.0)",
+		competitor: "No",
+	},
+	{ label: "Self-hostable", reloop: "Yes", competitor: "No" },
+	{ label: "Transactional API", reloop: "Yes", competitor: "Yes" },
+	{ label: "Marketing campaigns", reloop: "Yes", competitor: "Yes" },
+	{ label: "Template editor", reloop: "Yes", competitor: "Yes" },
+	{ label: "SMTP relay", reloop: "Yes", competitor: "Yes" },
+	{ label: "Webhooks", reloop: "Yes", competitor: "Yes" },
+	{
+		label: "Agent inbox",
+		reloop: "Built-in",
+		competitor: "Not included",
+	},
+	{
+		label: "Contract flexibility",
+		reloop: "Monthly tiers + self-host",
+		competitor: "Often annual enterprise",
+	},
+];
+
+const mailgunFeatures: ComparisonFeatureRow[] = [
+	{
+		label: "Open-source codebase",
+		reloop: "Yes (Apache 2.0)",
+		competitor: "No",
+	},
+	{ label: "Self-hostable", reloop: "Yes", competitor: "No" },
+	{ label: "REST API", reloop: "Yes", competitor: "Yes" },
+	{ label: "SMTP relay", reloop: "Yes", competitor: "Yes" },
+	{
+		label: "Inbound / reply handling",
+		reloop: "Agent inbox",
+		competitor: "Inbound routes",
+	},
+	{ label: "Email validation API", reloop: "Yes", competitor: "Yes" },
+	{
+		label: "Marketing campaigns",
+		reloop: "Yes",
+		competitor: "Limited",
+	},
+	{ label: "Agent / AI workflows", reloop: "Yes", competitor: "No" },
+	{
+		label: "Free tier",
+		reloop: "3,000 emails / month · 200 / day",
+		competitor: "Trial-based",
+	},
+];
+
+const awsSesFeatures: ComparisonFeatureRow[] = [
+	{
+		label: "Open-source platform",
+		reloop: "Yes (Apache 2.0)",
+		competitor: "No",
+	},
+	{
+		label: "Self-host on your AWS account",
+		reloop: "Yes",
+		competitor: "SES only",
+	},
+	{
+		label: "Marketing campaigns UI",
+		reloop: "Yes",
+		competitor: "No (DIY)",
+	},
+	{ label: "Transactional API", reloop: "Yes", competitor: "Yes" },
+	{
+		label: "Built-in delivery dashboard",
+		reloop: "Yes",
+		competitor: "CloudWatch / DIY",
+	},
+	{
+		label: "Webhooks",
+		reloop: "Native",
+		competitor: "SNS configuration",
+	},
+	{
+		label: "Template management",
+		reloop: "Yes",
+		competitor: "Limited",
+	},
+	{ label: "Agent inbox", reloop: "Yes", competitor: "No" },
+	{
+		label: "Per-email list price",
+		reloop: "Tier bundles",
+		competitor: "Very low at scale",
+	},
+];
+
+const postmarkFeatures: ComparisonFeatureRow[] = [
+	{
+		label: "Open-source codebase",
+		reloop: "Yes (Apache 2.0)",
+		competitor: "No",
+	},
+	{ label: "Self-hostable", reloop: "Yes", competitor: "No" },
+	{ label: "Transactional API", reloop: "Yes", competitor: "Yes" },
+	{
+		label: "Delivery analytics",
+		reloop: "Yes",
+		competitor: "Yes (detailed)",
+	},
+	{
+		label: "Marketing campaigns",
+		reloop: "Yes",
+		competitor: "Limited",
+	},
+	{ label: "SMTP relay", reloop: "Yes", competitor: "Yes" },
+	{
+		label: "Message streams / separation",
+		reloop: "Domain + campaign types",
+		competitor: "Streams",
+	},
+	{ label: "Agent inbox", reloop: "Yes", competitor: "No" },
+	{
+		label: "Free tier",
+		reloop: "3,000 emails / month · 200 / day",
+		competitor: "Trial credits",
+	},
+];
+
+const mailchimpFeatures: ComparisonFeatureRow[] = [
+	{
+		label: "Open-source codebase",
+		reloop: "Yes (Apache 2.0)",
+		competitor: "No",
+	},
+	{ label: "Self-hostable", reloop: "Yes", competitor: "No" },
+	{
+		label: "Newsletter / campaigns",
+		reloop: "Yes",
+		competitor: "Yes (primary)",
+	},
+	{
+		label: "Transactional API",
+		reloop: "Yes",
+		competitor: "Separate product path",
+	},
+	{ label: "SMTP relay", reloop: "Yes", competitor: "Limited" },
+	{
+		label: "Developer API focus",
+		reloop: "Primary",
+		competitor: "Secondary",
+	},
+	{
+		label: "Visual drag-and-drop editor",
+		reloop: "Yes",
+		competitor: "Yes (advanced)",
+	},
+	{ label: "Agent inbox", reloop: "Yes", competitor: "No" },
+	{
+		label: "Pricing basis",
+		reloop: "Emails sent",
+		competitor: "Contacts stored",
+	},
+];
+
+export const comparePages: ComparePageContent[] = [
+	{
+		slug: "resend",
+		competitor: "Resend",
+		title: "Reloop vs Resend",
+		description:
+			"Learn how Reloop compares to Resend and why Reloop is an open-source alternative for developer email.",
+		summary:
+			"Reloop is email infrastructure you can host or self-host (Apache 2.0, KumoMTA). Resend is a hosted DX layer over Amazon SES. Reloop Free is 3,000 emails/month with a 200/day cap; Individual is $10/month for 25,000 emails with no daily cap. Reloop is not a drop-in Resend proxy.",
+		categories: resendComparisonCategories,
+		faqs: [
+			{
+				question: "Does Reloop Free have a daily send limit?",
+				answer:
+					"Yes. Reloop Free includes 3,000 emails per month and 200 emails per day. Individual ($10/mo), Startup ($20/mo), and Enterprise have no daily cap. Self-hosted Reloop is limited by your own infrastructure, not Reloop Cloud quotas.",
+			},
+			{
+				question: "Is Reloop a drop-in Resend API?",
+				answer:
+					"No. Reloop is not a Resend proxy. Plan a small client adapter when migrating. Auth uses the x-api-key header with rl_ keys.",
+			},
+			{
+				question: "Is Reloop open source?",
+				answer:
+					"Yes. Reloop is Apache 2.0 with Reloop Labs use restrictions. Self-host at no Reloop license fee, or use Reloop Cloud.",
+			},
+		],
+	},
+	{
+		slug: "sendgrid",
+		competitor: "SendGrid",
+		title: "Reloop vs SendGrid",
+		description:
+			"Learn how Reloop compares to SendGrid for transactional and marketing email.",
+		summary:
+			"SendGrid bundles transactional APIs, marketing campaigns, and deliverability tooling—often with annual commits. Reloop is API-first, Apache 2.0, and self-hostable, with campaigns and transactional sends in one codebase. Reloop Cloud Free is 3,000 emails/month (200/day).",
+		features: sendgridFeatures,
+		faqs: [
+			{
+				question: "Can Reloop handle SendGrid-scale volume?",
+				answer:
+					"Hosted Individual ($10/mo, 25,000 emails), Startup ($20/mo, 50,000 emails), and Enterprise target growing throughput; overage is $0.80 per 1,000. Self-hosted Reloop scales with your Kubernetes or bare-metal footprint.",
+			},
+			{
+				question: "What about dedicated IPs?",
+				answer:
+					"Dedicated IPs are optional/custom on Reloop Enterprise. Self-hosted deployments can attach your own IPs directly to your MTA layer.",
+			},
+		],
+	},
+	{
+		slug: "mailgun",
+		competitor: "Mailgun",
+		title: "Reloop vs Mailgun",
+		description:
+			"Learn how Reloop compares to Mailgun for developer email APIs and SMTP.",
+		summary:
+			"Reloop offers REST + SMTP, inbound agent inbox, and Apache 2.0 self-host. Mailgun is hosted SaaS with inbound routes. Reloop Free is 3,000 emails/month (200/day).",
+		features: mailgunFeatures,
+		faqs: [
+			{
+				question: "Can Reloop replace Mailgun inbound routes?",
+				answer:
+					"Reloop's agent inbox and webhook model cover reply handling and automated triage. Map your existing inbound URLs to Reloop handlers during migration.",
+			},
+			{
+				question: "Do we lose deliverability moving off Mailgun?",
+				answer:
+					"Deliverability depends on domain reputation, content, and IPs—not the dashboard brand. Self-hosted Reloop lets you own IPs directly; hosted Reloop manages shared pools like other providers.",
+			},
+		],
+	},
+	{
+		slug: "aws-ses",
+		competitor: "AWS SES",
+		title: "Reloop vs AWS SES",
+		description:
+			"Learn how Reloop compares to Amazon SES as an email platform, not just an SMTP pipe.",
+		summary:
+			"SES is raw sending infrastructure. Reloop is a full email platform (API, campaigns, dashboard, agent inbox) that you can host or self-host. SES is often cheaper at extreme volume; Reloop competes on platform TCO, not on being the cheapest SMTP pipe.",
+		features: awsSesFeatures,
+		faqs: [
+			{
+				question: "Is Reloop cheaper than SES at 10M emails/month?",
+				answer:
+					"SES raw sending is often cheaper at extreme volume. Reloop competes on platform TCO—engineering time, campaign tooling, support, and unified ops—not on being the cheapest SMTP pipe.",
+			},
+			{
+				question: "Can we migrate boto3 sends to Reloop?",
+				answer:
+					"Yes. Replace AWS SDK send calls with Reloop REST or SMTP. Map SNS bounce notifications to Reloop webhook endpoints.",
+			},
+			{
+				question: "Do we need both SES and Reloop?",
+				answer:
+					"Not usually. Self-hosted Reloop includes outbound delivery. Some teams keep SES as an MTA backend during transition—that is an advanced integration, not the default path.",
+			},
+		],
+	},
+	{
+		slug: "postmark",
+		competitor: "Postmark",
+		title: "Reloop vs Postmark",
+		description:
+			"Learn how Reloop compares to Postmark for transactional email.",
+		summary:
+			"Postmark focuses on transactional delivery with streams. Reloop unifies transactional API sends and campaigns, is Apache 2.0 / self-hostable, and offers an agent inbox. Reloop Free is 3,000 emails/month (200/day).",
+		features: postmarkFeatures,
+		faqs: [
+			{
+				question: "Does Reloop match Postmark latency?",
+				answer:
+					"Hosted Reloop targets production-grade transactional latency. Self-hosted performance depends on your network and MTA setup—same as any self-managed stack.",
+			},
+			{
+				question: "Should we use both for streams?",
+				answer:
+					"Reloop can separate transactional API sends from campaign traffic without two vendors. Most Postmark stream use cases map to Reloop domains plus campaign modules.",
+			},
+		],
+	},
+	{
+		slug: "loops",
+		competitor: "Loops",
+		title: "Reloop vs Loops",
+		description:
+			"Compare Reloop to Loops: send-based pricing vs contact-list pricing, plus transactional API and self-host.",
+		summary:
+			"Loops prices by contact list size. Reloop prices by emails sent. Reloop Free is 3,000 emails/month (200/day); Individual is $10/month for 25,000 emails; Startup is $20/month for 50,000 emails. Reloop is the ESP/MTA, not a lifecycle UI on top of another sender.",
+		categories: loopsComparisonCategories,
+		faqs: [
+			{
+				question:
+					"Why should we choose send-based pricing over contact-based pricing?",
+				answer:
+					"Contact-based pricing charges you for inactive leads and users who never open your emails. Reloop's send-based pricing charges for emails sent. Free is 3,000 emails/month (200/day); paid overage is $0.80 per 1,000.",
+			},
+			{
+				question:
+					"Can Reloop handle both marketing campaigns and transactional APIs?",
+				answer:
+					"Yes. Reloop includes transactional API endpoints, SMTP relay, templates, broadcast campaigns, and an agent inbox. Reloop is the email infrastructure, not a connector to another ESP.",
+			},
+			{
+				question: "Can we self-host Reloop while migrating from Loops?",
+				answer:
+					"Yes. Reloop is Apache 2.0. You can deploy on your own Kubernetes or Docker infrastructure with no Reloop license fee. You still pay for your own servers and IPs.",
+			},
+		],
+	},
+	{
+		slug: "mailchimp",
+		competitor: "Mailchimp",
+		title: "Reloop vs Mailchimp",
+		description:
+			"Compare Reloop to Mailchimp: send-based developer email vs contact-list marketing SaaS.",
+		summary:
+			"Mailchimp is a marketer-first, contact-priced platform. Reloop is developer-first email infrastructure with send-based Reloop Cloud pricing and an Apache 2.0 self-host path. Reloop Free is 3,000 emails/month (200/day).",
+		features: mailchimpFeatures,
+		faqs: [
+			{
+				question: "Can non-technical teammates still send campaigns?",
+				answer:
+					"Yes. Reloop includes a campaign builder and template editor. Mailchimp's visual editor is more mature for pure marketer workflows—evaluate with your marketing lead.",
+			},
+			{
+				question: "Is Reloop only for developers?",
+				answer:
+					"Reloop is developer-first but not developer-only. Teams that want API control and marketer-friendly campaigns fit best. Reloop is an ESP/email infrastructure product, not a multi-provider email router.",
+			},
+		],
+	},
+];
+
+export function getComparePage(slug: string): ComparePageContent | undefined {
+	return comparePages.find((page) => page.slug === slug);
+}
+
+export function listComparePages(): ComparePageContent[] {
+	return comparePages;
+}
+
+function featuresTableMarkdown(
+	competitor: string,
+	features: ComparisonFeatureRow[],
+): string[] {
+	const lines = [
+		"| Feature | Reloop | " + competitor + " |",
+		"| --- | --- | --- |",
+	];
+	for (const row of features) {
+		lines.push(
+			`| ${row.label} | ${comparisonCellText(row.reloop)} | ${comparisonCellText(row.competitor)} |`,
+		);
+	}
+	return lines;
+}
+
+function categoriesMarkdown(
+	competitor: string,
+	categories: ComparisonCategory[],
+): string[] {
+	const lines: string[] = [];
+	for (const category of categories) {
+		lines.push(`## ${category.label}`, "");
+		if (category.intro) {
+			lines.push(category.intro, "");
+		}
+		lines.push(...featuresTableMarkdown(competitor, category.features), "");
+	}
+	return lines;
+}
+
+export function buildCompareMarkdown(slug: string): string | null {
+	const page = getComparePage(slug);
+	if (!page) return null;
+	const origin = getSiteUrl();
+	const path = `/compare/${page.slug}`;
+	const lines: string[] = [
+		`# ${page.title}`,
+		"",
+		`> ${page.description}`,
+		"",
+		`HTML: ${origin}${path}`,
+		`Markdown: ${origin}${path}.md`,
+		`Canonical pricing: ${origin}/pricing.md`,
+		"",
+		page.summary,
+		"",
+		"Reloop is the email service / infrastructure (ESP + MTA). It is not a multi-ESP connector that sits on SendGrid, Mailgun, Resend, or SES.",
+		"",
+	];
+
+	if (page.categories) {
+		lines.push(...categoriesMarkdown(page.competitor, page.categories));
+	} else if (page.features) {
+		lines.push(`## ${page.title}`, "");
+		lines.push(...featuresTableMarkdown(page.competitor, page.features), "");
+	}
+
+	if (page.faqs.length > 0) {
+		lines.push("## FAQ", "");
+		for (const faq of page.faqs) {
+			lines.push(`### ${faq.question}`, "", faq.answer, "");
+		}
+	}
+
+	lines.push(
+		"## Related",
+		"",
+		`- Pricing: ${origin}/pricing.md`,
+		`- Compare index: ${origin}/compare.md`,
+		`- License (Apache 2.0): ${origin}/license`,
+		"",
+	);
+
+	return lines.join("\n");
+}
+
+export function buildCompareIndexMarkdown(): string {
+	const origin = getSiteUrl();
+	const lines: string[] = [
+		"# Reloop vs the competition",
+		"",
+		"> Compare Reloop with Resend, SendGrid, Mailgun, AWS SES, Postmark, Loops, and Mailchimp.",
+		"",
+		`HTML: ${origin}/compare`,
+		`Canonical pricing: ${origin}/pricing.md`,
+		"",
+		"Reloop is open-source email infrastructure (Apache 2.0): transactional API, SMTP, campaigns, webhooks, and an agent inbox. Hosted Reloop Cloud plans are Free (3,000 emails/month, 200/day), Individual $10/month (25,000), Startup $20/month (50,000), Enterprise custom. Self-host has no Reloop license fee.",
+		"",
+		"## Comparisons",
+		"",
+	];
+	for (const page of comparePages) {
+		lines.push(
+			`- [${page.title}](${origin}/compare/${page.slug}) — [markdown](${origin}/compare/${page.slug}.md)`,
+		);
+	}
+	lines.push("", "## Hosted pricing (source of truth)", "");
+	for (const faq of pricingFaqItems.slice(0, 2)) {
+		lines.push(`### ${faq.question}`, "", faq.answer, "");
+	}
+	return lines.join("\n");
+}
+
+export function buildCompareJsonLd(page: ComparePageContent) {
+	const siteUrl = getSiteUrl();
+	const url = `${siteUrl}/compare/${page.slug}`;
+	const graph: Record<string, unknown>[] = [
+		{
+			"@context": "https://schema.org",
+			"@type": "WebPage",
+			name: page.title,
+			description: page.description,
+			url,
+			about: {
+				"@type": "SoftwareApplication",
+				name: "Reloop",
+				applicationCategory: "DeveloperApplication",
+				url: siteUrl,
+			},
+		},
+		pricingProductJsonLd(siteUrl),
+	];
+	if (page.faqs.length > 0) {
+		graph.push(faqPageJsonLd(page.faqs));
+	}
+	return graph;
+}
+
+export { sendgridFeatures, mailgunFeatures, awsSesFeatures, postmarkFeatures, mailchimpFeatures };

--- a/apps/frontend/web/src/lib/compare-content.ts
+++ b/apps/frontend/web/src/lib/compare-content.ts
@@ -208,7 +208,7 @@ export const comparePages: ComparePageContent[] = [
 			{
 				question: "Is Reloop open source?",
 				answer:
-					"Yes. Reloop is Apache 2.0 with Reloop Labs use restrictions. Self-host at no Reloop license fee, or use Reloop Cloud.",
+					"Yes. Reloop is licensed under Apache License 2.0 plus additional Reloop Labs terms: personal and internal self-host is allowed; commercial redistribution, third-party hosted services, and competing products are not. See https://reloop.sh/license. Reloop Cloud is the official hosted service.",
 			},
 		],
 	},

--- a/apps/frontend/web/src/lib/pricing-faq.ts
+++ b/apps/frontend/web/src/lib/pricing-faq.ts
@@ -1,0 +1,38 @@
+export type PricingFaqItem = {
+	question: string;
+	answer: string;
+};
+
+/** Canonical pricing FAQ — UI and JSON-LD must stay in lockstep. */
+export const pricingFaqItems: PricingFaqItem[] = [
+	{
+		question: "What counts as an email?",
+		answer:
+			"Each successfully sent email counts toward your monthly quota—transactional messages, campaign sends, and SMTP relay deliveries all use credits the same way.",
+	},
+	{
+		question: "Do I need a credit card to start?",
+		answer:
+			"No. The Free plan includes 3,000 emails per month and 200 emails per day, with no credit card required. Upgrade when your volume grows.",
+	},
+	{
+		question: "What happens if I exceed my monthly limit?",
+		answer:
+			"On paid plans, overage emails are billed at $0.80 per 1,000. On the Free plan, sending pauses at 3,000 emails per month or 200 emails per day until the next period unless you upgrade. Free has no overage.",
+	},
+	{
+		question: "Is self-hosting really free?",
+		answer:
+			"Yes. Reloop is open source under Apache 2.0 with Reloop Labs use restrictions. You can deploy on your own infrastructure at no Reloop license cost—you pay only for your servers and email delivery infrastructure. Self-host is not a Reloop Cloud subscription.",
+	},
+	{
+		question: "Is hosted pricing different from self-hosted?",
+		answer:
+			"Yes. Reloop Cloud (hosted) uses the published Free, Individual ($10/mo), Startup ($20/mo), and Enterprise tiers. Self-hosting the Apache 2.0 stack has no Reloop SaaS fee—it is not the same as buying those hosted plans for your own servers.",
+	},
+	{
+		question: "Can I switch plans at any time?",
+		answer:
+			"Yes. Upgrade or downgrade from your dashboard. Plan changes apply to the current billing period according to your subscription settings.",
+	},
+];

--- a/apps/frontend/web/src/lib/pricing-md.ts
+++ b/apps/frontend/web/src/lib/pricing-md.ts
@@ -40,7 +40,7 @@ export function buildPricingMarkdown(): string {
 	lines.push(
 		"## Self-host",
 		"",
-		"Self-hosting the open-source Reloop stack is free (infrastructure costs are yours).",
+		"Self-hosting the open-source Reloop stack has no Reloop license fee (infrastructure costs are yours). It is not a Reloop Cloud subscription and does not use the hosted Free / Individual / Startup / Enterprise price list.",
 		"See https://reloop.sh/self-host",
 		"",
 		"## Related",

--- a/apps/frontend/web/src/lib/schema.ts
+++ b/apps/frontend/web/src/lib/schema.ts
@@ -1,0 +1,102 @@
+import { pricingPlans, type PricingPlan } from "@reloop/pricing";
+import { getSiteUrl, siteDescription, siteName } from "@reloop/web/lib/site";
+
+export type FaqEntry = {
+	question: string;
+	answer: string;
+};
+
+export function faqPageJsonLd(items: FaqEntry[]) {
+	return {
+		"@context": "https://schema.org" as const,
+		"@type": "FAQPage" as const,
+		mainEntity: items.map((item) => ({
+			"@type": "Question" as const,
+			name: item.question,
+			acceptedAnswer: {
+				"@type": "Answer" as const,
+				text: item.answer,
+			},
+		})),
+	};
+}
+
+function planDescription(plan: PricingPlan): string {
+	const daily =
+		plan.comparison.dailyLimit === "No limit"
+			? "no daily send cap"
+			: `${plan.comparison.dailyLimit} emails per day`;
+	const extra = plan.extraEmailsLabel ? ` ${plan.extraEmailsLabel}.` : "";
+	return `${plan.description} ${plan.emailsLabel}, ${daily}.${extra}`;
+}
+
+export function pricingOfferJsonLd(plan: PricingPlan, siteUrl: string) {
+	const pricingUrl = `${siteUrl}/pricing`;
+	const ctaUrl = plan.ctaHref.startsWith("http")
+		? plan.ctaHref
+		: `${siteUrl}${plan.ctaHref}`;
+
+	if (plan.monthlyPrice === null) {
+		return {
+			"@type": "Offer" as const,
+			name: `${plan.name} plan`,
+			description: planDescription(plan),
+			url: ctaUrl,
+			availability: "https://schema.org/InStock" as const,
+			priceCurrency: "USD",
+		};
+	}
+
+	return {
+		"@type": "Offer" as const,
+		name: `${plan.name} plan`,
+		description: planDescription(plan),
+		url: pricingUrl,
+		availability: "https://schema.org/InStock" as const,
+		price: String(plan.monthlyPrice),
+		priceCurrency: "USD",
+		priceSpecification: {
+			"@type": "UnitPriceSpecification" as const,
+			price: String(plan.monthlyPrice),
+			priceCurrency: "USD",
+			unitText: "MONTH",
+		},
+	};
+}
+
+export function pricingOffersJsonLd(siteUrl = getSiteUrl()) {
+	return pricingPlans.map((plan) => pricingOfferJsonLd(plan, siteUrl));
+}
+
+const PRODUCT_DESCRIPTION =
+	"Open-source email infrastructure (Apache 2.0). Hosted Reloop Cloud plans: Free (3,000 emails/month, 200/day), Individual $10/month (25,000 emails, no daily cap), Startup $20/month (50,000 emails, no daily cap), Enterprise custom. Self-host has no Reloop license fee.";
+
+/** Product + Offer JSON-LD driven by `@reloop/pricing`. No reviews or invented plans. */
+export function pricingProductJsonLd(siteUrl = getSiteUrl()) {
+	return {
+		"@context": "https://schema.org" as const,
+		"@type": "Product" as const,
+		name: "Reloop",
+		image: `${siteUrl}/web-app-manifest-512x512.png`,
+		description: PRODUCT_DESCRIPTION,
+		brand: {
+			"@type": "Brand" as const,
+			name: "Reloop Labs",
+		},
+		license: `${siteUrl}/license`,
+		offers: pricingOffersJsonLd(siteUrl),
+	};
+}
+
+export function pricingSoftwareApplicationJsonLd(siteUrl = getSiteUrl()) {
+	return {
+		"@context": "https://schema.org" as const,
+		"@type": "SoftwareApplication" as const,
+		name: siteName,
+		operatingSystem: "All",
+		applicationCategory: "DeveloperApplication",
+		description: siteDescription,
+		license: `${siteUrl}/license`,
+		offers: pricingOffersJsonLd(siteUrl),
+	};
+}

--- a/apps/frontend/web/src/lib/schema.ts
+++ b/apps/frontend/web/src/lib/schema.ts
@@ -32,19 +32,9 @@ function planDescription(plan: PricingPlan): string {
 
 export function pricingOfferJsonLd(plan: PricingPlan, siteUrl: string) {
 	const pricingUrl = `${siteUrl}/pricing`;
-	const ctaUrl = plan.ctaHref.startsWith("http")
-		? plan.ctaHref
-		: `${siteUrl}${plan.ctaHref}`;
 
 	if (plan.monthlyPrice === null) {
-		return {
-			"@type": "Offer" as const,
-			name: `${plan.name} plan`,
-			description: planDescription(plan),
-			url: ctaUrl,
-			availability: "https://schema.org/InStock" as const,
-			priceCurrency: "USD",
-		};
+		return null;
 	}
 
 	return {
@@ -65,7 +55,9 @@ export function pricingOfferJsonLd(plan: PricingPlan, siteUrl: string) {
 }
 
 export function pricingOffersJsonLd(siteUrl = getSiteUrl()) {
-	return pricingPlans.map((plan) => pricingOfferJsonLd(plan, siteUrl));
+	return pricingPlans
+		.map((plan) => pricingOfferJsonLd(plan, siteUrl))
+		.filter((offer): offer is NonNullable<typeof offer> => offer !== null);
 }
 
 const PRODUCT_DESCRIPTION =

--- a/apps/frontend/web/src/lib/sitemap-md.ts
+++ b/apps/frontend/web/src/lib/sitemap-md.ts
@@ -270,6 +270,7 @@ export function buildPublicDiscoveryMarkdown(
 		"## Markdown twins",
 		"",
 		`- Site index pages: \`${origin}/index.md\`, \`${origin}/about.md\`, \`${origin}/developers.md\`, \`${origin}/pricing.md\``,
+		`- Compare pages: \`${origin}/compare.md\`, \`${origin}/compare/<vendor>.md\``,
 		`- Blog posts: \`${origin}/blog/<slug>.md\``,
 		`- Docs pages: \`${origin}/docs/<path>.md\``,
 		"- Docs content negotiation: `Accept: text/markdown` on `/docs/*` HTML routes",

--- a/packages/pricing/src/index.ts
+++ b/packages/pricing/src/index.ts
@@ -262,7 +262,7 @@ export const pricingPlans: PricingPlan[] = [
 			webhooks: "Custom",
 			customDomains: "Custom",
 			attachmentSize: "Custom",
-			dataRetention: "Custom",
+			dataRetention: "45 days",
 			restApi: true,
 			smtpRelay: true,
 			scheduledEmails: true,
@@ -391,6 +391,32 @@ export const comparisonSections: ComparisonSection[] = [
 		rows: [{ label: "Uptime SLA Guarantee", key: "uptimeSla", type: "text" }],
 	},
 ];
+
+export const paidOverageUsdPerThousand = 0.8;
+
+/**
+ * Cheapest published Reloop Cloud USD for a monthly send volume.
+ * Free has no overage (sending pauses). Paid plans use included volume + $0.80/1k.
+ */
+export function hostedMonthlyUsdForVolume(volume: number): number {
+	if (volume <= 0) return 0;
+	const free = pricingPlans.find((p) => p.id === "free");
+	const freeIncluded = Number(
+		(free?.comparison.monthlyEmails ?? "3000").replace(/,/g, ""),
+	);
+	if (volume <= freeIncluded) return 0;
+
+	let best = Number.POSITIVE_INFINITY;
+	for (const plan of pricingPlans) {
+		if (plan.monthlyPrice === null || plan.monthlyPrice === 0) continue;
+		const included = Number(plan.comparison.monthlyEmails.replace(/,/g, ""));
+		if (!Number.isFinite(included)) continue;
+		const extraThousands = Math.max(0, volume - included) / 1000;
+		const cost = plan.monthlyPrice + extraThousands * paidOverageUsdPerThousand;
+		if (cost < best) best = cost;
+	}
+	return Number.isFinite(best) ? Math.round(best) : 0;
+}
 
 export function formatPrice(amount: number) {
 	return new Intl.NumberFormat("en-US", {


### PR DESCRIPTION
## Summary
- Drive Product/Offer JSON-LD from `@reloop/pricing` and remove fake `aggregateRating` / `Sarah Chen` reviews. Hosted offers are now Free / Individual $10 / Startup $20 / Enterprise — not “Essentials $9”.
- Correct AI-citation facts: Reloop Cloud Free is 3,000 emails/month with a **200/day** cap; license is Apache 2.0 (not MIT); Enterprise retention matches 45 days; hosted vs self-host FAQ no longer implies paid self-host SaaS tiers.
- Enrich `llms.txt` / `index.md` / `about.md` with ICP, what Reloop is and is not, a pricing snapshot, and compare `.md` twins plus FAQ/Product schema on vs-X pages. Docs `guides/pricing.mdx` now points at canonical `/pricing.md`.

## Test plan
- [ ] Open `/pricing` and inspect JSON-LD: four real offers, no reviews, FAQ matches the page.
- [ ] `curl https://reloop.sh/pricing.md` (or local) lists Free 200/day; Individual/Startup “No daily limit”.
- [ ] `/compare/resend` Free daily limit is 200/day; `/compare/resend.md` twin exists via markdown rewrite.
- [ ] `/skill.md` frontmatter `license: Apache-2.0`; blog Open Source CTA no longer says MIT.
- [ ] `/llms.txt` includes what Reloop is/isn't, ICP, and compare `.md` links.
- [ ] Docs `/docs/guides/pricing` matches published Cloud tiers and links to `/pricing.md`.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comparison pages for major email providers with updated feature, pricing, FAQ, and savings information.
  * Added structured metadata to improve search and discovery across pricing and comparison pages.
  * Added markdown access to comparison content and expanded product discovery resources.

* **Documentation**
  * Clarified hosted pricing, usage limits, overages, retention, self-hosting costs, licensing, target audiences, and product scope.
  * Updated licensing references from MIT to Apache 2.0.

* **Bug Fixes**
  * Corrected pricing calculations, free-tier limits, overage details, and enterprise data retention information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR centralizes hosted-plan facts and expands machine-readable pricing and comparison content while removing stale reviews and licensing claims.
- Sources Product and Offer metadata from `@reloop/pricing`.
- Updates hosted limits, retention, licensing, FAQs, comparison pages, and markdown discovery resources.
- Adds shared schema, comparison-content, and pricing-markdown helpers.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because the comparison calculator continues to publish an overage rate that contradicts the calculation it presents.

The marketing calculator computes hosted Reloop costs with the shared `$0.80 / 1k` overage rate while its visible savings footnote still tells users the rate is `$0.10 / 1k`, leaving the previously reported pricing contradiction unresolved.

**Files Needing Attention:** apps/frontend/web/src/app/compare/components/compare-calculator.tsx

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/pricing/src/index.ts | Defines the canonical hosted tiers, limits, overage rate, and volume-based pricing helper. |
| apps/frontend/web/src/app/pricing/page.tsx | Reworks pricing metadata and structured data to consume canonical plan information without fabricated ratings or reviews. |
| apps/frontend/web/src/app/compare/components/compare-calculator.tsx | Uses the shared pricing engine, but the previously reported marketing footnote remains inconsistent with its overage rate. |
| apps/frontend/web/src/lib/compare-content.ts | Adds centralized markdown content generation for vendor comparison pages. |
| apps/frontend/web/src/lib/schema.ts | Adds reusable structured-data builders for products, offers, breadcrumbs, and FAQs. |
| apps/frontend/web/src/lib/sitemap-md.ts | Adds compare-page discovery links to the markdown sitemap without introducing a reachable injection path. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  P["@reloop/pricing"] --> W["Pricing page"]
  P --> J["Product / Offer JSON-LD"]
  P --> M["pricing.md"]
  C["Comparison data"] --> V["Vendor comparison pages"]
  C --> S["FAQ / Product schema"]
  C --> D["Compare markdown twins"]
  D --> L["llms.txt and sitemap.md discovery"]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: align leftover GEO facts with canon..."](https://github.com/reloop-labs/reloop/commit/10e5c66b42f19117dd7a0d04b5e4ecad73550693) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55130953)</sub>

<!-- /greptile_comment -->