### PR TITLE
fix(dashboard): send logout to the landing page instead of login

### DIFF
--- a/apps/frontend/dashboard/src/features/auth/session-query.test.ts
+++ b/apps/frontend/dashboard/src/features/auth/session-query.test.ts
@@ -75,16 +75,16 @@ describe("logout session cache", () => {
 			defaultOptions: { queries: { staleTime: 30_000 } },
 		});
 		seedAuthenticatedCache(queryClient);
-		const push = vi.fn();
+		const navigate = vi.fn();
 
-		await signOutAndClearSession(queryClient, { push });
+		await signOutAndClearSession(queryClient, navigate);
 
 		expect(signOutMock).toHaveBeenCalledOnce();
 		expect(queryClient.getQueryData(queryKeys.auth.session())).toBeUndefined();
-		expect(push).toHaveBeenCalledWith("/login");
+		expect(navigate).toHaveBeenCalledWith("/");
 		// Order: API sign-out first, then navigate (cache already empty)
 		expect(signOutMock.mock.invocationCallOrder[0]).toBeLessThan(
-			push.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
+			navigate.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
 		);
 	});
 });

--- a/apps/frontend/dashboard/src/features/auth/session-query.ts
+++ b/apps/frontend/dashboard/src/features/auth/session-query.ts
@@ -5,7 +5,6 @@ import {
 	useQuery,
 	useQueryClient,
 } from "@tanstack/react-query";
-import { useRouter } from "next/navigation";
 
 import { useCallback } from "react";
 import { queryKeys } from "#/lib/query-keys";
@@ -65,24 +64,19 @@ export function clearClientAuthState(queryClient: QueryClient) {
 	queryClient.clear();
 }
 
-/**
- * Sign out via Better Auth, wipe the client cache, then go to login.
- * Shared by the user menu and command palette.
- */
+/** Full-page nav to `/` so we leave dashboard `basePath`. */
 export async function signOutAndClearSession(
 	queryClient: QueryClient,
-	router: { push: (href: string) => void },
+	navigate: (href: string) => void = (href) => {
+		window.location.href = href;
+	},
 ) {
 	await authClient.signOut();
 	clearClientAuthState(queryClient);
-	router.push("/login");
+	navigate("/");
 }
 
 export function useSignOut() {
 	const queryClient = useQueryClient();
-	const router = useRouter();
-	return useCallback(
-		() => signOutAndClearSession(queryClient, router),
-		[queryClient, router],
-	);
+	return useCallback(() => signOutAndClearSession(queryClient), [queryClient]);
 }


### PR DESCRIPTION
Summary
- After logout, send the user to the marketing homepage (/) instead of /dashboard/login.

- Use a full-page navigation so we leave the dashboard basePath. router.push("/") stays on /dashboard and the protected layout then bounces a signed-out user back to login.

Test plan
- [x] Sign in, open the user menu, and log out
- [x] Confirm the browser lands on / (landing page), not /dashboard/login
- [x] Visiting a protected dashboard URL while signed out still redirects to /dashboard/login

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated sign-out behavior to reliably clear the session before navigating.
  - Signing out now redirects to the home page instead of the login page.
  - Improved navigation handling during logout, including fallback browser navigation.

- **Tests**
  - Updated logout coverage to verify the new navigation destination and execution order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR changes dashboard logout to perform a full-page navigation to the marketing homepage, escaping the dashboard base path.
- Replaces the Next.js router dependency with an injectable full-page navigation callback.
- Updates the logout cache test to verify navigation to `/` after sign-out and cache clearing.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security issues identified.

The browser-only logout path signs out, clears cached client state, and then performs the intended full-page navigation outside the dashboard base path; all existing callers and focused tests match the revised helper contract.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/frontend/dashboard/src/features/auth/session-query.ts | Replaces base-path-aware router navigation with intentional browser-level navigation after logout; no actionable regression found. |
| apps/frontend/dashboard/src/features/auth/session-query.test.ts | Updates the focused logout test for the new callback contract and landing-page destination. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(dashboard): send logout to the landi..."](https://github.com/reloop-labs/reloop/commit/92f1fa9f1e73b03272d5c96a4d611bd3c1bbe3ae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55663723)</sub>

<!-- /greptile_comment -->