### PR TITLE
feat: apply domain TLS mode on outbound SMTP delivery

### DIFF
--- a/apps/backend/domain/src/routes/kumomta/log-incoming/log-incoming.controllers.ts
+++ b/apps/backend/domain/src/routes/kumomta/log-incoming/log-incoming.controllers.ts
@@ -34,6 +34,7 @@ export async function logIncomingController({
 	trackingDomain: string | null;
 	clickTracking: boolean;
 	openTracking: boolean;
+	tls: "opportunistic" | "enforced";
 }> {
 	const log = useLogger();
 	let textBody = body.textBody || "";
@@ -81,6 +82,7 @@ export async function logIncomingController({
 			trackingSubdomain: true,
 			domain: true,
 			systemVerified: true,
+			tls: true,
 		},
 	});
 
@@ -163,5 +165,6 @@ export async function logIncomingController({
 		trackingDomain,
 		clickTracking: domainRecord.isClickTrackingEnabled,
 		openTracking: domainRecord.isOpenTrackingEnabled,
+		tls: domainRecord.tls ?? "opportunistic",
 	};
 }

--- a/apps/backend/domain/src/routes/kumomta/log-incoming/log-incoming.route.ts
+++ b/apps/backend/domain/src/routes/kumomta/log-incoming/log-incoming.route.ts
@@ -28,6 +28,7 @@ export const logIncomingRoute = new Elysia().use(authMiddleware).post(
 				trackingDomain: t.Nullable(t.String()),
 				clickTracking: t.Boolean(),
 				openTracking: t.Boolean(),
+				tls: t.Union([t.Literal("opportunistic"), t.Literal("enforced")]),
 			}),
 			400: ErrorResponseSchema,
 			401: ErrorResponseSchema,

--- a/apps/backend/mail/src/routes/mail/send-email/send-email.controllers.ts
+++ b/apps/backend/mail/src/routes/mail/send-email/send-email.controllers.ts
@@ -144,6 +144,7 @@ export async function sendEmailController({
 		domainId: currentDomain.id,
 		emailLogId,
 		apiKey,
+		tlsMode: currentDomain.tls ?? "opportunistic",
 		useInternalInject,
 	});
 

--- a/apps/backend/mail/src/routes/mail/send-email/steps/step-6-send-email.ts
+++ b/apps/backend/mail/src/routes/mail/send-email/steps/step-6-send-email.ts
@@ -14,6 +14,7 @@ export async function sendEmail_step6({
 	domainId,
 	emailLogId,
 	apiKey,
+	tlsMode,
 	useInternalInject = false,
 }: {
 	body: MailModel.SendEmailBody;
@@ -24,6 +25,7 @@ export async function sendEmail_step6({
 	domainId: string;
 	emailLogId: string;
 	apiKey: string;
+	tlsMode: "opportunistic" | "enforced";
 	useInternalInject?: boolean;
 }) {
 	try {
@@ -55,6 +57,7 @@ export async function sendEmail_step6({
 				// Never put the internal secret into outbound message headers.
 				...(useInternalInject ? {} : { "X-Api-Key": apiKey }),
 				...(body.headers || {}),
+				"X-Reloop-TLS-Mode": tlsMode,
 			},
 		});
 	} catch (error) {

--- a/apps/backend/smtp/package.json
+++ b/apps/backend/smtp/package.json
@@ -1,5 +1,8 @@
 {
 	"name": "be-smtp",
 	"version": "1.0.0",
-	"private": true
+	"private": true,
+	"scripts": {
+		"test": "bun test test/"
+	}
 }

--- a/apps/backend/smtp/policy/queue.lua
+++ b/apps/backend/smtp/policy/queue.lua
@@ -1,5 +1,16 @@
 local kumo = require 'kumo'
 local constants = require 'policy.constants'
+local tls = require 'policy.tls'
+
+kumo.on('get_egress_pool', function(pool_name)
+  local make = kumo.make_egress_pool or function(t) return t end
+  return make {
+    name = pool_name,
+    entries = {
+      { name = pool_name },
+    },
+  }
+end)
 
 kumo.on('get_queue_config', function(domain, tenant, campaign, routing_domain)
   if domain:find('%.log_hook$') then
@@ -8,30 +19,32 @@ kumo.on('get_queue_config', function(domain, tenant, campaign, routing_domain)
     }
   end
 
-  if constants.env == 'development' then
-    return kumo.make_queue_config {
-      protocol = {
-        smtp = {
-          mx_list = { 'reloop-mailpit:1025' },
-          ehlo_domain = constants.hostname,
-        },
+  local queue = {
+    egress_pool = tls.egress_pool(tenant),
+  }
+
+  if tls.is_development(constants.env) then
+    queue.protocol = {
+      smtp = {
+        mx_list = { 'reloop-mailpit:1025' },
+        ehlo_domain = constants.hostname,
+      },
+    }
+  else
+    queue.protocol = {
+      smtp = {
+        ehlo_domain = constants.hostname,
       },
     }
   end
 
-  return kumo.make_queue_config {
-    protocol = {
-      smtp = {
-        ehlo_domain = constants.hostname,
-      },
-    },
-  }
+  return kumo.make_queue_config(queue)
 end)
 
 kumo.on('get_egress_path_config', function(routing_domain, egress_source, site_name)
   local make = kumo.make_egress_path or function(t) return t end
   return make {
-    enable_tls = "OpportunisticInsecure",
+    enable_tls = tls.enable_tls(constants.env, egress_source),
     ehlo_domain = constants.hostname,
   }
 end)
@@ -39,6 +52,7 @@ end)
 kumo.on('get_egress_source', function(source_name)
   local make = kumo.make_egress_source or function(t) return t end
   return make {
+    name = source_name,
     ehlo_domain = constants.hostname,
   }
 end)

--- a/apps/backend/smtp/policy/smtp.lua
+++ b/apps/backend/smtp/policy/smtp.lua
@@ -15,6 +15,8 @@ local function apply_reloop_logic(msg, api_key)
     print("[LOG-INCOMING] [" .. msg_id .. "] Found X-Api-Key header: using it as api_key")
   end
   msg:remove_all_named_headers('X-Api-Key')
+  local header_tls_mode = msg:get_first_named_header_value('X-Reloop-TLS-Mode')
+  msg:remove_all_named_headers('X-Reloop-TLS-Mode')
   local sender = msg:sender()
   local domain = ""
   local from_email = ""
@@ -131,8 +133,10 @@ local function apply_reloop_logic(msg, api_key)
           msg:set_data(new_data)
           print("[TRACKING] [" .. msg_id .. "] injected tracking into message (domain: " .. tostring(body.trackingDomain) .. ")")
         end
+        utils.apply_tls_mode(msg, body.tls or header_tls_mode)
       else
         print("[LOG-INCOMING] [" .. msg_id .. "] ERROR: backend returned 200 but no ID found")
+        utils.apply_tls_mode(msg, header_tls_mode)
       end
     elseif code == 401 then
       print("[LOG-INCOMING] [" .. msg_id .. "] REJECTED: Invalid API key")
@@ -154,6 +158,7 @@ local function apply_reloop_logic(msg, api_key)
   else
     msg:set_meta('X-Email-Log-ID', existing_log_id)
     print("[LOG-INCOMING] [" .. msg_id .. "] Skipped log-incoming, already logged with ID=" .. existing_log_id)
+    utils.apply_tls_mode(msg, header_tls_mode)
   end
 
   -- Ensure mandatory headers for deliverability

--- a/apps/backend/smtp/policy/tls.lua
+++ b/apps/backend/smtp/policy/tls.lua
@@ -16,7 +16,7 @@ function tls.egress_pool(tenant)
 end
 
 function tls.is_development(env)
-  return env == 'development' or env == 'dev'
+  return env == 'development' or env == 'dev' or env == 'local'
 end
 
 -- OpportunisticInsecure: STARTTLS when advertised, skip cert checks, fall

--- a/apps/backend/smtp/policy/tls.lua
+++ b/apps/backend/smtp/policy/tls.lua
@@ -1,0 +1,33 @@
+-- Pure TLS policy helpers. Keep in sync with apps/backend/smtp/test/tls-policy.test.ts
+local tls = {}
+
+function tls.normalize_tls_mode(mode)
+  if type(mode) == 'string' and string.lower(mode) == 'enforced' then
+    return 'enforced'
+  end
+  return 'opportunistic'
+end
+
+function tls.egress_pool(tenant)
+  if tenant == 'enforced' then
+    return 'tls_enforced'
+  end
+  return 'tls_opportunistic'
+end
+
+function tls.is_development(env)
+  return env == 'development' or env == 'dev'
+end
+
+-- OpportunisticInsecure: STARTTLS when advertised, skip cert checks, fall
+-- back to plaintext if the MX has no TLS. Matches dashboard "Opportunistic".
+-- Required: bounce if the MX does not advertise TLS (dashboard "Enforced").
+-- Local Mailpit has no STARTTLS, so development always stays opportunistic.
+function tls.enable_tls(env, egress_source)
+  if not tls.is_development(env) and egress_source == 'tls_enforced' then
+    return 'Required'
+  end
+  return 'OpportunisticInsecure'
+end
+
+return tls

--- a/apps/backend/smtp/policy/utils.lua
+++ b/apps/backend/smtp/policy/utils.lua
@@ -1,4 +1,5 @@
 local constants = require 'policy.constants'
+local tls = require 'policy.tls'
 
 local utils = {}
 
@@ -164,6 +165,20 @@ function utils.inject_tracking(data, email_log_id, tracking_domain, click_tracki
   end)
 
   return data
+end
+
+function utils.normalize_tls_mode(mode)
+  return tls.normalize_tls_mode(mode)
+end
+
+--- Stamp TLS policy on the message so get_queue_config can pick an egress pool.
+--- Tenant is the KumoMTA queue dimension that flows into egress_source.
+function utils.apply_tls_mode(msg, mode)
+  local tls_mode = tls.normalize_tls_mode(mode)
+  msg:set_meta('tls_mode', tls_mode)
+  msg:set_meta('tenant', tls_mode)
+  print("[TLS] [" .. msg:id() .. "] mode=" .. tls_mode)
+  return tls_mode
 end
 
 return utils

--- a/apps/backend/smtp/test/tls-policy.test.ts
+++ b/apps/backend/smtp/test/tls-policy.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * TypeScript mirror of policy/tls.lua. If a case fails here, update both files.
+ */
+function normalizeTlsMode(mode: unknown): "opportunistic" | "enforced" {
+	if (typeof mode === "string" && mode.toLowerCase() === "enforced") {
+		return "enforced";
+	}
+	return "opportunistic";
+}
+
+function tlsEgressPool(tenant: string): "tls_enforced" | "tls_opportunistic" {
+	if (tenant === "enforced") {
+		return "tls_enforced";
+	}
+	return "tls_opportunistic";
+}
+
+function isDevelopment(env: string): boolean {
+	return env === "development" || env === "dev";
+}
+
+function enableTls(
+	env: string,
+	egressSource: string,
+): "Required" | "OpportunisticInsecure" {
+	if (!isDevelopment(env) && egressSource === "tls_enforced") {
+		return "Required";
+	}
+	return "OpportunisticInsecure";
+}
+
+const policyDir = join(dirname(fileURLToPath(import.meta.url)), "../policy");
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "../../../..");
+
+describe("normalizeTlsMode", () => {
+	test("defaults unknown values to opportunistic", () => {
+		expect(normalizeTlsMode(undefined)).toBe("opportunistic");
+		expect(normalizeTlsMode(null)).toBe("opportunistic");
+		expect(normalizeTlsMode("")).toBe("opportunistic");
+		expect(normalizeTlsMode("Opportunistic")).toBe("opportunistic");
+		expect(normalizeTlsMode("required")).toBe("opportunistic");
+	});
+
+	test("accepts enforced case-insensitively", () => {
+		expect(normalizeTlsMode("enforced")).toBe("enforced");
+		expect(normalizeTlsMode("Enforced")).toBe("enforced");
+		expect(normalizeTlsMode("ENFORCED")).toBe("enforced");
+	});
+});
+
+describe("tlsEgressPool", () => {
+	test("maps tenant to a dedicated source so TLS modes do not share a ready queue", () => {
+		expect(tlsEgressPool("enforced")).toBe("tls_enforced");
+		expect(tlsEgressPool("opportunistic")).toBe("tls_opportunistic");
+		expect(tlsEgressPool("")).toBe("tls_opportunistic");
+	});
+});
+
+describe("enableTls", () => {
+	test("opportunistic uses STARTTLS with plaintext fallback", () => {
+		expect(enableTls("production", "tls_opportunistic")).toBe(
+			"OpportunisticInsecure",
+		);
+		expect(enableTls("development", "tls_opportunistic")).toBe(
+			"OpportunisticInsecure",
+		);
+	});
+
+	test("enforced requires TLS only outside local Mailpit", () => {
+		expect(enableTls("production", "tls_enforced")).toBe("Required");
+		expect(enableTls("development", "tls_enforced")).toBe(
+			"OpportunisticInsecure",
+		);
+		expect(enableTls("dev", "tls_enforced")).toBe("OpportunisticInsecure");
+	});
+});
+
+describe("policy sources stay wired", () => {
+	test("tls.lua exports the functions used by queue and smtp policy", () => {
+		const tlsLua = readFileSync(join(policyDir, "tls.lua"), "utf8");
+		expect(tlsLua).toContain("function tls.normalize_tls_mode");
+		expect(tlsLua).toContain("function tls.egress_pool");
+		expect(tlsLua).toContain("function tls.enable_tls");
+		expect(tlsLua).toContain("OpportunisticInsecure");
+		expect(tlsLua).toContain("Required");
+	});
+
+	test("queue.lua selects egress pool and enable_tls from tls.lua", () => {
+		const queueLua = readFileSync(join(policyDir, "queue.lua"), "utf8");
+		expect(queueLua).toContain("require 'policy.tls'");
+		expect(queueLua).toContain("tls.egress_pool(tenant)");
+		expect(queueLua).toContain("tls.enable_tls(constants.env, egress_source)");
+	});
+
+	test("smtp.lua stamps tenant from log-incoming or X-Reloop-TLS-Mode", () => {
+		const smtpLua = readFileSync(join(policyDir, "smtp.lua"), "utf8");
+		expect(smtpLua).toContain("X-Reloop-TLS-Mode");
+		expect(smtpLua).toContain("utils.apply_tls_mode");
+		expect(smtpLua).toContain("body.tls or header_tls_mode");
+	});
+
+	test("mail inject and log-incoming pass tls through", () => {
+		const step6 = readFileSync(
+			join(
+				repoRoot,
+				"apps/backend/mail/src/routes/mail/send-email/steps/step-6-send-email.ts",
+			),
+			"utf8",
+		);
+		const logIncoming = readFileSync(
+			join(
+				repoRoot,
+				"apps/backend/domain/src/routes/kumomta/log-incoming/log-incoming.controllers.ts",
+			),
+			"utf8",
+		);
+		expect(step6).toContain('"X-Reloop-TLS-Mode": tlsMode');
+		expect(logIncoming).toContain("tls: domainRecord.tls");
+	});
+});

--- a/apps/backend/smtp/test/tls-policy.test.ts
+++ b/apps/backend/smtp/test/tls-policy.test.ts
@@ -21,7 +21,7 @@ function tlsEgressPool(tenant: string): "tls_enforced" | "tls_opportunistic" {
 }
 
 function isDevelopment(env: string): boolean {
-	return env === "development" || env === "dev";
+	return env === "development" || env === "dev" || env === "local";
 }
 
 function enableTls(
@@ -77,6 +77,7 @@ describe("enableTls", () => {
 			"OpportunisticInsecure",
 		);
 		expect(enableTls("dev", "tls_enforced")).toBe("OpportunisticInsecure");
+		expect(enableTls("local", "tls_enforced")).toBe("OpportunisticInsecure");
 	});
 });
 


### PR DESCRIPTION
## Summary
- Domain TLS (opportunistic / enforced) is no longer dashboard-only: log-incoming and HTTP inject pass the mode into KumoMTA.
- Outbound delivery uses a dedicated egress pool per mode. Opportunistic tries STARTTLS and can fall back to plaintext (`OpportunisticInsecure`). Enforced requires TLS in production (`Required`).
- Local/dev always stays opportunistic so Mailpit (no STARTTLS) still accepts mail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added domain-specific TLS modes: opportunistic or enforced.
  * Incoming mail responses now report the selected TLS mode.
  * Outgoing email automatically applies the configured TLS mode.
  * SMTP delivery now supports tenant-specific routing and environment-aware TLS policies.
  * TLS settings are preserved throughout message processing and delivery.

* **Bug Fixes**
  * Added a safe fallback to opportunistic TLS when no domain setting is configured.
  * Improved TLS handling for development environments and local delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR propagates each sender domain's TLS mode through mail injection and SMTP policy, then selects mode-specific egress configuration for outbound delivery.
- Adds TLS mode to the domain callback and HTTP-injection headers.
- Removes the internal control header and stores the normalized mode in KumoMTA metadata.
- Routes enforced and opportunistic messages through dedicated egress pools.
- Requires TLS for enforced delivery outside local development while preserving Mailpit compatibility.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/backend/domain/src/routes/kumomta/log-incoming/log-incoming.controllers.ts | Returns the sender domain's configured TLS mode to the outbound SMTP policy with an opportunistic fallback. |
| apps/backend/mail/src/routes/mail/send-email/steps/step-6-send-email.ts | Adds the selected TLS mode as an internal message header during KumoMTA injection. |
| apps/backend/smtp/policy/smtp.lua | Consumes and removes the internal TLS header, then applies the selected mode to message metadata. |
| apps/backend/smtp/policy/queue.lua | Selects mode-specific egress pools and environment-aware transport TLS configuration. |
| apps/backend/smtp/policy/tls.lua | Defines TLS-mode normalization, egress-pool selection, development detection, and transport policy. |
| apps/backend/smtp/policy/utils.lua | Stamps the normalized TLS mode into the KumoMTA tenant and policy metadata. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Sender domain TLS setting] --> B[Mail or SMTP submission]
    B --> C[Outbound SMTP policy]
    C --> D[Normalize TLS mode]
    D --> E{Mode}
    E -->|opportunistic| F[tls_opportunistic egress pool]
    E -->|enforced| G[tls_enforced egress pool]
    F --> H[OpportunisticInsecure]
    G --> I{Local development?}
    I -->|Yes| H
    I -->|No| J[Required TLS]
    H --> K[Recipient MX or Mailpit]
    J --> L[Recipient MX]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: treat local env as development for ..."](https://github.com/reloop-labs/reloop/commit/7d207bd3403e7ccb300befe01db18beb839c0f12) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55901981)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Email lifecycle](https://app.greptile.com/rellop/-/custom-context/knowledge-base/reloop-labs/reloop/-/docs/email-lifecycle.md)
- Knowledge Base — [Outbound email delivery](https://app.greptile.com/rellop/-/custom-context/knowledge-base/reloop-labs/reloop/-/docs/outbound-email-delivery.md)
- Knowledge Base — [SMTP edge and policy](https://app.greptile.com/rellop/-/custom-context/knowledge-base/reloop-labs/reloop/-/docs/smtp-edge-and-policy.md)
- Knowledge Base — [Customer data and domains](https://app.greptile.com/rellop/-/custom-context/knowledge-base/reloop-labs/reloop/-/docs/customer-data-and-domains.md)
</details>


<!-- /greptile_comment -->