### PR TITLE
fix: remove deprecated TypeScript baseUrl from tsconfigs

### DIFF
--- a/apps/backend/admin/tsconfig.json
+++ b/apps/backend/admin/tsconfig.json
@@ -12,7 +12,6 @@
 		"composite": false,
 		"declaration": false,
 		"declarationMap": false,
-		"baseUrl": ".",
 		"rootDir": "./src",
 		"paths": {
 			"@reloop/admin/*": ["./src/*"]

--- a/apps/backend/api-key/tsconfig.json
+++ b/apps/backend/api-key/tsconfig.json
@@ -12,7 +12,6 @@
 		"composite": false,
 		"declaration": false,
 		"declarationMap": false,
-		"baseUrl": ".",
 		"paths": {
 			"@reloop/api-key/*": ["./src/*"]
 		}

--- a/apps/backend/auth/tsconfig.json
+++ b/apps/backend/auth/tsconfig.json
@@ -10,7 +10,6 @@
 		"outDir": "./dist",
 		"types": ["bun"],
 		"composite": false,
-		"declarationMap": false,
-		"baseUrl": "."
+		"declarationMap": false
 	}
 }

--- a/apps/backend/contacts/tsconfig.json
+++ b/apps/backend/contacts/tsconfig.json
@@ -12,9 +12,8 @@
 		"composite": false,
 		"declaration": false,
 		"declarationMap": false,
-		"baseUrl": "./src",
 		"paths": {
-			"@be/contacts/*": ["./*"]
+			"@be/contacts/*": ["./src/*"]
 		}
 	},
 	"include": ["src/**/*"],

--- a/apps/backend/credits/tsconfig.json
+++ b/apps/backend/credits/tsconfig.json
@@ -13,7 +13,6 @@
 		"jsx": "react-jsx",
 		"declaration": false,
 		"declarationMap": false,
-		"baseUrl": ".",
 		"rootDir": "./src",
 		"paths": {
 			"@reloop/credits/*": ["./src/*"]

--- a/apps/backend/domain/tsconfig.json
+++ b/apps/backend/domain/tsconfig.json
@@ -12,9 +12,8 @@
 		"composite": false,
 		"declaration": false,
 		"declarationMap": false,
-		"baseUrl": "./src",
 		"paths": {
-			"@reloop/domain/*": ["./*"]
+			"@reloop/domain/*": ["./src/*"]
 		}
 	}
 }

--- a/apps/backend/email/tsconfig.json
+++ b/apps/backend/email/tsconfig.json
@@ -13,7 +13,6 @@
 		"jsx": "react-jsx",
 		"declaration": false,
 		"declarationMap": false,
-		"baseUrl": ".",
 		"paths": {
 			"@reloop/email/*": ["./src/*"],
 			"@reloop/email/emails/*": ["./emails/*"],

--- a/apps/backend/inbox/tsconfig.json
+++ b/apps/backend/inbox/tsconfig.json
@@ -13,7 +13,6 @@
 		"jsx": "react-jsx",
 		"declaration": false,
 		"declarationMap": false,
-		"baseUrl": ".",
 		"paths": {
 			"@reloop/be-inbox/*": ["./src/*"]
 		}

--- a/apps/backend/logs/tsconfig.json
+++ b/apps/backend/logs/tsconfig.json
@@ -13,7 +13,6 @@
 		"jsx": "react-jsx",
 		"declaration": false,
 		"declarationMap": false,
-		"baseUrl": ".",
 		"paths": {
 			"@reloop/logs/*": ["./src/*"]
 		}

--- a/apps/backend/mail/tsconfig.json
+++ b/apps/backend/mail/tsconfig.json
@@ -13,7 +13,6 @@
 		"jsx": "react-jsx",
 		"declaration": false,
 		"declarationMap": false,
-		"baseUrl": ".",
 		"paths": {
 			"@reloop/be-mail/*": ["./src/*"]
 		}

--- a/apps/backend/template/tsconfig.json
+++ b/apps/backend/template/tsconfig.json
@@ -13,7 +13,6 @@
 		"jsx": "react-jsx",
 		"declaration": false,
 		"declarationMap": false,
-		"baseUrl": ".",
 		"paths": {
 			"@be/template/*": ["./src/*"]
 		}

--- a/apps/backend/tools/tsconfig.json
+++ b/apps/backend/tools/tsconfig.json
@@ -12,9 +12,8 @@
 		"composite": false,
 		"declaration": false,
 		"declarationMap": false,
-		"baseUrl": "./src",
 		"paths": {
-			"@be/tools/*": ["./*"]
+			"@be/tools/*": ["./src/*"]
 		}
 	},
 	"include": ["src", "test"]

--- a/apps/backend/upload/tsconfig.json
+++ b/apps/backend/upload/tsconfig.json
@@ -13,7 +13,6 @@
 		"jsx": "react-jsx",
 		"declaration": false,
 		"declarationMap": false,
-		"baseUrl": ".",
 		"paths": {
 			"@be/upload/*": ["./src/*"]
 		}

--- a/apps/backend/webhook/tsconfig.json
+++ b/apps/backend/webhook/tsconfig.json
@@ -13,7 +13,6 @@
 		"jsx": "react-jsx",
 		"declaration": false,
 		"declarationMap": false,
-		"baseUrl": ".",
 		"paths": {
 			"@reloop/webhook/*": ["./src/*"],
 			"@reloop/webhook-events": [

--- a/apps/backend/workflow/tsconfig.json
+++ b/apps/backend/workflow/tsconfig.json
@@ -12,9 +12,8 @@
 		"composite": false,
 		"declaration": false,
 		"declarationMap": false,
-		"baseUrl": "./src",
 		"paths": {
-			"@be/workflow/*": ["./*"]
+			"@be/workflow/*": ["./src/*"]
 		}
 	},
 	"include": ["src"]

--- a/apps/frontend/console/tsconfig.json
+++ b/apps/frontend/console/tsconfig.json
@@ -1,7 +1,6 @@
 {
 	"extends": "@reloop/tsconfig/nextjs.json",
 	"compilerOptions": {
-		"baseUrl": ".",
 		"paths": {
 			"@fe/console/*": ["./src/*"]
 		}

--- a/apps/frontend/dashboard/tsconfig.json
+++ b/apps/frontend/dashboard/tsconfig.json
@@ -1,7 +1,6 @@
 {
 	"extends": "@reloop/tsconfig/nextjs.json",
 	"compilerOptions": {
-		"baseUrl": ".",
 		"paths": {
 			"#/*": ["./src/*"],
 			"@/*": ["./src/*"],

--- a/apps/frontend/docs/tsconfig.json
+++ b/apps/frontend/docs/tsconfig.json
@@ -15,7 +15,6 @@
 		"isolatedModules": true,
 		"jsx": "preserve",
 		"incremental": true,
-		"baseUrl": ".",
 		"paths": {
 			"@reloop/fe-docs/*": ["./src/*"],
 			"@reloop/fe-docs/.source": [".source"],

--- a/apps/frontend/links/tsconfig.json
+++ b/apps/frontend/links/tsconfig.json
@@ -1,7 +1,6 @@
 {
 	"extends": "@reloop/tsconfig/nextjs.json",
 	"compilerOptions": {
-		"baseUrl": ".",
 		"paths": {
 			"@reloop/links/*": ["./src/*"]
 		}

--- a/apps/frontend/web/tsconfig.json
+++ b/apps/frontend/web/tsconfig.json
@@ -1,7 +1,6 @@
 {
 	"extends": "@reloop/tsconfig/nextjs.json",
 	"compilerOptions": {
-		"baseUrl": ".",
 		"paths": {
 			"@reloop/web/*": ["./src/*"],
 			"@be/domain/*": ["../../backend/domain/src/*"]

--- a/packages/auth/tsconfig.json
+++ b/packages/auth/tsconfig.json
@@ -7,7 +7,6 @@
 		"moduleResolution": "NodeNext",
 		"jsx": "react-jsx",
 		"jsxImportSource": "react",
-		"baseUrl": ".",
 		"paths": {
 			"@reloop/auth/*": ["./src/*"]
 		}

--- a/packages/bus/tsconfig.json
+++ b/packages/bus/tsconfig.json
@@ -1,8 +1,5 @@
 {
 	"extends": "@reloop/tsconfig/base.json",
 	"include": ["src"],
-	"exclude": ["node_modules"],
-	"compilerOptions": {
-		"baseUrl": "."
-	}
+	"exclude": ["node_modules"]
 }

--- a/packages/cache/tsconfig.json
+++ b/packages/cache/tsconfig.json
@@ -1,8 +1,5 @@
 {
 	"extends": "@reloop/tsconfig/base.json",
 	"include": ["src"],
-	"exclude": ["node_modules"],
-	"compilerOptions": {
-		"baseUrl": "."
-	}
+	"exclude": ["node_modules"]
 }

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -3,7 +3,6 @@
 	"include": ["src"],
 	"exclude": ["node_modules"],
 	"compilerOptions": {
-		"baseUrl": ".",
 		"module": "ESNext",
 		"moduleResolution": "bundler"
 	}

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -14,7 +14,6 @@
 		"skipLibCheck": true,
 		"strict": true,
 		"target": "ES2022",
-		"baseUrl": ".",
 		"paths": {
 			"@reloop/db": ["../../packages/db/src/*"],
 			"@reloop/cache": ["../../packages/cache/src/*"],

--- a/packages/tsconfig/nextjs.json
+++ b/packages/tsconfig/nextjs.json
@@ -9,7 +9,6 @@
 		"allowJs": true,
 		"jsx": "preserve",
 		"noEmit": true,
-		"baseUrl": ".",
 		"paths": {
 			"@reloop/ui": ["../../packages/ui/src/*"],
 			"@reloop/auth": ["../../packages/auth/src/*"],

--- a/packages/webhook-delivery/tsconfig.json
+++ b/packages/webhook-delivery/tsconfig.json
@@ -1,8 +1,5 @@
 {
 	"extends": "@reloop/tsconfig/base.json",
 	"include": ["src", "test"],
-	"exclude": ["node_modules"],
-	"compilerOptions": {
-		"baseUrl": "."
-	}
+	"exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Summary
- Remove the deprecated `baseUrl` compiler option from shared and package `tsconfig` files so TypeScript 6 no longer reports `TS5101`.
- `paths` no longer need `baseUrl` (especially when it was `.`). For the few configs that used `"baseUrl": "./src"`, that prefix is now inlined into the path mappings.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the deprecated TypeScript `baseUrl` option while preserving existing module-resolution targets.
- Removes `baseUrl` from shared, backend, frontend, and package tsconfigs.
- Rewrites mappings previously relative to `"./src"` so they remain equivalent without `baseUrl`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete module-resolution, build, or security regression identified.

The removed `"baseUrl": "."` settings were redundant for the relative mappings, while every mapping formerly based at `"./src"` was adjusted to retain the same resolved filesystem target.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/tsconfig/base.json | Removes the shared `"baseUrl": "."`; its relative path targets continue resolving from the directory containing this config. |
| packages/tsconfig/nextjs.json | Removes the redundant Next.js base URL while preserving the shared aliases and their filesystem targets. |
| apps/backend/contacts/tsconfig.json | Rewrites the contacts alias from `./*` to `./src/*` to preserve its target after removing `"baseUrl": "./src"`. |
| apps/backend/domain/tsconfig.json | Preserves domain alias resolution by inlining the former `./src` base into the path mapping. |
| apps/backend/tools/tsconfig.json | Preserves tools alias resolution by replacing the former base-relative mapping with `./src/*`. |
| apps/backend/workflow/tsconfig.json | Preserves workflow alias resolution by inlining the removed `./src` base into the mapping. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: remove deprecated TypeScript baseUr..."](https://github.com/reloop-labs/reloop/commit/c5e6c856cb2cb3f5e728e1067e7d699b292c756e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55693624)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized TypeScript project configuration across backend, frontend, and shared packages.
  - Removed legacy path-resolution settings while preserving existing import aliases.
  - Updated selected aliases to resolve source modules consistently.
  - No end-user-facing functionality or public APIs changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->