### PR TITLE
feat: self-host installer for a fresh VPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,18 @@ For full setup instructions — prerequisites, environment config, Docker servic
 
 ---
 
+## Self-Host
+
+Deploy the whole stack on a fresh Ubuntu 22.04/24.04 or Debian 12/13 server with one command:
+
+```bash
+curl -fsSL https://reloop.sh/install.sh | sudo bash
+```
+
+The installer runs preflight checks, installs Docker, prompts for your domain, generates production secrets, deploys every service, verifies health, and prints the DNS records to add. See the **[VPS guide →](https://reloop.sh/docs/self-host/vps)**
+
+---
+
 ## Hosted Service
 
 Reloop is also available as a fully managed hosted service from Reloop Labs — same codebase, zero infrastructure to run. [Sign up at reloop.sh](https://reloop.sh/dashboard/signup).

--- a/apps/frontend/docs/content/docs/self-host/index.mdx
+++ b/apps/frontend/docs/content/docs/self-host/index.mdx
@@ -29,7 +29,7 @@ Deployment templates and guides for popular cloud providers and self-hosted PaaS
     Easily deploy on your self-hosted Dokploy instance. (Coming Soon)
   </Card>
   <Card title="VPS" icon="server" href="/self-host/vps">
-    Standard VPS deployment guides for Ubuntu, Debian, and more. (Coming Soon)
+    One-command installer for a fresh Ubuntu or Debian server.
   </Card>
   <Card title="Vercel" icon="siVercel" href="/self-host/vercel">
     Deploy the frontend and serverless endpoints on Vercel. (Coming Soon)

--- a/apps/frontend/docs/content/docs/self-host/requirements.mdx
+++ b/apps/frontend/docs/content/docs/self-host/requirements.mdx
@@ -16,7 +16,7 @@ Reloop's performance is highly dependent on database throughput and the speed of
 | **Storage** | 20 GB SSD | 50 GB+ NVMe SSD |
 
 > [!NOTE]
-> The Docker Compose deployment needs more disk than the numbers above: the container images alone are about 28 GB, so plan for 45 GB minimum and 60 GB comfortably. See [Deploy on VPS](/self-host/vps).
+> The Docker Compose deployment needs more disk than the numbers above: the container images alone are about 22 GB, so plan for 35 GB minimum and 50 GB comfortably. See [Deploy on VPS](/self-host/vps).
 
 > [!NOTE]
 > SSD/NVMe storage is highly recommended. PostgreSQL stores relational data and telemetry logs, which benefit from fast disk I/O speeds to prevent latency.

--- a/apps/frontend/docs/content/docs/self-host/requirements.mdx
+++ b/apps/frontend/docs/content/docs/self-host/requirements.mdx
@@ -16,6 +16,9 @@ Reloop's performance is highly dependent on database throughput and the speed of
 | **Storage** | 20 GB SSD | 50 GB+ NVMe SSD |
 
 > [!NOTE]
+> The Docker Compose deployment needs more disk than the numbers above: the container images alone are about 28 GB, so plan for 45 GB minimum and 60 GB comfortably. See [Deploy on VPS](/self-host/vps).
+
+> [!NOTE]
 > SSD/NVMe storage is highly recommended. PostgreSQL stores relational data and telemetry logs, which benefit from fast disk I/O speeds to prevent latency.
 
 ---

--- a/apps/frontend/docs/content/docs/self-host/services.mdx
+++ b/apps/frontend/docs/content/docs/self-host/services.mdx
@@ -40,3 +40,20 @@ The Reloop stack consists of **19 application services** (3 frontends, 16 backen
 * **NATS JetStream**: Real-time event broker.
 * **Mailpit**: SMTP sandbox mail catcher.
 * **Caddy**: High-performance reverse proxy and automatic SSL manager.
+
+---
+
+## What the VPS installer deploys
+
+The [one-command VPS installer](/docs/self-host/vps) deploys a reduced set — 20 containers instead of the full platform. It leaves out the pieces that only exist for the hosted service:
+
+| Left out | Why |
+| :--- | :--- |
+| `web`, `docs` | Public marketing site and documentation; `/docs` redirects to reloop.sh |
+| `credits` | Billing and quota metering; self-hosted sending is not metered |
+| `tools` | Public email-validation tools |
+| `admin`, `console` | Operator tooling for the hosted platform |
+| MinIO | Point `upload` at any S3-compatible provider instead |
+| Mailpit | Development mail catcher, never used in production |
+
+`upload` is deployed only when you configure S3 storage during install.

--- a/apps/frontend/docs/content/docs/self-host/vps.mdx
+++ b/apps/frontend/docs/content/docs/self-host/vps.mdx
@@ -1,7 +1,136 @@
 ---
 title: Deploy on VPS
-description: Learn how to self-host Reloop on a VPS / Virtual Private Server.
+description: Install the full Reloop stack on a fresh Ubuntu or Debian server with one command.
 icon: server
 ---
 
-Coming Soon
+The Reloop self-host installer takes a fresh VPS and turns it into a running Reloop deployment: it installs Docker, generates production secrets, writes the Compose stack, applies the database schema, starts every service, verifies it is healthy, and prints the DNS records you need to add.
+
+```bash
+curl -fsSL https://reloop.sh/install.sh | sudo bash
+```
+
+---
+
+## Before you start
+
+| Requirement | Value |
+| :--- | :--- |
+| **Operating system** | Ubuntu 22.04 LTS, Ubuntu 24.04 LTS, Debian 12, Debian 13 |
+| **Architecture** | x86_64 |
+| **CPU** | 2 vCPUs minimum, 4+ recommended |
+| **RAM** | 4 GB minimum, 8 GB recommended |
+| **Disk** | 45 GB minimum, 60 GB recommended |
+| **Ports** | `80`, `443`, `25`, `465`, `587` free |
+| **Access** | root or sudo |
+
+> [!NOTE]
+> The container images are roughly 28 GB in total, which is why the disk floor is higher than for a source install. The installer refuses to continue on a smaller disk rather than failing halfway through the download.
+
+Many providers block outbound port `25` by default. Reloop still sends through the submission ports, but inbound mail needs `25` open in both directions — ask your provider to unblock it if you plan to receive mail.
+
+---
+
+## What the installer asks
+
+| Prompt | Purpose | Default |
+| :--- | :--- | :--- |
+| Primary Reloop domain | The hostname the dashboard and API are served on | — |
+| Administrator email | Let's Encrypt contact and your first Reloop account | — |
+| Database name | PostgreSQL database | `reloop` |
+| Database user | PostgreSQL role | `reloop` |
+| Configure automatic HTTPS | Let Caddy obtain and renew certificates | `yes` |
+
+Everything else is generated: database and Redis passwords, the Better Auth secret, the internal service secret, the tracking and preferences secrets, the webhook encryption key, and the object storage credentials. They are written to `/opt/reloop/.env` with mode `0600`.
+
+Enter the domain as a bare hostname — `reloop.example.com`, not `https://reloop.example.com` and not `reloop.example.com/admin`.
+
+---
+
+## What gets installed
+
+```text
+/opt/reloop/
+├── .env                 production configuration and secrets (0600, root)
+├── docker-compose.yml   the production stack
+├── Caddyfile            reverse proxy and TLS
+└── backups/             automatic database dumps taken before schema changes
+```
+
+The stack runs 27 containers: 18 Reloop backend services, 4 frontends (dashboard, docs, console, links), PostgreSQL, Redis, NATS, MinIO, and Caddy. Only Caddy (`80`, `443`) and the two mail transports (`25` inbound, `465`/`587` submission) publish host ports — the databases, object storage and event bus stay on the internal Docker network.
+
+A `reloop` command is installed alongside it:
+
+```bash
+reloop status            # container health
+reloop logs [service]    # follow logs
+reloop restart           # restart the stack
+reloop update            # pull the configured version and redeploy
+```
+
+---
+
+## DNS
+
+When the installer finishes it prints the records for the installation itself:
+
+```text
+reloop.example.com            A    203.0.113.10
+link.reloop.example.com       A    203.0.113.10
+inbound.reloop.example.com    A    203.0.113.10
+reloop.example.com            TXT  "v=spf1 ip4:203.0.113.10 -all"
+```
+
+- The apex record serves the dashboard, the API and the Let's Encrypt HTTP challenge.
+- `link.` serves click and open tracking plus the unsubscribe pages, and is the CNAME target for customer tracking domains.
+- `inbound.` is the MX target for mail your verified domains receive.
+- The SPF record authorises the server to send for the host domain, which is what the `include:` in each sending domain's SPF resolves to.
+
+These are separate from the SPF, DKIM, DMARC and MX records for the domains you send from. Those are generated per domain by Reloop — add a domain under **Domains** in the dashboard and it shows the exact records. See [Connect a domain](/docs/guides/connect-domain).
+
+You can run the installer before adding DNS. Caddy keeps retrying certificate issuance in the background and HTTPS starts working on its own once the records resolve. Follow it with `reloop logs proxy`.
+
+---
+
+## First sign-in
+
+Reloop sends one-time codes through its own mail pipeline, which needs a verified sending domain — so a fresh installation has no way to email you the first code. The installer generates a bootstrap code, writes it to `DEFAULT_OTP` in `/opt/reloop/.env`, and prints it once.
+
+1. Open `https://your-domain/dashboard`
+2. Sign up with the administrator email
+3. Enter the printed code
+
+Once one of your domains is verified and sending, remove the `DEFAULT_OTP` line from `/opt/reloop/.env` and run `reloop restart auth`. Set `DISABLE_SIGNUP=true` in the same file if you do not want anyone else creating accounts.
+
+---
+
+## Running it again
+
+Re-running the installer is safe. It detects the existing installation and offers to abort, reconfigure (re-ask the domain and HTTPS settings while keeping data and secrets), or redeploy with the existing configuration. Secrets, volumes and the database are never regenerated or dropped, and a database dump is taken before any schema change.
+
+---
+
+## Unattended installs
+
+Every prompt has an environment variable, so the installer can run without a terminal:
+
+```bash
+curl -fsSL https://reloop.sh/install.sh | sudo \
+  RELOOP_NONINTERACTIVE=true \
+  RELOOP_DOMAIN=reloop.example.com \
+  RELOOP_ADMIN_EMAIL=admin@example.com \
+  RELOOP_PUBLIC_IP=203.0.113.10 \
+  bash
+```
+
+| Variable | Purpose |
+| :--- | :--- |
+| `RELOOP_NONINTERACTIVE` | Never prompt; fail if a required value is missing |
+| `RELOOP_DOMAIN` | Primary hostname |
+| `RELOOP_ADMIN_EMAIL` | Administrator email |
+| `RELOOP_DB_NAME` / `RELOOP_DB_USER` | Database name and role |
+| `RELOOP_HTTPS` | `yes` or `no` |
+| `RELOOP_PUBLIC_IP` | Skip public address detection |
+| `RELOOP_VERSION` | Image tag to deploy (default `latest`) |
+| `RELOOP_EXISTING` | `abort`, `reconfigure` or `continue` for a re-run |
+| `RELOOP_INSTALL_DIR` | Installation directory (default `/opt/reloop`) |

--- a/apps/frontend/docs/content/docs/self-host/vps.mdx
+++ b/apps/frontend/docs/content/docs/self-host/vps.mdx
@@ -20,12 +20,12 @@ curl -fsSL https://reloop.sh/install.sh | sudo bash
 | **Architecture** | x86_64 |
 | **CPU** | 2 vCPUs minimum, 4+ recommended |
 | **RAM** | 4 GB minimum, 8 GB recommended |
-| **Disk** | 45 GB minimum, 60 GB recommended |
+| **Disk** | 35 GB minimum, 50 GB recommended |
 | **Ports** | `80`, `443`, `25`, `465`, `587` free |
 | **Access** | root or sudo |
 
 > [!NOTE]
-> The container images are roughly 28 GB in total, which is why the disk floor is higher than for a source install. The installer refuses to continue on a smaller disk rather than failing halfway through the download.
+> The container images are roughly 22 GB in total, which is why the disk floor is higher than for a source install. The installer refuses to continue on a smaller disk rather than failing halfway through the download.
 
 Many providers block outbound port `25` by default. Reloop still sends through the submission ports, but inbound mail needs `25` open in both directions — ask your provider to unblock it if you plan to receive mail.
 
@@ -40,8 +40,9 @@ Many providers block outbound port `25` by default. Reloop still sends through t
 | Database name | PostgreSQL database | `reloop` |
 | Database user | PostgreSQL role | `reloop` |
 | Configure automatic HTTPS | Let Caddy obtain and renew certificates | `yes` |
+| Configure object storage | S3-compatible storage for file uploads | `no` |
 
-Everything else is generated: database and Redis passwords, the Better Auth secret, the internal service secret, the tracking and preferences secrets, the webhook encryption key, and the object storage credentials. They are written to `/opt/reloop/.env` with mode `0600`.
+Everything else is generated: database and Redis passwords, the Better Auth secret, the internal service secret, the tracking and preferences secrets, and the webhook encryption key. They are written to `/opt/reloop/.env` with mode `0600`.
 
 Enter the domain as a bare hostname — `reloop.example.com`, not `https://reloop.example.com` and not `reloop.example.com/admin`.
 
@@ -57,7 +58,9 @@ Enter the domain as a bare hostname — `reloop.example.com`, not `https://reloo
 └── backups/             automatic database dumps taken before schema changes
 ```
 
-The stack runs 27 containers: 18 Reloop backend services, 4 frontends (dashboard, docs, console, links), PostgreSQL, Redis, NATS, MinIO, and Caddy. Only Caddy (`80`, `443`) and the two mail transports (`25` inbound, `465`/`587` submission) publish host ports — the databases, object storage and event bus stay on the internal Docker network.
+The stack runs 20 containers: 14 Reloop backend services, 2 frontends (dashboard, links), PostgreSQL, Redis, NATS and Caddy. Only Caddy (`80`, `443`) and the two mail transports (`25` inbound, `465`/`587` submission) publish host ports — the database and event bus stay on the internal Docker network.
+
+A self-hosted install deliberately leaves out the parts of Reloop that only make sense for the hosted service: the public documentation site (`/docs` redirects to reloop.sh), the credits and quota service, the public email-validation tools, the operator console, and bundled object storage. Sending is not metered.
 
 A `reloop` command is installed alongside it:
 
@@ -67,6 +70,19 @@ reloop logs [service]    # follow logs
 reloop restart           # restart the stack
 reloop update            # pull the configured version and redeploy
 ```
+
+---
+
+## File uploads
+
+Reloop stores template images and attachments in S3-compatible object storage. The installer does not bundle a storage server — point it at whichever provider you already use (AWS S3, Cloudflare R2, Hetzner Object Storage, Backblaze B2, a MinIO box of your own).
+
+Answer yes to the storage prompt and supply the endpoint, access key, secret key, bucket and region. The `upload` service is then deployed alongside the rest of the stack.
+
+Answer no and file uploads stay off. To turn them on later, set the `S3_*` values and `COMPOSE_PROFILES=storage` in `/opt/reloop/.env`, then run `reloop restart`.
+
+> [!NOTE]
+> The bucket must serve objects publicly over HTTP. Reloop hands out file URLs as `{S3_ENDPOINT}/{S3_BUCKET}/{path}`, so anything the dashboard uploads has to be readable at that address.
 
 ---
 
@@ -130,6 +146,9 @@ curl -fsSL https://reloop.sh/install.sh | sudo \
 | `RELOOP_ADMIN_EMAIL` | Administrator email |
 | `RELOOP_DB_NAME` / `RELOOP_DB_USER` | Database name and role |
 | `RELOOP_HTTPS` | `yes` or `no` |
+| `RELOOP_S3` | `yes` to configure object storage, `no` to disable file uploads |
+| `RELOOP_S3_ENDPOINT` / `RELOOP_S3_ACCESS_KEY` / `RELOOP_S3_SECRET_KEY` | Object storage credentials |
+| `RELOOP_S3_BUCKET` / `RELOOP_S3_REGION` | Bucket and region |
 | `RELOOP_PUBLIC_IP` | Skip public address detection |
 | `RELOOP_VERSION` | Image tag to deploy (default `latest`) |
 | `RELOOP_EXISTING` | `abort`, `reconfigure` or `continue` for a re-run |

--- a/install/install.sh
+++ b/install/install.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+INSTALLER_VERSION="1.0.0"
+INSTALLER_URL="https://reloop.sh/install.sh"
+
+INSTALL_DIR="${RELOOP_INSTALL_DIR:-/opt/reloop}"
+INSTALL_REF="${RELOOP_INSTALL_REF:-main}"
+ASSET_BASE_URL="${RELOOP_INSTALL_BASE_URL:-https://raw.githubusercontent.com/reloop-labs/reloop/$INSTALL_REF/install}"
+
+RELOOP_VERSION="${RELOOP_VERSION:-}"
+RELOOP_DOMAIN="${RELOOP_DOMAIN:-}"
+RELOOP_ADMIN_EMAIL="${RELOOP_ADMIN_EMAIL:-}"
+RELOOP_PUBLIC_IP="${RELOOP_PUBLIC_IP:-}"
+RELOOP_HTTPS="${RELOOP_HTTPS:-}"
+POSTGRES_DB="${RELOOP_DB_NAME:-}"
+POSTGRES_USER="${RELOOP_DB_USER:-}"
+
+NONINTERACTIVE=0
+case "${RELOOP_NONINTERACTIVE:-}" in
+1 | true | yes) NONINTERACTIVE=1 ;;
+esac
+ALLOW_UNSUPPORTED_OS=0
+case "${RELOOP_ALLOW_UNSUPPORTED_OS:-}" in
+1 | true | yes) ALLOW_UNSUPPORTED_OS=1 ;;
+esac
+EXISTING_ACTION="${RELOOP_EXISTING:-}"
+
+HEALTH_TIMEOUT="${RELOOP_HEALTH_TIMEOUT:-240}"
+HEALTH_TIMEOUT_FOLLOWUP="${RELOOP_HEALTH_TIMEOUT_FOLLOWUP:-60}"
+
+REQUIRED_PORTS=(80 443 25 465 587)
+declare -A PORT_PURPOSE=(
+	[80]="HTTP — ACME challenges and the redirect to HTTPS"
+	[443]="HTTPS — the Reloop dashboard and API"
+	[25]="SMTP — inbound mail delivered to your domains"
+	[465]="SMTPS — outbound submission"
+	[587]="Submission — outbound submission with STARTTLS"
+)
+
+ASSET_DIR=""
+SELF_DIR=""
+
+cleanup() {
+	local code=$?
+	if [ -n "$ASSET_DIR" ] && [ "${ASSET_DIR_IS_TEMP:-0}" = "1" ]; then
+		rm -rf "$ASSET_DIR"
+	fi
+	if [ -n "${TTY_FD:-}" ]; then
+		exec 3>&- 2>/dev/null || true
+	fi
+	exit "$code"
+}
+
+on_error() {
+	local line="$1"
+	printf '\n\033[31m[ERROR]\033[0m The installer stopped unexpectedly at line %s.\n' "$line" >&2
+	printf 'Re-running the installer is safe: it keeps the existing configuration and data.\n' >&2
+}
+
+fetch_assets() {
+	if [ -n "${BASH_SOURCE[0]:-}" ] && [ -f "${BASH_SOURCE[0]}" ]; then
+		SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+	fi
+
+	if [ -n "$SELF_DIR" ] && [ -d "$SELF_DIR/lib" ] && [ -d "$SELF_DIR/templates" ]; then
+		ASSET_DIR="$SELF_DIR"
+		ASSET_DIR_IS_TEMP=0
+		return 0
+	fi
+
+	ASSET_DIR="$(mktemp -d -t reloop-install.XXXXXXXX)"
+	ASSET_DIR_IS_TEMP=1
+	chmod 700 "$ASSET_DIR"
+	mkdir -p "$ASSET_DIR/lib" "$ASSET_DIR/templates"
+
+	local proto='=https'
+	case "$ASSET_BASE_URL" in
+	http://*) proto='=http,https' ;;
+	esac
+
+	local f
+	for f in lib/common.sh lib/prompts.sh lib/preflight.sh lib/docker.sh \
+		lib/config.sh lib/deploy.sh lib/health.sh lib/dns.sh \
+		templates/docker-compose.yml templates/Caddyfile templates/Caddyfile.http \
+		templates/reloop; do
+		curl -fsSL --proto "$proto" --proto-redir "$proto" \
+			--retry 3 --retry-delay 2 --max-time 120 \
+			-o "$ASSET_DIR/$f" "$ASSET_BASE_URL/$f" ||
+			{
+				printf 'Failed to download installer component: %s\n' "$f" >&2
+				printf 'Source: %s\n' "$ASSET_BASE_URL/$f" >&2
+				exit 1
+			}
+	done
+}
+
+trap 'on_error $LINENO' ERR
+trap cleanup EXIT
+
+fetch_assets
+
+# shellcheck source=lib/common.sh
+. "$ASSET_DIR/lib/common.sh"
+# shellcheck source=lib/prompts.sh
+. "$ASSET_DIR/lib/prompts.sh"
+# shellcheck source=lib/preflight.sh
+. "$ASSET_DIR/lib/preflight.sh"
+# shellcheck source=lib/docker.sh
+. "$ASSET_DIR/lib/docker.sh"
+# shellcheck source=lib/config.sh
+. "$ASSET_DIR/lib/config.sh"
+# shellcheck source=lib/dns.sh
+. "$ASSET_DIR/lib/dns.sh"
+# shellcheck source=lib/deploy.sh
+. "$ASSET_DIR/lib/deploy.sh"
+# shellcheck source=lib/health.sh
+. "$ASSET_DIR/lib/health.sh"
+
+print_summary() {
+	local apex
+	apex="$(zone_apex "$RELOOP_DOMAIN")"
+
+	printf '\n'
+	rule
+	printf 'Reloop installation complete\n'
+	rule
+
+	printf '\nApplication domain:\n%s\n' "$RELOOP_DOMAIN"
+	printf '\nServer IPv4:\n%s\n' "$RELOOP_PUBLIC_IP"
+
+	dns_instructions "$apex"
+
+	printf '\nNAME values are relative to the %s zone.\n' "$apex"
+
+	printf '\nWhat each record is for:\n'
+	printf '  %-38s dashboard, API and Let'"'"'s Encrypt validation\n' "$RELOOP_DOMAIN"
+	printf '  %-38s click and open tracking, unsubscribe pages\n' "$RELOOP_TRACKING_HOST"
+	printf '  %-38s MX target for mail your domains receive\n' "$RELOOP_INBOUND_HOST"
+	printf '  %-38s authorises this server to send for the host domain\n' "SPF TXT"
+
+	printf '\nOnce DNS propagates, Reloop will be available at:\n'
+	printf '%s://%s\n' "$RELOOP_SCHEME" "$RELOOP_DOMAIN"
+
+	if [ "$RELOOP_HTTPS" = "yes" ]; then
+		printf '\nHTTPS: Caddy requests a certificate as soon as %s resolves to\n' "$RELOOP_DOMAIN"
+		printf '%s. It retries automatically — no action needed after DNS is added.\n' "$RELOOP_PUBLIC_IP"
+		printf 'Watch it happen with:  reloop logs proxy\n'
+	else
+		printf '\nHTTPS is disabled. Reloop is served over plain HTTP on port 80.\n'
+	fi
+
+	printf '\n'
+	rule
+	printf 'First sign-in\n'
+	rule
+	printf '\n  1. Open %s://%s/dashboard\n' "$RELOOP_SCHEME" "$RELOOP_DOMAIN"
+	printf '  2. Sign up with %s\n' "$RELOOP_ADMIN_EMAIL"
+	printf '  3. Enter this one-time code when asked:  %s\n' "$DEFAULT_OTP"
+	printf '\n  Reloop cannot email a code until one of your own domains is verified,\n'
+	printf '  so this fixed code stands in. Remove DEFAULT_OTP from %s/.env\n' "$INSTALL_DIR"
+	printf '  and run "reloop restart auth" once your domain is sending mail.\n'
+
+	printf '\n'
+	rule
+	printf 'Sending and receiving domains\n'
+	rule
+	printf '\n  The records above only cover this Reloop installation. The SPF, DKIM,\n'
+	printf '  DMARC and MX records for the domains you send from are generated by\n'
+	printf '  Reloop itself — add a domain under Domains in the dashboard and it\n'
+	printf '  shows the exact records for that domain.\n'
+
+	printf '\n'
+	rule
+	printf 'Managing this installation\n'
+	rule
+	printf '\n  reloop status          container health\n'
+	printf '  reloop logs [service]  follow logs\n'
+	printf '  reloop restart         restart the stack\n'
+	printf '  reloop update          pull new images and redeploy\n'
+	printf '\n  Configuration: %s/.env (root-only, holds every secret)\n' "$INSTALL_DIR"
+	printf '\n'
+}
+
+main() {
+	open_tty
+
+	heading "Reloop Self-Host Installer ${INSTALLER_VERSION}"
+
+	preflight
+	ensure_docker
+	check_ports
+
+	install -d -m 0755 -o root -g root "$INSTALL_DIR"
+	ok "Installation directory: $INSTALL_DIR"
+
+	detect_existing_install
+	collect_configuration
+	detect_public_ip
+
+	write_env_file
+	write_stack_files
+
+	pull_images
+	start_infrastructure
+	run_migrations
+	start_application
+	verify_deployment
+
+	print_summary
+}
+
+main "$@"

--- a/install/install.sh
+++ b/install/install.sh
@@ -15,6 +15,12 @@ RELOOP_PUBLIC_IP="${RELOOP_PUBLIC_IP:-}"
 RELOOP_HTTPS="${RELOOP_HTTPS:-}"
 POSTGRES_DB="${RELOOP_DB_NAME:-}"
 POSTGRES_USER="${RELOOP_DB_USER:-}"
+RELOOP_S3="${RELOOP_S3:-}"
+S3_ENDPOINT="${RELOOP_S3_ENDPOINT:-}"
+S3_ACCESS_KEY="${RELOOP_S3_ACCESS_KEY:-}"
+S3_SECRET_KEY="${RELOOP_S3_SECRET_KEY:-}"
+S3_BUCKET="${RELOOP_S3_BUCKET:-}"
+S3_REGION="${RELOOP_S3_REGION:-}"
 
 NONINTERACTIVE=0
 case "${RELOOP_NONINTERACTIVE:-}" in
@@ -179,6 +185,13 @@ print_summary() {
 	printf '  reloop restart         restart the stack\n'
 	printf '  reloop update          pull new images and redeploy\n'
 	printf '\n  Configuration: %s/.env (root-only, holds every secret)\n' "$INSTALL_DIR"
+
+	if [ "$STORAGE_ENABLED" != "yes" ]; then
+		printf '\n  File uploads are off: no S3 storage was configured. Set the S3_*\n'
+		printf '  values and COMPOSE_PROFILES=storage in %s/.env, then run\n' "$INSTALL_DIR"
+		printf '  "reloop restart" to turn them on.\n'
+	fi
+
 	printf '\n'
 }
 

--- a/install/lib/common.sh
+++ b/install/lib/common.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+
+if [ -t 1 ] && [ -z "${NO_COLOR:-}" ]; then
+	C_RESET=$'\033[0m'
+	C_DIM=$'\033[2m'
+	C_BOLD=$'\033[1m'
+	C_RED=$'\033[31m'
+	C_GREEN=$'\033[32m'
+	C_YELLOW=$'\033[33m'
+else
+	C_RESET=""
+	C_DIM=""
+	C_BOLD=""
+	C_RED=""
+	C_GREEN=""
+	C_YELLOW=""
+fi
+
+TTY_FD=""
+
+open_tty() {
+	if { exec 3<>/dev/tty; } 2>/dev/null; then
+		TTY_FD=3
+	fi
+	return 0
+}
+
+heading() {
+	printf '\n%s%s%s\n' "$C_BOLD" "$1" "$C_RESET"
+}
+
+step() {
+	printf '\n%s%s%s\n' "$C_BOLD" "$1" "$C_RESET"
+}
+
+ok() {
+	printf '  %s✓%s %s\n' "$C_GREEN" "$C_RESET" "$1"
+}
+
+info() {
+	printf '  %s·%s %s\n' "$C_DIM" "$C_RESET" "$1"
+}
+
+warn() {
+	printf '  %s!%s %s\n' "$C_YELLOW" "$C_RESET" "$1"
+}
+
+err() {
+	printf '\n%s[ERROR]%s %s\n' "$C_RED" "$C_RESET" "$1" >&2
+}
+
+die() {
+	trap - ERR
+	err "$1"
+	shift
+	for line in "$@"; do
+		printf '%s\n' "$line" >&2
+	done
+	printf '\n' >&2
+	exit 1
+}
+
+rule() {
+	printf '%s\n' "============================================================"
+}
+
+have() {
+	command -v "$1" >/dev/null 2>&1
+}
+
+# Alphanumeric only: any other charset would need quoting in .env and YAML.
+gen_secret() {
+	local n="${1:-40}" out
+	out="$(
+		set +o pipefail
+		LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c "$n"
+	)"
+	if [ "${#out}" -ne "$n" ]; then
+		die "Could not read $n bytes of randomness from /dev/urandom."
+	fi
+	printf '%s' "$out"
+}
+
+gen_hex() {
+	local bytes="${1:-32}" out
+	out="$(
+		set +o pipefail
+		od -An -tx1 -N "$bytes" /dev/urandom | tr -d ' \n'
+	)"
+	if [ "${#out}" -ne $((bytes * 2)) ]; then
+		die "Could not read $bytes bytes of randomness from /dev/urandom."
+	fi
+	printf '%s' "$out"
+}
+
+gen_digits() {
+	local n="${1:-6}" out
+	out="$(
+		set +o pipefail
+		LC_ALL=C tr -dc '0-9' </dev/urandom | head -c "$n"
+	)"
+	if [ "${#out}" -ne "$n" ]; then
+		die "Could not read $n digits of randomness from /dev/urandom."
+	fi
+	printf '%s' "$out"
+}
+
+compose() {
+	docker compose --project-directory "$INSTALL_DIR" \
+		-f "$INSTALL_DIR/docker-compose.yml" "$@"
+}

--- a/install/lib/config.sh
+++ b/install/lib/config.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+
+ENV_FILE=""
+EXISTING_INSTALL=0
+REUSE_CONFIG=0
+
+env_get() {
+	local key="$1" file="$2"
+	[ -f "$file" ] || return 1
+	sed -n "s/^${key}=\(.*\)$/\1/p" "$file" | tail -1
+}
+
+detect_existing_install() {
+	ENV_FILE="$INSTALL_DIR/.env"
+	[ -f "$ENV_FILE" ] || return 0
+
+	EXISTING_INSTALL=1
+	local existing_domain
+	existing_domain="$(env_get RELOOP_DOMAIN "$ENV_FILE" || true)"
+
+	heading "Existing Reloop installation detected"
+	printf '  Location: %s\n' "$INSTALL_DIR"
+	[ -n "$existing_domain" ] && printf '  Domain:   %s\n' "$existing_domain"
+
+	if [ "$NONINTERACTIVE" = "1" ]; then
+		case "$EXISTING_ACTION" in
+		abort) die "An installation already exists at $INSTALL_DIR (RELOOP_EXISTING=abort)." ;;
+		reconfigure) REUSE_CONFIG=0 ;;
+		continue) REUSE_CONFIG=1 ;;
+		*) die "Set RELOOP_EXISTING to abort, reconfigure or continue for a non-interactive re-run." ;;
+		esac
+		return 0
+	fi
+
+	local choice
+	ask_choice choice "How would you like to proceed?" \
+		"Abort — change nothing" \
+		"Reconfigure — re-ask domain and HTTPS settings, keep data and secrets" \
+		"Continue — redeploy with the existing configuration"
+
+	case "$choice" in
+	1) die "Aborted. Nothing was changed." ;;
+	2) REUSE_CONFIG=0 ;;
+	3) REUSE_CONFIG=1 ;;
+	esac
+}
+
+load_existing_values() {
+	local key
+	for key in RELOOP_VERSION RELOOP_DOMAIN RELOOP_ADMIN_EMAIL RELOOP_PUBLIC_IP \
+		RELOOP_HTTPS POSTGRES_DB POSTGRES_USER POSTGRES_PASSWORD REDIS_PASSWORD \
+		BETTER_AUTH_SECRET RELOOP_INTERNAL_SECRET TRACKING_SECRET PREFERENCES_SECRET \
+		WEBHOOK_ENCRYPTION_KEY S3_ACCESS_KEY S3_SECRET_KEY DEFAULT_OTP; do
+		local value
+		value="$(env_get "$key" "$ENV_FILE" || true)"
+		if [ -n "$value" ]; then
+			printf -v "PRESERVED_$key" '%s' "$value"
+		fi
+	done
+}
+
+preserved_or_new() {
+	local key="$1" generator="$2" length="$3"
+	local ref="PRESERVED_$key"
+	if [ -n "${!ref-}" ]; then
+		printf -v "$key" '%s' "${!ref}"
+	else
+		printf -v "$key" '%s' "$("$generator" "$length")"
+	fi
+}
+
+collect_configuration() {
+	if [ "$EXISTING_INSTALL" = "1" ]; then
+		load_existing_values
+	fi
+
+	if [ "$REUSE_CONFIG" = "1" ]; then
+		local key
+		for key in RELOOP_DOMAIN RELOOP_ADMIN_EMAIL RELOOP_HTTPS RELOOP_PUBLIC_IP \
+			POSTGRES_DB POSTGRES_USER; do
+			local ref="PRESERVED_$key"
+			[ -n "${!ref-}" ] && printf -v "$key" '%s' "${!ref}"
+		done
+		step "Using the existing configuration"
+		ok "Domain: $RELOOP_DOMAIN"
+		ok "Administrator email: $RELOOP_ADMIN_EMAIL"
+	else
+		step "Configuration"
+
+		ask RELOOP_DOMAIN "Primary Reloop domain" \
+			"The hostname Reloop will be served on, e.g. reloop.example.com" \
+			"${PRESERVED_RELOOP_DOMAIN:-}" valid_hostname \
+			"Enter a bare hostname — no scheme, no path, no port. Example: reloop.example.com"
+
+		ask RELOOP_ADMIN_EMAIL "Administrator email" \
+			"Used for Let's Encrypt notices and as your first Reloop account" \
+			"${PRESERVED_RELOOP_ADMIN_EMAIL:-}" valid_email \
+			"Enter a valid email address, e.g. admin@example.com"
+
+		ask POSTGRES_DB "Database name" "" \
+			"${PRESERVED_POSTGRES_DB:-reloop}" valid_pg_identifier \
+			"Use lowercase letters, digits and underscores, starting with a letter."
+
+		ask POSTGRES_USER "Database user" "" \
+			"${PRESERVED_POSTGRES_USER:-reloop}" valid_pg_identifier \
+			"Use lowercase letters, digits and underscores, starting with a letter."
+
+		ask_yes_no RELOOP_HTTPS "Configure automatic HTTPS" "${PRESERVED_RELOOP_HTTPS:-yes}"
+	fi
+
+	if [ "$EXISTING_INSTALL" = "1" ] && [ -n "${PRESERVED_POSTGRES_USER:-}" ] &&
+		{ [ "$POSTGRES_USER" != "$PRESERVED_POSTGRES_USER" ] ||
+			[ "$POSTGRES_DB" != "${PRESERVED_POSTGRES_DB:-}" ]; }; then
+		die "The database name and user cannot be changed on an existing installation." \
+			"The current database is $PRESERVED_POSTGRES_DB owned by $PRESERVED_POSTGRES_USER." \
+			"Keep those values, or start from a clean server."
+	fi
+
+	RELOOP_VERSION="${RELOOP_VERSION:-${PRESERVED_RELOOP_VERSION:-latest}}"
+	RELOOP_TRACKING_HOST="link.$RELOOP_DOMAIN"
+	RELOOP_INBOUND_HOST="inbound.$RELOOP_DOMAIN"
+
+	if [ "$RELOOP_HTTPS" = "yes" ]; then
+		RELOOP_SCHEME="https"
+		RELOOP_SITE_ADDRESS="$RELOOP_DOMAIN"
+		RELOOP_TRACKING_SITE_ADDRESS="$RELOOP_TRACKING_HOST"
+	else
+		RELOOP_SCHEME="http"
+		RELOOP_SITE_ADDRESS="http://$RELOOP_DOMAIN"
+		RELOOP_TRACKING_SITE_ADDRESS="http://$RELOOP_TRACKING_HOST"
+	fi
+
+	preserved_or_new POSTGRES_PASSWORD gen_secret 32
+	preserved_or_new REDIS_PASSWORD gen_secret 32
+	preserved_or_new BETTER_AUTH_SECRET gen_secret 48
+	preserved_or_new RELOOP_INTERNAL_SECRET gen_secret 48
+	preserved_or_new TRACKING_SECRET gen_secret 48
+	preserved_or_new PREFERENCES_SECRET gen_secret 48
+	preserved_or_new WEBHOOK_ENCRYPTION_KEY gen_hex 32
+	preserved_or_new S3_ACCESS_KEY gen_secret 20
+	preserved_or_new S3_SECRET_KEY gen_secret 40
+	preserved_or_new DEFAULT_OTP gen_digits 6
+}
+
+write_env_file() {
+	step "Generating secure configuration..."
+
+	local tmp
+	tmp="$(mktemp "$INSTALL_DIR/.env.new.XXXXXX")"
+	chmod 600 "$tmp"
+
+	cat >"$tmp" <<EOF
+# Reloop production configuration — generated by the Reloop self-host installer.
+# This file holds every credential for this deployment. Keep it at mode 0600
+# and back it up: losing it means losing access to the encrypted data.
+
+RELOOP_VERSION=$RELOOP_VERSION
+RELOOP_DOMAIN=$RELOOP_DOMAIN
+RELOOP_TRACKING_HOST=$RELOOP_TRACKING_HOST
+RELOOP_INBOUND_HOST=$RELOOP_INBOUND_HOST
+RELOOP_ADMIN_EMAIL=$RELOOP_ADMIN_EMAIL
+RELOOP_PUBLIC_IP=$RELOOP_PUBLIC_IP
+RELOOP_HTTPS=$RELOOP_HTTPS
+RELOOP_SITE_ADDRESS=$RELOOP_SITE_ADDRESS
+RELOOP_TRACKING_SITE_ADDRESS=$RELOOP_TRACKING_SITE_ADDRESS
+RELOOP_ACME_EMAIL=$RELOOP_ADMIN_EMAIL
+
+NODE_ENV=production
+BASE_URL=$RELOOP_SCHEME://$RELOOP_DOMAIN
+HOST_DOMAIN=$RELOOP_DOMAIN
+TRACKING_DOMAIN=$RELOOP_TRACKING_HOST
+TRACKING_BASE_URL=$RELOOP_SCHEME://$RELOOP_TRACKING_HOST
+INBOUND_HOSTNAME=$RELOOP_INBOUND_HOST
+SMTP_HOSTNAME=$RELOOP_DOMAIN
+DKIM_SELECTOR=reloop
+
+POSTGRES_DB=$POSTGRES_DB
+POSTGRES_USER=$POSTGRES_USER
+POSTGRES_PASSWORD=$POSTGRES_PASSWORD
+PG_URL=postgresql://$POSTGRES_USER:$POSTGRES_PASSWORD@postgres:5432/$POSTGRES_DB
+
+REDIS_PASSWORD=$REDIS_PASSWORD
+REDIS_URL=redis://:$REDIS_PASSWORD@redis:6379
+
+NATS_URL=nats://nats:4222
+
+S3_ENDPOINT=http://minio:9000
+S3_ACCESS_KEY=$S3_ACCESS_KEY
+S3_SECRET_KEY=$S3_SECRET_KEY
+S3_BUCKET=reloop-uploads
+S3_REGION=us-east-1
+S3_FORCE_PATH_STYLE=true
+
+BETTER_AUTH_SECRET=$BETTER_AUTH_SECRET
+RELOOP_INTERNAL_SECRET=$RELOOP_INTERNAL_SECRET
+TRACKING_SECRET=$TRACKING_SECRET
+PREFERENCES_SECRET=$PREFERENCES_SECRET
+WEBHOOK_ENCRYPTION_KEY=$WEBHOOK_ENCRYPTION_KEY
+
+# Bootstrap sign-in code. Reloop cannot email a one-time code until you have
+# verified a sending domain, so this fixed code stands in for the first login.
+# Remove it (and restart) as soon as your own domain sends mail.
+DEFAULT_OTP=$DEFAULT_OTP
+DISABLE_SIGNUP=false
+
+KUMOMTA_MIN_FREE_SPACE=5%
+KUMOMTA_MIN_FREE_INODES=0
+KUMOMTA_RSPAMD_URL=http://spam:11333/checkv2
+KUMOMTA_CHECK_RECIPIENT_URL=http://domain:8011/api/domain
+KUMOMTA_WEBHOOK_URL=http://domain:8011/api/domain
+RSPAMD_REDIS_SERVERS=redis:6379
+RSPAMD_REDIS_PASSWORD=$REDIS_PASSWORD
+EOF
+
+	if [ -f "$ENV_FILE" ] && ! cmp -s "$tmp" "$ENV_FILE"; then
+		local backup
+		backup="$INSTALL_DIR/.env.backup.$(date +%Y%m%d%H%M%S)"
+		cp -p "$ENV_FILE" "$backup"
+		chmod 600 "$backup"
+		info "Previous configuration saved to $(basename "$backup")"
+	fi
+
+	mv "$tmp" "$ENV_FILE"
+	chown root:root "$ENV_FILE"
+	chmod 600 "$ENV_FILE"
+	ok "Wrote $ENV_FILE (root-only, 0600)"
+}
+
+install_asset() {
+	local src="$1" dest="$2" mode="$3"
+	if [ -f "$dest" ] && ! cmp -s "$src" "$dest"; then
+		cp -p "$dest" "$dest.backup.$(date +%Y%m%d%H%M%S)"
+		info "Local changes to $(basename "$dest") saved alongside it"
+	fi
+	install -m "$mode" -o root -g root "$src" "$dest"
+}
+
+write_stack_files() {
+	install_asset "$ASSET_DIR/templates/docker-compose.yml" "$INSTALL_DIR/docker-compose.yml" 0644
+
+	if [ "$RELOOP_HTTPS" = "yes" ]; then
+		install_asset "$ASSET_DIR/templates/Caddyfile" "$INSTALL_DIR/Caddyfile" 0644
+	else
+		install_asset "$ASSET_DIR/templates/Caddyfile.http" "$INSTALL_DIR/Caddyfile" 0644
+	fi
+
+	install -m 0755 -o root -g root "$ASSET_DIR/templates/reloop" /usr/local/bin/reloop
+	ok "Wrote docker-compose.yml, Caddyfile and the reloop command"
+}

--- a/install/lib/config.sh
+++ b/install/lib/config.sh
@@ -50,7 +50,8 @@ load_existing_values() {
 	for key in RELOOP_VERSION RELOOP_DOMAIN RELOOP_ADMIN_EMAIL RELOOP_PUBLIC_IP \
 		RELOOP_HTTPS POSTGRES_DB POSTGRES_USER POSTGRES_PASSWORD REDIS_PASSWORD \
 		BETTER_AUTH_SECRET RELOOP_INTERNAL_SECRET TRACKING_SECRET PREFERENCES_SECRET \
-		WEBHOOK_ENCRYPTION_KEY S3_ACCESS_KEY S3_SECRET_KEY DEFAULT_OTP; do
+		WEBHOOK_ENCRYPTION_KEY S3_ENDPOINT S3_ACCESS_KEY S3_SECRET_KEY \
+		S3_BUCKET S3_REGION DEFAULT_OTP; do
 		local value
 		value="$(env_get "$key" "$ENV_FILE" || true)"
 		if [ -n "$value" ]; then
@@ -69,7 +70,50 @@ preserved_or_new() {
 	fi
 }
 
+collect_storage() {
+	local fallback=no
+	[ -n "${PRESERVED_S3_ENDPOINT:-}" ] && fallback=yes
+
+	ask_yes_no RELOOP_S3 \
+		"Configure S3-compatible object storage (needed for file uploads)" "$fallback"
+
+	if [ "$RELOOP_S3" != "yes" ]; then
+		STORAGE_ENABLED=no
+		COMPOSE_PROFILES=""
+		S3_ENDPOINT=""
+		S3_ACCESS_KEY=""
+		S3_SECRET_KEY=""
+		S3_BUCKET=""
+		S3_REGION=""
+		return 0
+	fi
+
+	STORAGE_ENABLED=yes
+	COMPOSE_PROFILES=storage
+
+	ask S3_ENDPOINT "S3 endpoint URL" \
+		"e.g. https://s3.eu-central-1.amazonaws.com" \
+		"${PRESERVED_S3_ENDPOINT:-}" valid_url \
+		"Enter a full URL including https://"
+	ask S3_ACCESS_KEY "S3 access key" "" \
+		"${PRESERVED_S3_ACCESS_KEY:-}" valid_any ""
+	ask S3_SECRET_KEY "S3 secret key" "" \
+		"${PRESERVED_S3_SECRET_KEY:-}" valid_any ""
+	ask S3_BUCKET "S3 bucket" "" \
+		"${PRESERVED_S3_BUCKET:-reloop-uploads}" valid_any ""
+	ask S3_REGION "S3 region" "" \
+		"${PRESERVED_S3_REGION:-us-east-1}" valid_any ""
+}
+
 collect_configuration() {
+	STORAGE_ENABLED=no
+	COMPOSE_PROFILES=""
+	S3_ENDPOINT="${S3_ENDPOINT:-}"
+	S3_ACCESS_KEY="${S3_ACCESS_KEY:-}"
+	S3_SECRET_KEY="${S3_SECRET_KEY:-}"
+	S3_BUCKET="${S3_BUCKET:-}"
+	S3_REGION="${S3_REGION:-}"
+
 	if [ "$EXISTING_INSTALL" = "1" ]; then
 		load_existing_values
 	fi
@@ -77,10 +121,15 @@ collect_configuration() {
 	if [ "$REUSE_CONFIG" = "1" ]; then
 		local key
 		for key in RELOOP_DOMAIN RELOOP_ADMIN_EMAIL RELOOP_HTTPS RELOOP_PUBLIC_IP \
-			POSTGRES_DB POSTGRES_USER; do
+			POSTGRES_DB POSTGRES_USER S3_ENDPOINT S3_ACCESS_KEY S3_SECRET_KEY \
+			S3_BUCKET S3_REGION; do
 			local ref="PRESERVED_$key"
 			[ -n "${!ref-}" ] && printf -v "$key" '%s' "${!ref}"
 		done
+		if [ -n "$S3_ENDPOINT" ]; then
+			STORAGE_ENABLED=yes
+			COMPOSE_PROFILES=storage
+		fi
 		step "Using the existing configuration"
 		ok "Domain: $RELOOP_DOMAIN"
 		ok "Administrator email: $RELOOP_ADMIN_EMAIL"
@@ -106,6 +155,8 @@ collect_configuration() {
 			"Use lowercase letters, digits and underscores, starting with a letter."
 
 		ask_yes_no RELOOP_HTTPS "Configure automatic HTTPS" "${PRESERVED_RELOOP_HTTPS:-yes}"
+
+		collect_storage
 	fi
 
 	if [ "$EXISTING_INSTALL" = "1" ] && [ -n "${PRESERVED_POSTGRES_USER:-}" ] &&
@@ -137,8 +188,6 @@ collect_configuration() {
 	preserved_or_new TRACKING_SECRET gen_secret 48
 	preserved_or_new PREFERENCES_SECRET gen_secret 48
 	preserved_or_new WEBHOOK_ENCRYPTION_KEY gen_hex 32
-	preserved_or_new S3_ACCESS_KEY gen_secret 20
-	preserved_or_new S3_SECRET_KEY gen_secret 40
 	preserved_or_new DEFAULT_OTP gen_digits 6
 }
 
@@ -184,11 +233,12 @@ REDIS_URL=redis://:$REDIS_PASSWORD@redis:6379
 
 NATS_URL=nats://nats:4222
 
-S3_ENDPOINT=http://minio:9000
+COMPOSE_PROFILES=$COMPOSE_PROFILES
+S3_ENDPOINT=$S3_ENDPOINT
 S3_ACCESS_KEY=$S3_ACCESS_KEY
 S3_SECRET_KEY=$S3_SECRET_KEY
-S3_BUCKET=reloop-uploads
-S3_REGION=us-east-1
+S3_BUCKET=$S3_BUCKET
+S3_REGION=$S3_REGION
 S3_FORCE_PATH_STYLE=true
 
 BETTER_AUTH_SECRET=$BETTER_AUTH_SECRET

--- a/install/lib/deploy.sh
+++ b/install/lib/deploy.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-INFRA_SERVICES=(postgres redis nats minio)
+INFRA_SERVICES=(postgres redis nats)
 
 pull_images() {
 	step "Downloading Reloop ${RELOOP_VERSION} container images..."
-	info "About 28 GB on a first install — this is the slowest step."
+	info "About 20 GB on a first install — this is the slowest step."
 
 	local log total pid pulled status
 	log="$(mktemp -t reloop-pull.XXXXXX)"
@@ -53,7 +53,6 @@ start_infrastructure() {
 	ok "PostgreSQL ready"
 	ok "Redis ready"
 	ok "NATS ready"
-	ok "Object storage ready"
 }
 
 database_has_tables() {

--- a/install/lib/deploy.sh
+++ b/install/lib/deploy.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+
+INFRA_SERVICES=(postgres redis nats minio)
+
+pull_images() {
+	step "Downloading Reloop ${RELOOP_VERSION} container images..."
+	info "About 28 GB on a first install — this is the slowest step."
+
+	local log total pid pulled status
+	log="$(mktemp -t reloop-pull.XXXXXX)"
+	total="$(compose config --images 2>/dev/null | sort -u | grep -c . || true)"
+	[ -n "$total" ] && [ "$total" -gt 0 ] || total="?"
+
+	compose --progress plain pull >"$log" 2>&1 &
+	pid=$!
+
+	local started=$SECONDS
+	while kill -0 "$pid" 2>/dev/null; do
+		pulled="$(grep -c ' Pulled' "$log" 2>/dev/null || true)"
+		pulled="${pulled:-0}"
+		printf '\r  %s·%s %s of %s images downloaded (%ss elapsed)' \
+			"$C_DIM" "$C_RESET" "$pulled" "$total" "$((SECONDS - started))"
+		sleep 5
+	done
+
+	status=0
+	wait "$pid" || status=$?
+	printf '\r\033[K'
+
+	if [ "$status" -ne 0 ]; then
+		printf '\n' >&2
+		tail -20 "$log" >&2
+		rm -f "$log"
+		die "Failed to download the Reloop container images." \
+			"If the output above mentions a pull rate limit, Docker Hub is throttling" \
+			"this server's IP. Wait an hour, or authenticate with a Docker Hub account:" \
+			"  docker login" \
+			"" \
+			"Then retry:" \
+			"  cd $INSTALL_DIR && docker compose pull"
+	fi
+
+	rm -f "$log"
+	ok "Images downloaded"
+}
+
+start_infrastructure() {
+	step "Starting infrastructure..."
+	if ! compose up -d --wait --wait-timeout 300 "${INFRA_SERVICES[@]}"; then
+		diagnose_services "${INFRA_SERVICES[@]}"
+		die "Infrastructure services did not become healthy."
+	fi
+	ok "PostgreSQL ready"
+	ok "Redis ready"
+	ok "NATS ready"
+	ok "Object storage ready"
+}
+
+database_has_tables() {
+	local count
+	count="$(compose exec -T postgres psql -U "$POSTGRES_USER" -d "$POSTGRES_DB" -tAc \
+		"select count(*) from information_schema.tables where table_schema='public'" 2>/dev/null | tr -dc '0-9')"
+	[ -n "$count" ] && [ "$count" -gt 0 ]
+}
+
+prune_backups() {
+	local dir="$1" old
+	while read -r old; do
+		[ -n "$old" ] && rm -f "$old"
+	done < <(ls -1t "$dir"/pre-migration-*.sql.gz 2>/dev/null | tail -n +6)
+}
+
+backup_database() {
+	local dir="$INSTALL_DIR/backups"
+	install -d -m 0700 -o root -g root "$dir"
+	local file
+	file="$dir/pre-migration-$(date +%Y%m%d%H%M%S).sql.gz"
+	info "Backing up the existing database before applying schema changes"
+	if compose exec -T postgres pg_dump -U "$POSTGRES_USER" -d "$POSTGRES_DB" | gzip >"$file"; then
+		chmod 600 "$file"
+		prune_backups "$dir"
+		ok "Backup written to $file"
+	else
+		rm -f "$file"
+		die "Could not back up the database before migrating." \
+			"Refusing to change the schema without a backup."
+	fi
+}
+
+run_migrations() {
+	step "Applying the database schema..."
+	if database_has_tables; then
+		backup_database
+	fi
+	if ! compose --profile tools run --rm migrate; then
+		diagnose_services postgres
+		die "Database migration failed." \
+			"Re-run it manually once the cause is fixed:" \
+			"  cd $INSTALL_DIR && docker compose --profile tools run --rm migrate"
+	fi
+	ok "Schema applied"
+}
+
+start_application() {
+	step "Deploying Reloop..."
+	if ! compose up -d --remove-orphans; then
+		die "docker compose up failed." \
+			"Inspect the stack with:" \
+			"  cd $INSTALL_DIR && docker compose ps" \
+			"  cd $INSTALL_DIR && docker compose logs --tail 50"
+	fi
+	ok "All services started"
+}

--- a/install/lib/dns.sh
+++ b/install/lib/dns.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+
+is_private_ipv4() {
+	local ip="$1"
+	case "$ip" in
+	10.* | 127.* | 169.254.* | 192.168.* | 0.* | 255.*) return 0 ;;
+	172.1[6-9].* | 172.2[0-9].* | 172.3[0-1].*) return 0 ;;
+	100.6[4-9].* | 100.[7-9][0-9].* | 100.1[0-1][0-9].* | 100.12[0-7].*) return 0 ;;
+	esac
+	return 1
+}
+
+local_public_ipv4s() {
+	ip -4 -o addr show scope global 2>/dev/null |
+		awk '{print $2, $4}' |
+		grep -Ev '^(docker[0-9]*|br-[0-9a-f]+|veth|lo|virbr[0-9]*|kube|cni|flannel|tailscale)' |
+		awk '{split($2, a, "/"); print a[1]}'
+}
+
+remote_public_ipv4() {
+	local url ip
+	for url in https://api.ipify.org https://ifconfig.me/ip https://icanhazip.com; do
+		ip="$(curl -fsS --max-time 10 "$url" 2>/dev/null | tr -d '[:space:]')" || continue
+		if valid_ipv4 "$ip"; then
+			printf '%s' "$ip"
+			return 0
+		fi
+	done
+	return 1
+}
+
+detect_public_ip() {
+	step "Detecting the server's public address..."
+
+	if [ -n "${RELOOP_PUBLIC_IP:-}" ]; then
+		valid_ipv4 "$RELOOP_PUBLIC_IP" ||
+			die "RELOOP_PUBLIC_IP is not a valid IPv4 address: $RELOOP_PUBLIC_IP"
+		ok "Public IPv4: $RELOOP_PUBLIC_IP (provided)"
+		return 0
+	fi
+
+	local candidates=() ip
+	while read -r ip; do
+		[ -n "$ip" ] || continue
+		is_private_ipv4 "$ip" && continue
+		candidates+=("$ip")
+	done < <(local_public_ipv4s)
+
+	local remote=""
+	remote="$(remote_public_ipv4 || true)"
+	if [ -n "$remote" ]; then
+		local seen=0 c
+		for c in "${candidates[@]}"; do
+			[ "$c" = "$remote" ] && seen=1
+		done
+		[ "$seen" = "0" ] && candidates+=("$remote")
+	fi
+
+	if [ "${#candidates[@]}" -eq 0 ]; then
+		if [ "$NONINTERACTIVE" = "1" ]; then
+			die "Could not determine the server's public IPv4 address." \
+				"Set RELOOP_PUBLIC_IP=<address> and re-run."
+		fi
+		warn "No public IPv4 address could be detected automatically"
+		ask RELOOP_PUBLIC_IP "Server public IPv4 address" \
+			"The address your DNS A records should point at" \
+			"" valid_ipv4 "Enter a valid IPv4 address, e.g. 203.0.113.10"
+		return 0
+	fi
+
+	if [ "${#candidates[@]}" -eq 1 ]; then
+		RELOOP_PUBLIC_IP="${candidates[0]}"
+		ok "Public IPv4: $RELOOP_PUBLIC_IP"
+		return 0
+	fi
+
+	if [ "$NONINTERACTIVE" = "1" ]; then
+		RELOOP_PUBLIC_IP="${remote:-${candidates[0]}}"
+		warn "Several public addresses found; using $RELOOP_PUBLIC_IP"
+		return 0
+	fi
+
+	local choice
+	ask_choice choice "This server has more than one public address. Which one should DNS point at?" \
+		"${candidates[@]}"
+	RELOOP_PUBLIC_IP="${candidates[$((choice - 1))]}"
+	ok "Public IPv4: $RELOOP_PUBLIC_IP"
+}
+
+dns_instructions() {
+	local apex="$1" name_app name_link name_inbound
+	name_app="$(dns_label "$RELOOP_DOMAIN" "$apex")"
+	name_link="$(dns_label "$RELOOP_TRACKING_HOST" "$apex")"
+	name_inbound="$(dns_label "$RELOOP_INBOUND_HOST" "$apex")"
+
+	printf '\n'
+	printf 'Add these records at the DNS host for %s:\n\n' "$apex"
+	printf '  %-6s %-28s %-32s %s\n' "TYPE" "NAME" "VALUE" "TTL"
+	printf '  %-6s %-28s %-32s %s\n' "----" "----" "-----" "---"
+	printf '  %-6s %-28s %-32s %s\n' "A" "$name_app" "$RELOOP_PUBLIC_IP" "Auto"
+	printf '  %-6s %-28s %-32s %s\n' "A" "$name_link" "$RELOOP_PUBLIC_IP" "Auto"
+	printf '  %-6s %-28s %-32s %s\n' "A" "$name_inbound" "$RELOOP_PUBLIC_IP" "Auto"
+	printf '  %-6s %-28s %-32s %s\n' "TXT" "$name_app" "v=spf1 ip4:$RELOOP_PUBLIC_IP -all" "Auto"
+	printf '\n'
+	printf 'Full records:\n\n'
+	printf '  %-38s A    %s\n' "$RELOOP_DOMAIN" "$RELOOP_PUBLIC_IP"
+	printf '  %-38s A    %s\n' "$RELOOP_TRACKING_HOST" "$RELOOP_PUBLIC_IP"
+	printf '  %-38s A    %s\n' "$RELOOP_INBOUND_HOST" "$RELOOP_PUBLIC_IP"
+	printf '  %-38s TXT  "v=spf1 ip4:%s -all"\n' "$RELOOP_DOMAIN" "$RELOOP_PUBLIC_IP"
+}
+
+dns_label() {
+	local fqdn="$1" apex="$2"
+	if [ "$fqdn" = "$apex" ]; then
+		printf '@'
+	else
+		printf '%s' "${fqdn%".$apex"}"
+	fi
+}
+
+TWO_LABEL_SUFFIXES="co.uk ac.uk gov.uk org.uk net.uk me.uk com.au net.au org.au edu.au \
+co.nz net.nz org.nz co.za org.za com.br net.br com.mx com.ar com.tr com.sg com.hk \
+com.cn net.cn org.cn co.jp or.jp ne.jp co.kr co.in net.in org.in co.il com.pl"
+
+# Guessing the zone wrong sends the reader to the wrong DNS record name.
+zone_apex() {
+	local fqdn="$1" n last2 suffix
+	n="$(awk -F. '{print NF}' <<<"$fqdn")"
+	if [ "$n" -le 2 ]; then
+		printf '%s' "$fqdn"
+		return
+	fi
+	last2="$(cut -d. -f$((n - 1))-"$n" <<<"$fqdn")"
+	for suffix in $TWO_LABEL_SUFFIXES; do
+		if [ "$last2" = "$suffix" ]; then
+			if [ "$n" -le 3 ]; then
+				printf '%s' "$fqdn"
+			else
+				printf '%s' "$(cut -d. -f$((n - 2))-"$n" <<<"$fqdn")"
+			fi
+			return
+		fi
+	done
+	printf '%s' "$last2"
+}

--- a/install/lib/docker.sh
+++ b/install/lib/docker.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+
+MIN_DOCKER_VERSION="24.0.0"
+MIN_COMPOSE_VERSION="2.20.0"
+
+version_ge() {
+	[ "$(printf '%s\n%s\n' "$2" "$1" | sort -V | head -1)" = "$2" ]
+}
+
+setup_docker_repo() {
+	export DEBIAN_FRONTEND=noninteractive
+	export NEEDRESTART_MODE=a
+	export NEEDRESTART_SUSPEND=1
+
+	apt-get update -qq >/dev/null 2>&1
+	apt-get install -y -qq ca-certificates curl gnupg >/dev/null 2>&1
+
+	install -m 0755 -d /etc/apt/keyrings
+	local keyring="/etc/apt/keyrings/docker.asc"
+	if ! curl -fsSL --proto '=https' "https://download.docker.com/linux/$OS_ID/gpg" -o "$keyring"; then
+		die "Could not download the Docker apt signing key." \
+			"Check outbound HTTPS access to download.docker.com and retry."
+	fi
+	chmod a+r "$keyring"
+
+	local codename="$OS_CODENAME"
+	if [ -z "$codename" ]; then
+		codename="$(. /etc/os-release && echo "${UBUNTU_CODENAME:-${VERSION_CODENAME:-}}")"
+	fi
+	[ -n "$codename" ] || die "Could not determine the distribution codename for the Docker repository."
+
+	printf 'deb [arch=amd64 signed-by=%s] https://download.docker.com/linux/%s %s stable\n' \
+		"$keyring" "$OS_ID" "$codename" >/etc/apt/sources.list.d/docker.list
+
+	apt-get update -qq >/dev/null 2>&1
+}
+
+install_docker_engine() {
+	info "Installing Docker Engine from the official Docker apt repository"
+	setup_docker_repo
+	if ! apt-get install -y -qq docker-ce docker-ce-cli containerd.io \
+		docker-buildx-plugin docker-compose-plugin >/dev/null 2>&1; then
+		die "Docker installation failed." \
+			"Inspect the output above, or install Docker manually:" \
+			"  https://docs.docker.com/engine/install/"
+	fi
+
+	systemctl enable --now docker >/dev/null 2>&1 || true
+	ok "Docker Engine installed"
+}
+
+ensure_docker() {
+	step "Checking Docker..."
+
+	if ! have docker; then
+		case "$OS_ID" in
+		ubuntu | debian) install_docker_engine ;;
+		*)
+			die "Docker is not installed and this OS has no automatic install path." \
+				"Install Docker 24+ and the Compose plugin, then re-run the installer."
+			;;
+		esac
+	fi
+
+	local docker_version
+	if ! docker_version="$(docker version --format '{{.Server.Version}}' 2>/dev/null)"; then
+		systemctl start docker >/dev/null 2>&1 || true
+		if ! docker_version="$(docker version --format '{{.Server.Version}}' 2>/dev/null)"; then
+			die "The Docker daemon is not responding." \
+				"Diagnose it with:" \
+				"  systemctl status docker" \
+				"  journalctl -u docker -n 50 --no-pager"
+		fi
+	fi
+
+	if ! version_ge "${docker_version%%-*}" "$MIN_DOCKER_VERSION"; then
+		die "Docker $docker_version is too old (Reloop needs $MIN_DOCKER_VERSION or newer)." \
+			"Upgrade Docker: https://docs.docker.com/engine/install/"
+	fi
+	ok "Docker $docker_version available"
+
+	local compose_version
+	if ! compose_version="$(docker compose version --short 2>/dev/null)"; then
+		case "$OS_ID" in
+		ubuntu | debian)
+			info "Installing the Docker Compose plugin"
+			setup_docker_repo
+			apt-get install -y -qq docker-compose-plugin >/dev/null 2>&1 ||
+				die "Could not install the Docker Compose plugin."
+			compose_version="$(docker compose version --short 2>/dev/null)" ||
+				die "Docker Compose v2 is still unavailable after installation."
+			;;
+		*)
+			die "Docker Compose v2 is missing." \
+				"Install the compose plugin: https://docs.docker.com/compose/install/"
+			;;
+		esac
+	fi
+
+	if ! version_ge "${compose_version#v}" "$MIN_COMPOSE_VERSION"; then
+		die "Docker Compose ${compose_version} is too old (Reloop needs $MIN_COMPOSE_VERSION or newer)." \
+			"Upgrade the compose plugin: https://docs.docker.com/compose/install/"
+	fi
+	ok "Docker Compose ${compose_version} available"
+
+	if ! docker info >/dev/null 2>&1; then
+		die "\`docker info\` failed." \
+			"The daemon is installed but unhealthy. Check: journalctl -u docker -n 50 --no-pager"
+	fi
+	ok "Docker daemon healthy"
+
+	systemctl is-enabled docker >/dev/null 2>&1 || systemctl enable docker >/dev/null 2>&1 || true
+}

--- a/install/lib/health.sh
+++ b/install/lib/health.sh
@@ -9,19 +9,17 @@ API_HEALTH=(
 	"mail|Mail|http://mail:8015/api/mail/health"
 	"logs|Logs|http://logs:8016/api/logs/health"
 	"workflow|Workflows|http://workflow:8017/api/workflow/health"
-	"upload|Uploads|http://upload:8018/api/upload/health"
 	"template|Templates|http://template:8019/api/template/health"
 	"inbox|Inbox|http://inbox:8021/api/inbox/health"
 	"email|Email|http://email:8022/api/email/health"
-	"credits|Credits|http://credits:8023/api/credits/health"
-	"admin|Admin|http://admin:8024/api/admin/health"
-	"tools|Tools|http://tools:8026/api/tools/health"
+)
+
+STORAGE_HEALTH=(
+	"upload|Uploads|http://upload:8018/api/upload/health"
 )
 
 WEB_HEALTH=(
 	"dashboard|Dashboard|http://dashboard:3000/dashboard/healthz"
-	"docs|Documentation|http://docs:3000/docs"
-	"console|Console|http://console:3002/console"
 	"links|Links|http://links:3005/"
 )
 
@@ -129,6 +127,9 @@ verify_deployment() {
 	fi
 
 	check_group API_HEALTH 1
+	if [ "$STORAGE_ENABLED" = "yes" ]; then
+		check_group STORAGE_HEALTH 1
+	fi
 	check_group WEB_HEALTH 0
 	check_mail_transport
 	check_restart_loops || true

--- a/install/lib/health.sh
+++ b/install/lib/health.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+
+API_HEALTH=(
+	"auth|Auth|http://auth:8000/api/auth/health"
+	"domain|Domain|http://domain:8011/api/domain/health"
+	"api-key|API keys|http://api-key:8012/api/api-key/health"
+	"webhook|Webhooks|http://webhook:8013/api/webhook/health"
+	"contacts|Contacts|http://contacts:8014/api/contacts/health"
+	"mail|Mail|http://mail:8015/api/mail/health"
+	"logs|Logs|http://logs:8016/api/logs/health"
+	"workflow|Workflows|http://workflow:8017/api/workflow/health"
+	"upload|Uploads|http://upload:8018/api/upload/health"
+	"template|Templates|http://template:8019/api/template/health"
+	"inbox|Inbox|http://inbox:8021/api/inbox/health"
+	"email|Email|http://email:8022/api/email/health"
+	"credits|Credits|http://credits:8023/api/credits/health"
+	"admin|Admin|http://admin:8024/api/admin/health"
+	"tools|Tools|http://tools:8026/api/tools/health"
+)
+
+WEB_HEALTH=(
+	"dashboard|Dashboard|http://dashboard:3000/dashboard/healthz"
+	"docs|Documentation|http://docs:3000/docs"
+	"console|Console|http://console:3002/console"
+	"links|Links|http://links:3005/"
+)
+
+MAIL_SERVICES=(smtp inbound spam)
+
+http_probe() {
+	compose exec -T proxy wget -q -O - -T 8 "$1" 2>/dev/null
+}
+
+container_state() {
+	docker inspect -f '{{.State.Status}}' "reloop-$1" 2>/dev/null || printf 'missing'
+}
+
+restart_count() {
+	docker inspect -f '{{.RestartCount}}' "reloop-$1" 2>/dev/null || printf '0'
+}
+
+diagnose_services() {
+	local svc
+	printf '\n'
+	printf '%sContainer status%s\n' "$C_BOLD" "$C_RESET"
+	compose ps || true
+	for svc in "$@"; do
+		printf '\n%sLast log lines — reloop-%s%s\n' "$C_BOLD" "$svc" "$C_RESET"
+		compose logs --tail 30 --no-color "$svc" 2>&1 | sed 's/^/    /' || true
+	done
+	printf '\n'
+}
+
+wait_for_probe() {
+	local url="$1" expect_success="$2" budget="$3" deadline body
+	deadline=$((SECONDS + budget))
+	while [ "$SECONDS" -lt "$deadline" ]; do
+		if body="$(http_probe "$url")"; then
+			if [ "$expect_success" = "0" ]; then
+				return 0
+			fi
+			case "$body" in
+			*DISCONNECTED* | *'"success":false'*) : ;;
+			*'"success":true'* | *'"status":"CONNECTED"'*) return 0 ;;
+			esac
+		fi
+		sleep 4
+	done
+	return 1
+}
+
+check_group() {
+	local -n entries="$1"
+	local expect_success="$2"
+	local failed=() entry svc label url budget="$HEALTH_TIMEOUT"
+	for entry in "${entries[@]}"; do
+		IFS='|' read -r svc label url <<<"$entry"
+		if wait_for_probe "$url" "$expect_success" "$budget"; then
+			ok "$label healthy"
+			budget="$HEALTH_TIMEOUT_FOLLOWUP"
+		else
+			printf '  %s✗%s %s did not become healthy\n' "$C_RED" "$C_RESET" "$label"
+			failed+=("$svc")
+		fi
+	done
+	if [ "${#failed[@]}" -gt 0 ]; then
+		FAILED_SERVICES+=("${failed[@]}")
+	fi
+}
+
+check_mail_transport() {
+	local svc state
+	for svc in "${MAIL_SERVICES[@]}"; do
+		state="$(container_state "$svc")"
+		if [ "$state" = "running" ] && [ "$(restart_count "$svc")" -le 2 ]; then
+			ok "Mail transport: $svc running"
+		else
+			printf '  %s✗%s Mail transport: %s is %s\n' "$C_RED" "$C_RESET" "$svc" "$state"
+			FAILED_SERVICES+=("$svc")
+		fi
+	done
+}
+
+check_restart_loops() {
+	local svc count looping=()
+	while read -r svc; do
+		[ -n "$svc" ] || continue
+		count="$(restart_count "$svc")"
+		if [ "$count" -ge 3 ]; then
+			looping+=("$svc")
+		fi
+	done < <(compose ps --services 2>/dev/null)
+
+	if [ "${#looping[@]}" -gt 0 ]; then
+		printf '  %s✗%s Restart loops detected: %s\n' "$C_RED" "$C_RESET" "${looping[*]}"
+		FAILED_SERVICES+=("${looping[@]}")
+		return 1
+	fi
+	ok "No restart loops"
+}
+
+verify_deployment() {
+	step "Verifying deployment..."
+	FAILED_SERVICES=()
+
+	if [ "$(container_state proxy)" != "running" ]; then
+		diagnose_services proxy
+		die "The reverse proxy is not running; no health checks could be run."
+	fi
+
+	check_group API_HEALTH 1
+	check_group WEB_HEALTH 0
+	check_mail_transport
+	check_restart_loops || true
+
+	if http_probe http://127.0.0.1:2019/config/ >/dev/null 2>&1; then
+		ok "Reverse proxy configured"
+	else
+		printf '  %s✗%s Reverse proxy is not serving its configuration\n' "$C_RED" "$C_RESET"
+		FAILED_SERVICES+=(proxy)
+	fi
+
+	if [ "${#FAILED_SERVICES[@]}" -eq 0 ]; then
+		return 0
+	fi
+
+	local unique
+	mapfile -t unique < <(printf '%s\n' "${FAILED_SERVICES[@]}" | sort -u)
+	diagnose_services "${unique[@]}"
+	die "Reloop was deployed but ${#unique[@]} service(s) are unhealthy: ${unique[*]}" \
+		"Inspect them with:" \
+		"  cd $INSTALL_DIR && docker compose logs ${unique[0]}" \
+		"" \
+		"Re-run the installer once the cause is fixed; your configuration and data are kept."
+}

--- a/install/lib/preflight.sh
+++ b/install/lib/preflight.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+
+MIN_RAM_MB=3800
+MIN_DISK_GB=45
+
+OS_ID=""
+OS_VERSION_ID=""
+OS_PRETTY=""
+OS_CODENAME=""
+
+detect_os() {
+	[ -r /etc/os-release ] || die "/etc/os-release is missing; this OS is not supported."
+	# shellcheck disable=SC1091
+	. /etc/os-release
+	OS_ID="${ID:-}"
+	OS_VERSION_ID="${VERSION_ID:-}"
+	OS_PRETTY="${PRETTY_NAME:-$OS_ID $OS_VERSION_ID}"
+	OS_CODENAME="${VERSION_CODENAME:-}"
+}
+
+check_root() {
+	if [ "$(id -u)" -ne 0 ]; then
+		die "The installer must run as root." \
+			"Re-run it with sudo:" \
+			"  curl -fsSL $INSTALLER_URL | sudo bash"
+	fi
+	ok "Running as root"
+}
+
+check_os() {
+	detect_os
+	case "$OS_ID" in
+	ubuntu)
+		case "$OS_VERSION_ID" in
+		22.04 | 24.04) ok "$OS_PRETTY supported" ;;
+		*)
+			if [ "$ALLOW_UNSUPPORTED_OS" = "1" ]; then
+				warn "$OS_PRETTY is untested (RELOOP_ALLOW_UNSUPPORTED_OS=1)"
+			else
+				die "Ubuntu $OS_VERSION_ID is not supported." \
+					"Supported: Ubuntu 22.04 LTS, Ubuntu 24.04 LTS, Debian 12, Debian 13." \
+					"Set RELOOP_ALLOW_UNSUPPORTED_OS=1 to continue anyway."
+			fi
+			;;
+		esac
+		;;
+	debian)
+		case "${OS_VERSION_ID%%.*}" in
+		12 | 13) ok "$OS_PRETTY supported" ;;
+		*)
+			if [ "$ALLOW_UNSUPPORTED_OS" = "1" ]; then
+				warn "$OS_PRETTY is untested (RELOOP_ALLOW_UNSUPPORTED_OS=1)"
+			else
+				die "Debian $OS_VERSION_ID is not supported." \
+					"Supported: Ubuntu 22.04 LTS, Ubuntu 24.04 LTS, Debian 12, Debian 13." \
+					"Set RELOOP_ALLOW_UNSUPPORTED_OS=1 to continue anyway."
+			fi
+			;;
+		esac
+		;;
+	*)
+		if [ "$ALLOW_UNSUPPORTED_OS" = "1" ]; then
+			warn "$OS_PRETTY is untested (RELOOP_ALLOW_UNSUPPORTED_OS=1)"
+		else
+			die "$OS_PRETTY is not supported." \
+				"Supported: Ubuntu 22.04 LTS, Ubuntu 24.04 LTS, Debian 12, Debian 13." \
+				"Set RELOOP_ALLOW_UNSUPPORTED_OS=1 to continue anyway."
+		fi
+		;;
+	esac
+}
+
+check_arch() {
+	local arch
+	arch="$(uname -m)"
+	case "$arch" in
+	x86_64) ok "x86_64 architecture" ;;
+	aarch64 | arm64)
+		die "arm64 is not supported yet." \
+			"Reloop publishes arm64 images for the backend services but the" \
+			"dashboard, docs and links images are amd64-only, so the stack" \
+			"cannot start on this machine. Use an x86_64 server."
+		;;
+	*) die "Unsupported CPU architecture: $arch (Reloop needs x86_64)." ;;
+	esac
+}
+
+check_memory() {
+	local kb mb
+	kb="$(awk '/^MemTotal:/ {print $2}' /proc/meminfo)"
+	mb=$((kb / 1024))
+	if [ "$mb" -lt "$MIN_RAM_MB" ]; then
+		die "Not enough memory: ${mb} MB detected, 4 GB is the documented minimum." \
+			"Reloop runs 22 containers; 8 GB is recommended for production."
+	fi
+	ok "Memory: ${mb} MB"
+	if [ "$mb" -lt 7000 ]; then
+		warn "8 GB is recommended for production traffic"
+	fi
+}
+
+check_disk() {
+	local avail_gb
+	avail_gb="$(df -BG --output=avail "$(dirname "$INSTALL_DIR")" 2>/dev/null | tail -1 | tr -dc '0-9')"
+	if [ -z "$avail_gb" ]; then
+		warn "Could not determine free disk space for $INSTALL_DIR"
+		return 0
+	fi
+	if [ "$avail_gb" -lt "$MIN_DISK_GB" ]; then
+		die "Not enough disk space: ${avail_gb} GB free, ${MIN_DISK_GB} GB required." \
+			"The Reloop container images alone are about 28 GB; 60 GB is recommended" \
+			"so there is room for the database, object storage and mail spools."
+	fi
+	ok "Disk space: ${avail_gb} GB free"
+	if [ "$avail_gb" -lt 60 ]; then
+		warn "60 GB is recommended once the database and mail spools grow"
+	fi
+}
+
+check_binaries() {
+	local missing=()
+	local b
+	for b in curl awk sed grep df tar; do
+		have "$b" || missing+=("$b")
+	done
+	if [ "${#missing[@]}" -gt 0 ]; then
+		die "Missing required commands: ${missing[*]}" \
+			"Install them with: apt-get install -y ${missing[*]}"
+	fi
+	ok "Required tools available"
+}
+
+check_network() {
+	local code
+	# The registry answers 401 without credentials; any status proves reachability.
+	code="$(curl -s --max-time 15 -o /dev/null -w '%{http_code}' https://registry-1.docker.io/v2/ 2>/dev/null || true)"
+	if [ -n "$code" ] && [ "$code" != "000" ]; then
+		ok "Outbound network reachable"
+		return 0
+	fi
+	die "Cannot reach registry-1.docker.io." \
+		"Reloop pulls its container images from Docker Hub; allow outbound HTTPS and retry."
+}
+
+port_owner() {
+	local port="$1" out=""
+	if have ss; then
+		out="$(ss -H -lntup "sport = :$port" 2>/dev/null | awk '{for(i=1;i<=NF;i++) if($i ~ /users:/) print $i}' | head -1)"
+	fi
+	if [ -z "$out" ] && have lsof; then
+		out="$(lsof -nP -iTCP:"$port" -sTCP:LISTEN -Fc 2>/dev/null | sed -n 's/^c//p' | head -1)"
+	fi
+	printf '%s' "$out"
+}
+
+port_in_use() {
+	local port="$1"
+	if have ss; then
+		ss -H -lnt "sport = :$port" 2>/dev/null | grep -q . && return 0
+		return 1
+	fi
+	if have lsof; then
+		lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1 && return 0
+		return 1
+	fi
+	return 1
+}
+
+port_is_ours() {
+	local port="$1"
+	docker ps --format '{{.Names}}\t{{.Ports}}' 2>/dev/null |
+		grep -E '^reloop-' | grep -q ":$port->"
+}
+
+check_ports() {
+	local conflicts=()
+	local port owner
+	for port in "${REQUIRED_PORTS[@]}"; do
+		if port_in_use "$port" && ! port_is_ours "$port"; then
+			owner="$(port_owner "$port")"
+			conflicts+=("$port|${owner:-unknown process}")
+		fi
+	done
+
+	if [ "${#conflicts[@]}" -eq 0 ]; then
+		ok "Required ports available (${REQUIRED_PORTS[*]})"
+		return 0
+	fi
+
+	local entry p o lines=()
+	for entry in "${conflicts[@]}"; do
+		p="${entry%%|*}"
+		o="${entry#*|}"
+		lines+=("  Port $p is held by: $o  (${PORT_PURPOSE[$p]:-required by Reloop})")
+	done
+
+	die "Required ports are already in use." "${lines[@]}" \
+		"" \
+		"Stop the listed services (or move them to other ports) and re-run the installer."
+}
+
+preflight() {
+	step "Checking server..."
+	check_root
+	check_os
+	check_arch
+	check_memory
+	check_disk
+	check_binaries
+	check_network
+}

--- a/install/lib/preflight.sh
+++ b/install/lib/preflight.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 MIN_RAM_MB=3800
-MIN_DISK_GB=45
+MIN_DISK_GB=35
 
 OS_ID=""
 OS_VERSION_ID=""
@@ -78,7 +78,7 @@ check_arch() {
 	aarch64 | arm64)
 		die "arm64 is not supported yet." \
 			"Reloop publishes arm64 images for the backend services but the" \
-			"dashboard, docs and links images are amd64-only, so the stack" \
+			"dashboard, console and links images are amd64-only, so the stack" \
 			"cannot start on this machine. Use an x86_64 server."
 		;;
 	*) die "Unsupported CPU architecture: $arch (Reloop needs x86_64)." ;;
@@ -108,12 +108,12 @@ check_disk() {
 	fi
 	if [ "$avail_gb" -lt "$MIN_DISK_GB" ]; then
 		die "Not enough disk space: ${avail_gb} GB free, ${MIN_DISK_GB} GB required." \
-			"The Reloop container images alone are about 28 GB; 60 GB is recommended" \
+			"The Reloop container images alone are about 22 GB; 50 GB is recommended" \
 			"so there is room for the database, object storage and mail spools."
 	fi
 	ok "Disk space: ${avail_gb} GB free"
-	if [ "$avail_gb" -lt 60 ]; then
-		warn "60 GB is recommended once the database and mail spools grow"
+	if [ "$avail_gb" -lt 50 ]; then
+		warn "50 GB is recommended once the database and mail spools grow"
 	fi
 }
 

--- a/install/lib/prompts.sh
+++ b/install/lib/prompts.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+
+# `curl | sudo bash` leaves stdin on the piped script, so prompts need the tty fd.
+read_line() {
+	local __var="$1" __line=""
+	if [ -n "$TTY_FD" ]; then
+		IFS= read -r __line <&"$TTY_FD" || return 1
+	else
+		IFS= read -r __line || return 1
+	fi
+	printf -v "$__var" '%s' "$__line"
+}
+
+prompt_label() {
+	printf '\n%s%s%s\n' "$C_BOLD" "$1" "$C_RESET"
+	if [ -n "${2:-}" ]; then
+		printf '%s%s%s\n' "$C_DIM" "$2" "$C_RESET"
+	fi
+}
+
+ask() {
+	local var="$1" label="$2" hint="$3" default="$4" validator="$5" errhint="$6"
+	local current answer
+
+	current="${!var-}"
+	if [ -n "$current" ]; then
+		if "$validator" "$current"; then
+			ok "$label: $current"
+			return 0
+		fi
+		die "Invalid value for $var: $current" "$errhint"
+	fi
+
+	if [ "$NONINTERACTIVE" = "1" ]; then
+		if [ -z "$default" ]; then
+			die "$label is required in non-interactive mode." "$errhint"
+		fi
+		printf -v "$var" '%s' "$default"
+		ok "$label: $default"
+		return 0
+	fi
+
+	while true; do
+		if [ -n "$default" ]; then
+			prompt_label "$label [$default]:" "$hint"
+		else
+			prompt_label "$label:" "$hint"
+		fi
+		printf '> '
+		if ! read_line answer; then
+			die "Standard input closed while waiting for an answer."
+		fi
+		[ -z "$answer" ] && answer="$default"
+		if [ -z "$answer" ]; then
+			warn "A value is required."
+			continue
+		fi
+		if "$validator" "$answer"; then
+			printf -v "$var" '%s' "$answer"
+			return 0
+		fi
+		warn "$errhint"
+	done
+}
+
+ask_yes_no() {
+	local var="$1" label="$2" default="$3" current answer suffix
+
+	current="${!var-}"
+	if [ -n "$current" ]; then
+		case "${current,,}" in
+		1 | y | yes | true) printf -v "$var" '%s' "yes" ;;
+		0 | n | no | false) printf -v "$var" '%s' "no" ;;
+		*) die "Invalid value for $var: $current (expected yes or no)" ;;
+		esac
+		ok "$label: ${!var}"
+		return 0
+	fi
+
+	if [ "$NONINTERACTIVE" = "1" ]; then
+		printf -v "$var" '%s' "$default"
+		ok "$label: $default"
+		return 0
+	fi
+
+	if [ "$default" = "yes" ]; then suffix="[Y/n]"; else suffix="[y/N]"; fi
+
+	while true; do
+		prompt_label "$label $suffix:" ""
+		printf '> '
+		if ! read_line answer; then
+			die "Standard input closed while waiting for an answer."
+		fi
+		case "${answer,,}" in
+		"") printf -v "$var" '%s' "$default" && return 0 ;;
+		y | yes) printf -v "$var" '%s' "yes" && return 0 ;;
+		n | no) printf -v "$var" '%s' "no" && return 0 ;;
+		*) warn "Answer y or n." ;;
+		esac
+	done
+}
+
+ask_choice() {
+	local var="$1" label="$2"
+	shift 2
+	local options=("$@") i answer
+
+	if [ "$NONINTERACTIVE" = "1" ]; then
+		die "$label requires an interactive terminal."
+	fi
+
+	while true; do
+		prompt_label "$label" ""
+		for i in "${!options[@]}"; do
+			printf '  %d. %s\n' "$((i + 1))" "${options[$i]}"
+		done
+		printf '> '
+		if ! read_line answer; then
+			die "Standard input closed while waiting for an answer."
+		fi
+		if [[ "$answer" =~ ^[0-9]+$ ]] && [ "$answer" -ge 1 ] && [ "$answer" -le "${#options[@]}" ]; then
+			printf -v "$var" '%s' "$answer"
+			return 0
+		fi
+		warn "Enter a number between 1 and ${#options[@]}."
+	done
+}
+
+valid_hostname() {
+	local value="$1"
+	[ "${#value}" -le 253 ] || return 1
+	[[ "$value" =~ ^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,63}$ ]]
+}
+
+valid_email() {
+	local value="$1"
+	[ "${#value}" -le 254 ] || return 1
+	[[ "$value" =~ ^[A-Za-z0-9._%+-]+@([A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+[A-Za-z]{2,63}$ ]]
+}
+
+# Unquoted-identifier charset only: the value is spliced into PG_URL and psql args.
+valid_pg_identifier() {
+	local value="$1"
+	[ "${#value}" -le 63 ] || return 1
+	[[ "$value" =~ ^[a-z_][a-z0-9_]*$ ]]
+}
+
+valid_ipv4() {
+	local value="$1" octet
+	[[ "$value" =~ ^[0-9]{1,3}(\.[0-9]{1,3}){3}$ ]] || return 1
+	case "$value" in
+	0.* | 127.* | 255.255.255.255) return 1 ;;
+	esac
+	local IFS=.
+	for octet in $value; do
+		[ "$octet" -le 255 ] || return 1
+	done
+	return 0
+}

--- a/install/lib/prompts.sh
+++ b/install/lib/prompts.sh
@@ -157,3 +157,14 @@ valid_ipv4() {
 	done
 	return 0
 }
+
+valid_url() {
+	case "$1" in
+	https://*.* | http://*.*) return 0 ;;
+	*) return 1 ;;
+	esac
+}
+
+valid_any() {
+	[ -n "$1" ]
+}

--- a/install/templates/Caddyfile
+++ b/install/templates/Caddyfile
@@ -11,11 +11,8 @@
 	handle /dashboard* {
 		reverse_proxy dashboard:3000
 	}
-	handle /console* {
-		reverse_proxy console:3002
-	}
 	handle /docs* {
-		reverse_proxy docs:3000
+		redir https://reloop.sh{uri} 302
 	}
 	handle /preferences* {
 		reverse_proxy links:3005
@@ -60,14 +57,10 @@
 	handle /api/email* {
 		reverse_proxy email:8022
 	}
-	handle /api/credits* {
-		reverse_proxy credits:8023
-	}
-	handle /api/admin* {
-		reverse_proxy admin:8024
-	}
-	handle /api/tool* {
-		reverse_proxy tools:8026
+
+	@removed path /api/credits* /api/tool* /api/admin*
+	handle @removed {
+		respond 404
 	}
 
 	handle {

--- a/install/templates/Caddyfile
+++ b/install/templates/Caddyfile
@@ -1,0 +1,102 @@
+{
+	email {$RELOOP_ACME_EMAIL}
+	on_demand_tls {
+		ask http://domain:8011/api/domain/v1/caddy/ask
+	}
+}
+
+(reloop_app) {
+	encode zstd gzip
+
+	handle /dashboard* {
+		reverse_proxy dashboard:3000
+	}
+	handle /console* {
+		reverse_proxy console:3002
+	}
+	handle /docs* {
+		reverse_proxy docs:3000
+	}
+	handle /preferences* {
+		reverse_proxy links:3005
+	}
+	handle /redirect* {
+		reverse_proxy links:3005
+	}
+
+	handle /api/auth* {
+		reverse_proxy auth:8000
+	}
+	handle /api/domain* {
+		reverse_proxy domain:8011
+	}
+	handle /api/api-key* {
+		reverse_proxy api-key:8012
+	}
+	handle /api/webhook* {
+		reverse_proxy webhook:8013
+	}
+	handle /api/contacts* {
+		reverse_proxy contacts:8014
+	}
+	handle /api/mail* {
+		reverse_proxy mail:8015
+	}
+	handle /api/logs* {
+		reverse_proxy logs:8016
+	}
+	handle /api/workflow* {
+		reverse_proxy workflow:8017
+	}
+	handle /api/upload* {
+		reverse_proxy upload:8018
+	}
+	handle /api/template* {
+		reverse_proxy template:8019
+	}
+	handle /api/inbox* {
+		reverse_proxy inbox:8021
+	}
+	handle /api/email* {
+		reverse_proxy email:8022
+	}
+	handle /api/credits* {
+		reverse_proxy credits:8023
+	}
+	handle /api/admin* {
+		reverse_proxy admin:8024
+	}
+	handle /api/tool* {
+		reverse_proxy tools:8026
+	}
+
+	handle {
+		redir /* /dashboard 302
+	}
+}
+
+(reloop_tracking) {
+	encode zstd gzip
+
+	handle /api/mail* {
+		reverse_proxy mail:8015
+	}
+	handle {
+		reverse_proxy links:3005
+	}
+}
+
+{$RELOOP_SITE_ADDRESS} {
+	import reloop_app
+}
+
+{$RELOOP_TRACKING_SITE_ADDRESS} {
+	import reloop_tracking
+}
+
+https:// {
+	tls {
+		on_demand
+	}
+	import reloop_tracking
+}

--- a/install/templates/Caddyfile.http
+++ b/install/templates/Caddyfile.http
@@ -8,11 +8,8 @@
 	handle /dashboard* {
 		reverse_proxy dashboard:3000
 	}
-	handle /console* {
-		reverse_proxy console:3002
-	}
 	handle /docs* {
-		reverse_proxy docs:3000
+		redir https://reloop.sh{uri} 302
 	}
 	handle /preferences* {
 		reverse_proxy links:3005
@@ -57,14 +54,10 @@
 	handle /api/email* {
 		reverse_proxy email:8022
 	}
-	handle /api/credits* {
-		reverse_proxy credits:8023
-	}
-	handle /api/admin* {
-		reverse_proxy admin:8024
-	}
-	handle /api/tool* {
-		reverse_proxy tools:8026
+
+	@removed path /api/credits* /api/tool* /api/admin*
+	handle @removed {
+		respond 404
 	}
 
 	handle {

--- a/install/templates/Caddyfile.http
+++ b/install/templates/Caddyfile.http
@@ -1,0 +1,92 @@
+{
+	auto_https off
+}
+
+(reloop_app) {
+	encode zstd gzip
+
+	handle /dashboard* {
+		reverse_proxy dashboard:3000
+	}
+	handle /console* {
+		reverse_proxy console:3002
+	}
+	handle /docs* {
+		reverse_proxy docs:3000
+	}
+	handle /preferences* {
+		reverse_proxy links:3005
+	}
+	handle /redirect* {
+		reverse_proxy links:3005
+	}
+
+	handle /api/auth* {
+		reverse_proxy auth:8000
+	}
+	handle /api/domain* {
+		reverse_proxy domain:8011
+	}
+	handle /api/api-key* {
+		reverse_proxy api-key:8012
+	}
+	handle /api/webhook* {
+		reverse_proxy webhook:8013
+	}
+	handle /api/contacts* {
+		reverse_proxy contacts:8014
+	}
+	handle /api/mail* {
+		reverse_proxy mail:8015
+	}
+	handle /api/logs* {
+		reverse_proxy logs:8016
+	}
+	handle /api/workflow* {
+		reverse_proxy workflow:8017
+	}
+	handle /api/upload* {
+		reverse_proxy upload:8018
+	}
+	handle /api/template* {
+		reverse_proxy template:8019
+	}
+	handle /api/inbox* {
+		reverse_proxy inbox:8021
+	}
+	handle /api/email* {
+		reverse_proxy email:8022
+	}
+	handle /api/credits* {
+		reverse_proxy credits:8023
+	}
+	handle /api/admin* {
+		reverse_proxy admin:8024
+	}
+	handle /api/tool* {
+		reverse_proxy tools:8026
+	}
+
+	handle {
+		redir /* /dashboard 302
+	}
+}
+
+(reloop_tracking) {
+	encode zstd gzip
+
+	handle /api/mail* {
+		reverse_proxy mail:8015
+	}
+	handle {
+		reverse_proxy links:3005
+	}
+}
+
+{$RELOOP_SITE_ADDRESS} {
+	import reloop_app
+}
+
+{$RELOOP_TRACKING_SITE_ADDRESS} {
+	import reloop_tracking
+}

--- a/install/templates/docker-compose.yml
+++ b/install/templates/docker-compose.yml
@@ -1,0 +1,371 @@
+name: reloop
+
+x-logging: &logging
+  logging:
+    driver: json-file
+    options:
+      max-size: "10m"
+      max-file: "3"
+
+x-infra-ready: &infra-ready
+  postgres:
+    condition: service_healthy
+  redis:
+    condition: service_healthy
+  nats:
+    condition: service_healthy
+
+x-backend: &backend
+  restart: unless-stopped
+  env_file:
+    - .env
+  depends_on: *infra-ready
+  networks:
+    - reloop
+  <<: *logging
+
+x-frontend: &frontend
+  restart: unless-stopped
+  environment:
+    NODE_ENV: production
+  networks:
+    - reloop
+  <<: *logging
+
+services:
+  postgres:
+    image: postgres:17-alpine
+    container_name: reloop-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 30s
+    networks:
+      - reloop
+    <<: *logging
+
+  redis:
+    image: redis:7-alpine
+    container_name: reloop-redis
+    restart: unless-stopped
+    command:
+      - redis-server
+      - --requirepass
+      - ${REDIS_PASSWORD}
+      - --appendonly
+      - "yes"
+      - --dir
+      - /data
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD-SHELL", "redis-cli --no-auth-warning -a \"$$REDIS_PASSWORD\" ping | grep -q PONG"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
+    environment:
+      REDIS_PASSWORD: ${REDIS_PASSWORD}
+    networks:
+      - reloop
+    <<: *logging
+
+  nats:
+    image: nats:2.10-alpine
+    container_name: reloop-nats
+    restart: unless-stopped
+    command: ["-js", "-sd", "/data", "-m", "8222"]
+    volumes:
+      - nats-data:/data
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:8222/healthz"]
+      interval: 10s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
+    networks:
+      - reloop
+    <<: *logging
+
+  minio:
+    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
+    container_name: reloop-minio
+    restart: unless-stopped
+    command: server /data
+    environment:
+      MINIO_ROOT_USER: ${S3_ACCESS_KEY}
+      MINIO_ROOT_PASSWORD: ${S3_SECRET_KEY}
+    volumes:
+      - minio-data:/data
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:9000/minio/health/live"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+      start_period: 20s
+    networks:
+      - reloop
+    <<: *logging
+
+  proxy:
+    image: caddy:2-alpine
+    container_name: reloop-proxy
+    restart: unless-stopped
+    env_file:
+      - .env
+    ports:
+      - "80:80"
+      - "443:443"
+      - "443:443/udp"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://127.0.0.1:2019/config/"]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+      start_period: 15s
+    networks:
+      reloop:
+        aliases:
+          - ${RELOOP_DOMAIN}
+          - ${RELOOP_TRACKING_HOST}
+    <<: *logging
+
+  auth:
+    <<: *backend
+    image: reloopsh/be-auth:${RELOOP_VERSION}
+    container_name: reloop-auth
+    environment:
+      PORT: 8000
+
+  domain:
+    <<: *backend
+    image: reloopsh/be-domain:${RELOOP_VERSION}
+    container_name: reloop-domain
+    environment:
+      PORT: 8011
+
+  api-key:
+    <<: *backend
+    image: reloopsh/be-api-key:${RELOOP_VERSION}
+    container_name: reloop-api-key
+    environment:
+      PORT: 8012
+
+  webhook:
+    <<: *backend
+    image: reloopsh/be-webhook:${RELOOP_VERSION}
+    container_name: reloop-webhook
+    environment:
+      PORT: 8013
+
+  contacts:
+    <<: *backend
+    image: reloopsh/be-contacts:${RELOOP_VERSION}
+    container_name: reloop-contacts
+    environment:
+      PORT: 8014
+
+  mail:
+    <<: *backend
+    image: reloopsh/be-mail:${RELOOP_VERSION}
+    container_name: reloop-mail
+    environment:
+      PORT: 8015
+      KUMOMTA_HTTP_URL: http://smtp:8000
+
+  logs:
+    <<: *backend
+    image: reloopsh/be-logs:${RELOOP_VERSION}
+    container_name: reloop-logs
+    environment:
+      PORT: 8016
+
+  workflow:
+    <<: *backend
+    image: reloopsh/be-workflow:${RELOOP_VERSION}
+    container_name: reloop-workflow
+    environment:
+      PORT: 8017
+
+  upload:
+    <<: *backend
+    image: reloopsh/be-upload:${RELOOP_VERSION}
+    container_name: reloop-upload
+    depends_on:
+      <<: *infra-ready
+      minio:
+        condition: service_healthy
+    environment:
+      PORT: 8018
+
+  template:
+    <<: *backend
+    image: reloopsh/be-template:${RELOOP_VERSION}
+    container_name: reloop-template
+    environment:
+      PORT: 8019
+
+  inbox:
+    <<: *backend
+    image: reloopsh/be-inbox:${RELOOP_VERSION}
+    container_name: reloop-inbox
+    environment:
+      PORT: 8021
+
+  email:
+    <<: *backend
+    image: reloopsh/be-email:${RELOOP_VERSION}
+    container_name: reloop-email
+    environment:
+      PORT: 8022
+
+  credits:
+    <<: *backend
+    image: reloopsh/be-credits:${RELOOP_VERSION}
+    container_name: reloop-credits
+    environment:
+      PORT: 8023
+
+  admin:
+    <<: *backend
+    image: reloopsh/be-admin:${RELOOP_VERSION}
+    container_name: reloop-admin
+    environment:
+      PORT: 8024
+
+  tools:
+    <<: *backend
+    image: reloopsh/be-tools:${RELOOP_VERSION}
+    container_name: reloop-tools
+    environment:
+      PORT: 8026
+
+  spam:
+    image: reloopsh/be-spam:${RELOOP_VERSION}
+    container_name: reloop-spam
+    restart: unless-stopped
+    environment:
+      RSPAMD_REDIS_SERVERS: redis:6379
+      RSPAMD_REDIS_PASSWORD: ${REDIS_PASSWORD}
+    volumes:
+      - rspamd-data:/var/lib/rspamd
+    depends_on:
+      redis:
+        condition: service_healthy
+    networks:
+      - reloop
+    <<: *logging
+
+  smtp:
+    image: reloopsh/be-smtp:${RELOOP_VERSION}
+    container_name: reloop-smtp
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      HOSTNAME: ${RELOOP_DOMAIN}
+    ports:
+      - "465:465"
+      - "587:587"
+    volumes:
+      - smtp-data:/var/spool/kumomta/data
+      - smtp-meta:/var/spool/kumomta/meta
+    depends_on:
+      nats:
+        condition: service_healthy
+    networks:
+      - reloop
+    <<: *logging
+
+  inbound:
+    image: reloopsh/be-inbound:${RELOOP_VERSION}
+    container_name: reloop-inbound
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      HOSTNAME: ${RELOOP_INBOUND_HOST}
+    ports:
+      - "25:25"
+    volumes:
+      - inbound-data:/var/spool/kumomta/data
+      - inbound-meta:/var/spool/kumomta/meta
+    depends_on:
+      nats:
+        condition: service_healthy
+      spam:
+        condition: service_started
+    networks:
+      - reloop
+    <<: *logging
+
+  dashboard:
+    <<: *frontend
+    image: reloopsh/fe-dashboard:${RELOOP_VERSION}
+    container_name: reloop-dashboard
+
+  docs:
+    <<: *frontend
+    image: reloopsh/fe-docs:${RELOOP_VERSION}
+    container_name: reloop-docs
+
+  console:
+    <<: *frontend
+    image: reloopsh/fe-console:${RELOOP_VERSION}
+    container_name: reloop-console
+
+  links:
+    <<: *frontend
+    image: reloopsh/fe-links:${RELOOP_VERSION}
+    container_name: reloop-links
+    environment:
+      NODE_ENV: production
+      NEXT_PUBLIC_URL: ${TRACKING_BASE_URL}
+      INTERNAL_API_URL: http://contacts:8014/api/contacts
+      INTERNAL_MAIL_API_URL: http://mail:8015/api/mail
+
+  migrate:
+    image: reloopsh/be-auth:${RELOOP_VERSION}
+    profiles:
+      - tools
+    working_dir: /app/packages/db
+    entrypoint: ["/app/node_modules/.bin/drizzle-kit"]
+    command: ["push", "--force"]
+    env_file:
+      - .env
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - reloop
+    <<: *logging
+
+networks:
+  reloop:
+    name: reloop
+
+volumes:
+  postgres-data:
+  redis-data:
+  nats-data:
+  minio-data:
+  caddy-data:
+  caddy-config:
+  rspamd-data:
+  smtp-data:
+  smtp-meta:
+  inbound-data:
+  inbound-meta:

--- a/install/templates/docker-compose.yml
+++ b/install/templates/docker-compose.yml
@@ -96,26 +96,6 @@ services:
       - reloop
     <<: *logging
 
-  minio:
-    image: minio/minio:RELEASE.2025-04-22T22-12-26Z
-    container_name: reloop-minio
-    restart: unless-stopped
-    command: server /data
-    environment:
-      MINIO_ROOT_USER: ${S3_ACCESS_KEY}
-      MINIO_ROOT_PASSWORD: ${S3_SECRET_KEY}
-    volumes:
-      - minio-data:/data
-    healthcheck:
-      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:9000/minio/health/live"]
-      interval: 15s
-      timeout: 10s
-      retries: 10
-      start_period: 20s
-    networks:
-      - reloop
-    <<: *logging
-
   proxy:
     image: caddy:2-alpine
     container_name: reloop-proxy
@@ -204,10 +184,8 @@ services:
     <<: *backend
     image: reloopsh/be-upload:${RELOOP_VERSION}
     container_name: reloop-upload
-    depends_on:
-      <<: *infra-ready
-      minio:
-        condition: service_healthy
+    profiles:
+      - storage
     environment:
       PORT: 8018
 
@@ -231,27 +209,6 @@ services:
     container_name: reloop-email
     environment:
       PORT: 8022
-
-  credits:
-    <<: *backend
-    image: reloopsh/be-credits:${RELOOP_VERSION}
-    container_name: reloop-credits
-    environment:
-      PORT: 8023
-
-  admin:
-    <<: *backend
-    image: reloopsh/be-admin:${RELOOP_VERSION}
-    container_name: reloop-admin
-    environment:
-      PORT: 8024
-
-  tools:
-    <<: *backend
-    image: reloopsh/be-tools:${RELOOP_VERSION}
-    container_name: reloop-tools
-    environment:
-      PORT: 8026
 
   spam:
     image: reloopsh/be-spam:${RELOOP_VERSION}
@@ -317,16 +274,6 @@ services:
     image: reloopsh/fe-dashboard:${RELOOP_VERSION}
     container_name: reloop-dashboard
 
-  docs:
-    <<: *frontend
-    image: reloopsh/fe-docs:${RELOOP_VERSION}
-    container_name: reloop-docs
-
-  console:
-    <<: *frontend
-    image: reloopsh/fe-console:${RELOOP_VERSION}
-    container_name: reloop-console
-
   links:
     <<: *frontend
     image: reloopsh/fe-links:${RELOOP_VERSION}
@@ -361,7 +308,6 @@ volumes:
   postgres-data:
   redis-data:
   nats-data:
-  minio-data:
   caddy-data:
   caddy-config:
   rspamd-data:

--- a/install/templates/reloop
+++ b/install/templates/reloop
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+INSTALL_DIR="${RELOOP_INSTALL_DIR:-/opt/reloop}"
+
+if [ ! -f "$INSTALL_DIR/docker-compose.yml" ]; then
+	printf 'No Reloop installation found at %s\n' "$INSTALL_DIR" >&2
+	exit 1
+fi
+
+if [ "$(id -u)" -ne 0 ]; then
+	printf 'reloop must run as root (the configuration is root-only).\n' >&2
+	exit 1
+fi
+
+compose() {
+	docker compose --project-directory "$INSTALL_DIR" \
+		-f "$INSTALL_DIR/docker-compose.yml" "$@"
+}
+
+backup_database() {
+	local dir="$INSTALL_DIR/backups" file user db
+	user="$(sed -n 's/^POSTGRES_USER=//p' "$INSTALL_DIR/.env" | tail -1)"
+	db="$(sed -n 's/^POSTGRES_DB=//p' "$INSTALL_DIR/.env" | tail -1)"
+	[ -n "$user" ] && [ -n "$db" ] || return 0
+	install -d -m 0700 -o root -g root "$dir"
+	file="$dir/pre-migration-$(date +%Y%m%d%H%M%S).sql.gz"
+	if compose exec -T postgres pg_dump -U "$user" -d "$db" | gzip >"$file"; then
+		chmod 600 "$file"
+		printf 'Database backed up to %s\n' "$file"
+	else
+		rm -f "$file"
+		printf 'Database backup failed; refusing to change the schema.\n' >&2
+		exit 1
+	fi
+}
+
+usage() {
+	cat <<'EOF'
+Usage: reloop <command> [service...]
+
+  status            Show every container and its health
+  logs [service]    Follow logs (all services, or one)
+  start             Start the stack
+  stop              Stop the stack (data is kept)
+  restart [service] Restart the stack or one service
+  update            Pull the configured image version and redeploy
+  migrate           Re-apply the database schema
+  backup            Dump the database to <install>/backups
+  config            Print the installation paths
+EOF
+}
+
+cmd="${1:-}"
+[ "$#" -gt 0 ] && shift || true
+
+case "$cmd" in
+status | ps)
+	compose ps
+	;;
+logs)
+	compose logs -f --tail 100 "$@"
+	;;
+start | up)
+	compose up -d
+	;;
+stop | down)
+	compose stop
+	;;
+restart)
+	compose restart "$@"
+	;;
+update)
+	compose pull
+	backup_database
+	compose --profile tools run --rm migrate
+	compose up -d --remove-orphans
+	compose ps
+	;;
+migrate)
+	backup_database
+	compose --profile tools run --rm migrate
+	;;
+backup)
+	backup_database
+	;;
+config)
+	printf 'Install directory: %s\n' "$INSTALL_DIR"
+	printf 'Configuration:     %s/.env\n' "$INSTALL_DIR"
+	printf 'Compose file:      %s/docker-compose.yml\n' "$INSTALL_DIR"
+	printf 'Reverse proxy:     %s/Caddyfile\n' "$INSTALL_DIR"
+	printf 'Backups:           %s/backups\n' "$INSTALL_DIR"
+	;;
+"" | -h | --help | help)
+	usage
+	;;
+*)
+	printf 'Unknown command: %s\n\n' "$cmd" >&2
+	usage >&2
+	exit 1
+	;;
+esac


### PR DESCRIPTION
Adds a one-command self-host installer for a fresh VPS, in the shape people expect from Coolify:

```bash
curl -fsSL https://reloop.sh/install.sh | sudo bash
```

It targets Ubuntu 22.04/24.04 and Debian 12/13 on x86_64, installs to `/opt/reloop`, and pulls the published `reloopsh/*` images rather than building 20 GB of images on a 2-vCPU box.

## What it does

1. Preflight — OS, architecture, memory, disk, required binaries, outbound network, and port conflicts on 80/443/25/465/587 with the owning process named.
2. Installs Docker Engine from the official apt repository if it is missing, or validates the existing version.
3. Prompts for the domain, admin email, database name and user, HTTPS, and object storage, with validation and re-prompting. Every prompt has an environment variable for unattended installs.
4. Generates every secret from `/dev/urandom` and writes `/opt/reloop/.env` at mode `0600`.
5. Writes the production Compose stack and Caddyfile, starts PostgreSQL/Redis/NATS, applies the schema with `drizzle-kit push` (taking a `pg_dump` first if the database already has tables), then brings up the application.
6. Verifies the deployment with real HTTP health probes through the proxy, checks the mail transports, and looks for restart loops. On failure it prints `compose ps` and the last 30 log lines of whatever is broken.
7. Prints the DNS records for the installation, kept separate from the per-domain SPF/DKIM/DMARC/MX records that Reloop generates in the dashboard.

Because a fresh install cannot email a one-time code until a sending domain is verified, the installer generates a `DEFAULT_OTP` bootstrap code and prints it once.

## Self-host is not the hosted platform

The stack is deliberately smaller than the full platform — 20 containers instead of 27. Left out:

| Service | Reason |
| :--- | :--- |
| `fe-web`, `fe-docs` | Marketing site and public documentation. `/docs` redirects to reloop.sh. |
| `be-credits` | Billing and quota metering. `be-mail` keeps its own in-process gate, which never trips without the metering subscriber, so self-hosted sending is unmetered. |
| `be-tools` | Public email-validation tools. |
| `be-admin`, `fe-console` | Operator tooling for the hosted platform. |
| MinIO | Replaced by any S3-compatible provider, configured at install time. |

`be-upload` sits behind a `storage` Compose profile and is deployed only when object storage is configured. `/api/credits*`, `/api/tool*` and `/api/admin*` return 404 rather than falling through to the dashboard redirect, so the client-side panels that call them fail cleanly.

That takes the footprint from 27.39 GB of images and 2.65 GB of container memory down to 19.34 GB and 2.05 GB, and the disk floor from 45 GB to 35 GB.

## Security

- Only Caddy (80, 443) and the two mail transports (25, 465/587) publish host ports. PostgreSQL, Redis, NATS and the backend services stay on the internal Docker network.
- No dev artefacts: no Mailpit, no exposed database ports, no default credentials.
- `.env` is `0600` and root-owned; secrets come from `/dev/urandom` and are never regenerated on a re-run.
- `set -Eeuo pipefail` throughout, no `eval`, and asset downloads are pinned to https.

## Layout

```
install/
├── install.sh              entry point
├── lib/                    common, prompts, preflight, docker, config, deploy, health, dns
└── templates/              docker-compose.yml, Caddyfile, Caddyfile.http, reloop CLI
```

A `reloop` management command is installed alongside the stack: `status`, `logs`, `start`, `stop`, `restart`, `update`, `migrate`, `backup`, `config`. `update` and `migrate` take a database dump first and keep the last five.

## Testing

Verified end to end on a disposable QEMU VM — pristine Ubuntu 24.04 cloud image, no Docker, no image cache, 40 GB disk:

- Fresh install from cold: preflight, Docker install, prompts, 20 image pulls, migrations, deploy, health checks. All probes green — 11 backend APIs, both frontends, all three mail transports, no restart loops.
- Re-run detection with all three paths (abort, reconfigure, continue), confirming secrets and data survive.
- Docker already installed, invalid domain input, all-defaults, port conflict, deliberately broken service, persistence across `restart`, and persistence across a full VM reboot.
- Routing checked against the running Caddy admin API rather than the source file, confirming the removed upstreams are absent and the 404 and redirect handlers are live.
- Migrations verified idempotent — 50 tables, re-runs cleanly.

Real public DNS and Let's Encrypt issuance are not covered: the test VM is behind NAT with no controlled domain. Caddy is confirmed to make genuine ACME requests and retry on its own once records resolve.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added one-command self-hosting deployment for supported Ubuntu and Debian servers.
  * Installer configures Docker, generates secrets, deploys services, verifies health, and provides DNS and sign-in guidance.
  * Added support for HTTPS, database configuration, optional S3-compatible storage, unattended installation, backups, updates, and migrations.
* **Documentation**
  * Added comprehensive VPS deployment guidance, prerequisites, disk-space requirements, deployed-service details, DNS setup, and safe reinstallation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a root-run VPS installer, a reduced production Compose topology, deployment health checks, migration and backup tooling, DNS guidance, and a `reloop` management command.

- Generates persistent production configuration and deploys PostgreSQL, Redis, NATS, Caddy, product services, and mail transports.
- Adds optional profile-gated S3 uploads and self-host documentation.
- Introduces a bootstrap authentication flow that currently exposes a universal fixed OTP and a storage enablement command that does not create the upload service.

<h3>Confidence Score: 2/5</h3>

The PR should not merge until the universal bootstrap OTP and broken storage activation workflow are fixed.

The installer exposes one fixed six-digit credential for authentication under arbitrary email addresses and can recreate it on reruns, while the documented storage workflow leaves the profile-gated upload service unstarted.

**Files Needing Attention:** install/lib/config.sh, install/templates/reloop, install/install.sh, apps/frontend/docs/content/docs/self-host/vps.mdx

<details open><summary><h3>Security Review</h3></summary>

The generated `DEFAULT_OTP` is accepted for every email while signup is enabled, making the bootstrap value a universal authentication credential. The installer also executes unverified components fetched from a mutable branch as root.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| install/install.sh | Adds the privileged installer orchestration, but downloads and sources executable assets from a mutable branch without integrity verification. |
| install/lib/config.sh | Generates and preserves deployment configuration, but installs a global fixed OTP with public signup enabled and restores it on reruns. |
| install/templates/docker-compose.yml | Defines the reduced production service topology, persistent volumes, mail ports, migration helper, and profile-gated upload service. |
| install/templates/reloop | Adds lifecycle and backup commands, but restart cannot activate a newly enabled Compose profile. |
| install/lib/deploy.sh | Pulls images, starts dependencies, backs up populated databases, applies the schema, and launches application services. |
| install/lib/health.sh | Adds internal HTTP probes, transport-state checks, restart-loop detection, and diagnostic output. |
| install/templates/Caddyfile | Routes the self-hosted application and tracking surfaces while explicitly returning 404 for omitted hosted APIs. |
| apps/frontend/docs/content/docs/self-host/vps.mdx | Documents the installation and operations workflow, including the ineffective `reloop restart` instruction for enabling storage. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Root installer] --> B[Preflight and Docker setup]
  A --> C[Generate .env and stack files]
  C --> D[PostgreSQL, Redis, NATS]
  D --> E[Schema synchronization]
  E --> F[Backend services]
  E --> G[Dashboard and links]
  E --> H[SMTP, inbound, spam]
  C -->|storage profile| I[Upload service and external S3]
  F --> J[Caddy]
  G --> J
  J --> K[HTTP and HTTPS clients]
  H --> L[Internet mail traffic]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["feat: update self-hosting requirements a..."](https://github.com/reloop-labs/reloop/commit/e7b02f2e3495beffd8368be1ba11322e63eb811a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57579238)</sub>

> Greptile also left **3 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Platform foundations](https://app.greptile.com/rellop/-/custom-context/knowledge-base/reloop-labs/reloop/-/docs/platform-foundations.md)
- Knowledge Base — [SMTP edge and policy](https://app.greptile.com/rellop/-/custom-context/knowledge-base/reloop-labs/reloop/-/docs/smtp-edge-and-policy.md)
- Knowledge Base — [Account operations and utilities](https://app.greptile.com/rellop/-/custom-context/knowledge-base/reloop-labs/reloop/-/docs/account-operations-and-utilities.md)
</details>


<!-- /greptile_comment -->