### PR TITLE
ci: refresh the disposable catalogue weekly from BillionVerify

### DIFF
--- a/.github/workflows/disposable-catalogue-refresh.yml
+++ b/.github/workflows/disposable-catalogue-refresh.yml
@@ -1,0 +1,66 @@
+name: Disposable catalogue refresh
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: disposable-catalogue-refresh
+  cancel-in-progress: true
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Refresh BillionVerify catalogue
+        run: bun run --filter=@reloop/email-validation refresh
+
+      - name: Test @reloop/email-validation
+        id: test
+        continue-on-error: true
+        run: bun test packages/email-validation
+
+      - name: Open or update pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: chore/disposable-catalogue-refresh
+          delete-branch: true
+          add-paths: |
+            packages/email-validation/data/upstream
+          commit-message: "chore: refresh BillionVerify disposable catalogue"
+          title: "chore: refresh BillionVerify disposable catalogue"
+          draft: ${{ steps.test.outcome != 'success' }}
+          body: |
+            Automated refresh of `packages/email-validation/data/upstream/` from
+            [BillionVerify/disposable](https://github.com/BillionVerify/disposable).
+
+            `data/local/` is never modified by this workflow.
+
+            Catalogue tests: `${{ steps.test.outcome }}`.
+
+            If this PR is a draft, a curated free provider was likely listed as
+            disposable. Add the host to `packages/email-validation/data/local/exceptions.txt`
+            on this branch and re-run tests before merging.
+
+      - name: Fail if catalogue tests failed
+        if: steps.test.outcome != 'success'
+        run: |
+          echo "Catalogue tests failed. The pull request (if any) was opened as a draft."
+          exit 1

--- a/.github/workflows/disposable-catalogue-refresh.yml
+++ b/.github/workflows/disposable-catalogue-refresh.yml
@@ -2,7 +2,7 @@ name: Disposable catalogue refresh
 
 on:
   schedule:
-    - cron: "0 6 * * 1"
+    - cron: "0 6 * * *"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Keep the vendored snapshot from going stale so new throwaway domains are picked up without a manual refresh.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated scheduled and on-demand refreshes for the disposable-email catalogue.
  * Refreshes now verify package tests and create or update a pull request with detected upstream changes.
  * Failed validation produces a draft pull request and marks the workflow as unsuccessful.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds scheduled and manually dispatched automation that refreshes BillionVerify's disposable-domain data, validates the email-validation package, and opens or updates a generated PR.
- Installs the pinned Bun runtime and repository dependencies.
- Refreshes only the vendored upstream catalogue and runs package tests.
- Uses test outcomes to draft the generated PR and fail the workflow.
- Reuses a fixed automation branch for subsequent refreshes.

<h3>Confidence Score: 3/5</h3>

The PR should not merge until the generated PR's draft lifecycle and preservation of curated exception fixes are made reliable.

Repeated runs target one automation-managed branch, but the current draft input does not reliably update an existing PR's review state and the documented manual exception workflow places fixes on a branch that subsequent automation can replace.

**Files Needing Attention:** .github/workflows/disposable-catalogue-refresh.yml

<details open><summary><h3>Security Review</h3></summary>

The workflow grants repository-write permissions to actions referenced by mutable major-version tags. Pinning those action references to audited commit SHAs would reduce the new scheduled supply-chain exposure.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/disposable-catalogue-refresh.yml | Adds useful catalogue-refresh automation, but existing-PR draft transitions and manual exception handling on the managed branch can leave the generated PR stuck or erase remediation work. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  S[Scheduled or manual run] --> R[Refresh upstream catalogue]
  R --> T[Run email-validation tests]
  T -->|Pass| P[Create or update refresh PR]
  T -->|Fail| D[Create or update draft PR]
  D --> F[Fail workflow]
  P --> N[Next scheduled refresh]
  D --> N
  N --> R
```
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: run the disposable catalogue refresh..."](https://github.com/reloop-labs/reloop/commit/8349fc0a454a48f35941c635053c9be6defefa2e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56364522)</sub>

> Greptile also left **3 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Contact management](https://app.greptile.com/rellop/-/custom-context/knowledge-base/reloop-labs/reloop/-/docs/contact-management.md)

<!-- /greptile_comment -->