### PR TITLE
fix: navigate Settings to usage and Back to app to the dashboard home

### DIFF
--- a/apps/frontend/dashboard/src/features/dashboard/sidebar/main-sidebar.tsx
+++ b/apps/frontend/dashboard/src/features/dashboard/sidebar/main-sidebar.tsx
@@ -18,30 +18,9 @@ export function MainSidebar() {
 	const pathname = usePathname();
 	const pathWithoutSlug = pathname.replace(/^\/dashboard/, "") || "/";
 	const isSettingsRoute = pathWithoutSlug.startsWith("/settings");
-	const [settingsPeek, setSettingsPeek] = useState(false);
-	const [settingsNavDismissed, setSettingsNavDismissed] = useState(false);
-	const showSettingsNav = settingsNavDismissed
-		? false
-		: settingsPeek || isSettingsRoute;
 	const isTemplateEditor =
 		Boolean(pathname.match(/\/templates\/[^/]+/)) ||
 		Boolean(pathname.match(/\/campaigns\/[^/]+\/edit/));
-
-	const openSettingsNav = () => {
-		setSettingsNavDismissed(false);
-		setSettingsPeek(true);
-	};
-	const closeSettingsNav = () => {
-		setSettingsPeek(false);
-		setSettingsNavDismissed(true);
-	};
-
-	useEffect(() => {
-		if (!isSettingsRoute) {
-			setSettingsNavDismissed(false);
-			setSettingsPeek(false);
-		}
-	}, [isSettingsRoute]);
 	const shouldReduceMotion = useReducedMotion();
 
 	useHotkeys("meta+b", (e) => {
@@ -101,7 +80,7 @@ export function MainSidebar() {
 
 					<div className="relative flex-1 overflow-hidden px-2 py-2">
 						<AnimatePresence mode="popLayout" initial={false}>
-							{showSettingsNav ? (
+							{isSettingsRoute ? (
 								<motion.div
 									key="settings"
 									initial={{
@@ -120,10 +99,7 @@ export function MainSidebar() {
 									transition={{ duration: 0.28, ease: [0.32, 0.72, 0, 1] }}
 									className="absolute inset-0 overflow-y-auto overflow-x-hidden px-2 py-2"
 								>
-									<SettingsSidebarItems
-										isCollapsed={false}
-										onCloseSettings={closeSettingsNav}
-									/>
+									<SettingsSidebarItems isCollapsed={false} />
 								</motion.div>
 							) : (
 								<motion.div
@@ -144,10 +120,7 @@ export function MainSidebar() {
 									transition={{ duration: 0.28, ease: [0.32, 0.72, 0, 1] }}
 									className="absolute inset-0 overflow-y-auto overflow-x-hidden px-2 py-2"
 								>
-									<SidebarItems
-										isCollapsed={false}
-										onOpenSettings={openSettingsNav}
-									/>
+									<SidebarItems isCollapsed={false} />
 								</motion.div>
 							)}
 						</AnimatePresence>
@@ -223,7 +196,7 @@ export function MainSidebar() {
 						)}
 					>
 						<AnimatePresence mode="popLayout" initial={false}>
-							{showSettingsNav ? (
+							{isSettingsRoute ? (
 								<motion.div
 									key="settings"
 									initial={{
@@ -250,7 +223,6 @@ export function MainSidebar() {
 								>
 									<SettingsSidebarItems
 										isCollapsed={!isTemplateEditor && isCollapsed}
-										onCloseSettings={closeSettingsNav}
 									/>
 								</motion.div>
 							) : (
@@ -280,7 +252,6 @@ export function MainSidebar() {
 								>
 									<SidebarItems
 										isCollapsed={!isTemplateEditor && isCollapsed}
-										onOpenSettings={openSettingsNav}
 									/>
 								</motion.div>
 							)}

--- a/apps/frontend/dashboard/src/features/dashboard/sidebar/settings-sidebar-items.tsx
+++ b/apps/frontend/dashboard/src/features/dashboard/sidebar/settings-sidebar-items.tsx
@@ -7,22 +7,20 @@ import { AnimatedHoverBackground } from "#/features/onboarding/animated-hover-ba
 import { useOrgPermissions } from "#/features/settings/use-org-permissions";
 import { filterSettingsNavigation, settingsNavigation } from "../navigation";
 import { SidebarNavIcon } from "./sidebar-nav-icon";
-import { SidebarNavButton, SidebarNavLink } from "./sidebar-nav-link";
+import { SidebarNavLink } from "./sidebar-nav-link";
 import { useSidebarHoverBox } from "./use-sidebar-hover-box";
 
 export function SettingsSidebarItems({
 	isCollapsed = false,
-	onCloseSettings,
 }: {
 	isCollapsed?: boolean;
-	onCloseSettings?: () => void;
 }) {
 	const [hoveredEl, setHoveredEl] = useState<HTMLElement | undefined>(
 		undefined,
 	);
 	const [containerEl, setContainerEl] = useState<HTMLDivElement | null>(null);
 
-	const backNavRef = useRef<HTMLButtonElement>(null);
+	const backNavRef = useRef<HTMLAnchorElement>(null);
 	const itemRefs = useRef<HTMLAnchorElement[]>([]);
 
 	const pathname = usePathname();
@@ -68,11 +66,11 @@ export function SettingsSidebarItems({
 			)}
 			onPointerLeave={() => setHoveredEl(undefined)}
 		>
-			{/* Back to main sidebar — does not change the page */}
-			<SidebarNavButton
+			{/* Leave settings and return to the app home (Emails). */}
+			<SidebarNavLink
+				href="/"
 				ref={backNavRef}
 				onPointerEnter={() => setHoveredEl(backNavRef.current ?? undefined)}
-				onClick={() => onCloseSettings?.()}
 				className={cn(
 					"relative z-10 mb-4 flex h-8 items-center rounded-lg transition-all",
 					isCollapsed
@@ -97,7 +95,7 @@ export function SettingsSidebarItems({
 						</span>
 					)}
 				</span>
-			</SidebarNavButton>
+			</SidebarNavLink>
 
 			{filteredSettingsNavigation.map((section, sectionIdx) => (
 				<div

--- a/apps/frontend/dashboard/src/features/dashboard/sidebar/sidebar-items.tsx
+++ b/apps/frontend/dashboard/src/features/dashboard/sidebar/sidebar-items.tsx
@@ -158,67 +158,74 @@ export function SidebarItems({
 									{section}
 								</div>
 							))}
-						<SidebarNavLink
-							href={path}
-							ref={(el) => {
-								if (el) mainNavRefs.current[index] = el;
-							}}
-							onPointerEnter={() => setHoveredEl(mainNavRefs.current[index])}
+						<div
 							className={cn(
-								"relative z-10 flex h-8 items-center rounded-lg transition-all",
-								isCollapsed
-									? "h-8 w-8 justify-center px-0"
-									: cn(
-											"w-full gap-2.5 px-2.5",
-											hasSubNav ? "justify-between" : "justify-start",
-										),
+								"flex items-center",
+								isCollapsed ? "justify-center" : "w-full",
 							)}
-							title={
-								isCollapsed
-									? shortcut
-										? `${label} (${shortcut.label})`
-										: label
-									: undefined
-							}
 						>
-							<span
+							<SidebarNavLink
+								href={path}
+								ref={(el) => {
+									if (el) mainNavRefs.current[index] = el;
+								}}
+								onPointerEnter={() => setHoveredEl(mainNavRefs.current[index])}
 								className={cn(
-									"flex min-w-0 items-center",
+									"relative z-10 flex h-8 items-center rounded-lg transition-all",
 									isCollapsed
-										? "justify-center"
-										: "flex-1 justify-between gap-2.5",
+										? "h-8 w-8 justify-center px-0"
+										: cn(
+												"min-w-0 flex-1 justify-start gap-2.5",
+												hasSubNav ? "py-0 pr-1 pl-2.5" : "px-2.5",
+											),
 								)}
+								title={
+									isCollapsed
+										? shortcut
+											? `${label} (${shortcut.label})`
+											: label
+										: undefined
+								}
 							>
 								<span
 									className={cn(
 										"flex min-w-0 items-center",
-										!isCollapsed && "gap-2.5",
+										isCollapsed
+											? "justify-center"
+											: "flex-1 justify-between gap-2.5",
 									)}
 								>
-									<SidebarNavIcon
-										name={iconName}
-										isSpecial={isSpecial}
-										isActive={activeMainIndex === index}
-									/>
-									{!isCollapsed && (
-										<span
-											className={cn(
-												"truncate font-medium text-[13px] transition-colors",
-												isSpecial
-													? "bg-gradient-to-r from-[#A855F7] to-[#EC4899] bg-clip-text text-transparent"
-													: activeMainIndex === index
-														? "text-text-strong-950"
-														: "text-text-sub-600 group-hover:text-text-strong-950",
-											)}
-										>
-											{label}
-										</span>
+									<span
+										className={cn(
+											"flex min-w-0 items-center",
+											!isCollapsed && "gap-2.5",
+										)}
+									>
+										<SidebarNavIcon
+											name={iconName}
+											isSpecial={isSpecial}
+											isActive={activeMainIndex === index}
+										/>
+										{!isCollapsed && (
+											<span
+												className={cn(
+													"truncate font-medium text-[13px] transition-colors",
+													isSpecial
+														? "bg-gradient-to-r from-[#A855F7] to-[#EC4899] bg-clip-text text-transparent"
+														: activeMainIndex === index
+															? "text-text-strong-950"
+															: "text-text-sub-600 group-hover:text-text-strong-950",
+												)}
+											>
+												{label}
+											</span>
+										)}
+									</span>
+									{!isCollapsed && shortcut && (
+										<ShortcutHint>{shortcut.label}</ShortcutHint>
 									)}
 								</span>
-								{!isCollapsed && shortcut && (
-									<ShortcutHint>{shortcut.label}</ShortcutHint>
-								)}
-							</span>
+							</SidebarNavLink>
 
 							{hasSubNav && !isCollapsed && (
 								<button
@@ -228,9 +235,7 @@ export function SidebarItems({
 									aria-label={
 										isExpanded ? `Collapse ${label}` : `Expand ${label}`
 									}
-									onClick={(e) => {
-										e.preventDefault();
-										e.stopPropagation();
+									onClick={() => {
 										setExpandedItems((prev) => {
 											const willOpen = !prev[path];
 											if (willOpen) {
@@ -246,7 +251,7 @@ export function SidebarItems({
 											return { ...prev, [path]: willOpen };
 										});
 									}}
-									className="flex h-5 w-5 items-center justify-center rounded-md transition-colors hover:bg-bg-weak-50"
+									className="relative z-10 mr-2.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-md transition-colors hover:bg-bg-weak-50"
 								>
 									<Icon
 										name="chevron-right"
@@ -257,7 +262,7 @@ export function SidebarItems({
 									/>
 								</button>
 							)}
-						</SidebarNavLink>
+						</div>
 
 						{hasSubNav && !isCollapsed && (
 							<AnimatePresence initial={false}>

--- a/apps/frontend/dashboard/src/features/dashboard/sidebar/sidebar-items.tsx
+++ b/apps/frontend/dashboard/src/features/dashboard/sidebar/sidebar-items.tsx
@@ -7,15 +7,13 @@ import { ShortcutHint } from "#/features/dashboard/keyboard-shortcuts-reveal";
 import { AnimatedHoverBackground } from "#/features/onboarding/animated-hover-background";
 import { mainNavigation } from "../navigation";
 import { SidebarNavIcon } from "./sidebar-nav-icon";
-import { SidebarNavButton, SidebarNavLink } from "./sidebar-nav-link";
+import { SidebarNavLink } from "./sidebar-nav-link";
 import { useSidebarHoverBox } from "./use-sidebar-hover-box";
 
 export function SidebarItems({
 	isCollapsed = false,
-	onOpenSettings,
 }: {
 	isCollapsed?: boolean;
-	onOpenSettings?: () => void;
 }) {
 	const [hoveredEl, setHoveredEl] = useState<HTMLElement | undefined>(
 		undefined,
@@ -160,168 +158,106 @@ export function SidebarItems({
 									{section}
 								</div>
 							))}
-						{path === "/settings" ? (
-							<SidebarNavButton
-								ref={(el) => {
-									if (el) mainNavRefs.current[index] = el;
-								}}
-								onPointerEnter={() => setHoveredEl(mainNavRefs.current[index])}
-								onClick={() => onOpenSettings?.()}
+						<SidebarNavLink
+							href={path}
+							ref={(el) => {
+								if (el) mainNavRefs.current[index] = el;
+							}}
+							onPointerEnter={() => setHoveredEl(mainNavRefs.current[index])}
+							className={cn(
+								"relative z-10 flex h-8 items-center rounded-lg transition-all",
+								isCollapsed
+									? "h-8 w-8 justify-center px-0"
+									: cn(
+											"w-full gap-2.5 px-2.5",
+											hasSubNav ? "justify-between" : "justify-start",
+										),
+							)}
+							title={
+								isCollapsed
+									? shortcut
+										? `${label} (${shortcut.label})`
+										: label
+									: undefined
+							}
+						>
+							<span
 								className={cn(
-									"relative z-10 flex h-8 items-center rounded-lg transition-all",
+									"flex min-w-0 items-center",
 									isCollapsed
-										? "h-8 w-8 justify-center px-0"
-										: "w-full justify-start gap-2.5 px-2.5",
+										? "justify-center"
+										: "flex-1 justify-between gap-2.5",
 								)}
-								title={
-									isCollapsed
-										? shortcut
-											? `${label} (${shortcut.label})`
-											: label
-										: undefined
-								}
 							>
 								<span
 									className={cn(
 										"flex min-w-0 items-center",
-										isCollapsed
-											? "justify-center"
-											: "flex-1 justify-between gap-2.5",
+										!isCollapsed && "gap-2.5",
 									)}
 								>
-									<span
-										className={cn(
-											"flex min-w-0 items-center",
-											!isCollapsed && "gap-2.5",
-										)}
-									>
-										<SidebarNavIcon
-											name={iconName}
-											isSpecial={isSpecial}
-											isActive={activeMainIndex === index}
-										/>
-										{!isCollapsed && (
-											<span
-												className={cn(
-													"truncate font-medium text-[13px] transition-colors",
-													isSpecial
-														? "bg-gradient-to-r from-[#A855F7] to-[#EC4899] bg-clip-text text-transparent"
-														: activeMainIndex === index
-															? "text-text-strong-950"
-															: "text-text-sub-600 group-hover:text-text-strong-950",
-												)}
-											>
-												{label}
-											</span>
-										)}
-									</span>
-									{!isCollapsed && shortcut && (
-										<ShortcutHint>{shortcut.label}</ShortcutHint>
-									)}
-								</span>
-							</SidebarNavButton>
-						) : (
-							<SidebarNavLink
-								href={path}
-								ref={(el) => {
-									if (el) mainNavRefs.current[index] = el;
-								}}
-								onPointerEnter={() => setHoveredEl(mainNavRefs.current[index])}
-								className={cn(
-									"relative z-10 flex h-8 items-center rounded-lg transition-all",
-									isCollapsed
-										? "h-8 w-8 justify-center px-0"
-										: cn(
-												"w-full gap-2.5 px-2.5",
-												hasSubNav ? "justify-between" : "justify-start",
-											),
-								)}
-								title={
-									isCollapsed
-										? shortcut
-											? `${label} (${shortcut.label})`
-											: label
-										: undefined
-								}
-							>
-								<span
-									className={cn(
-										"flex min-w-0 items-center",
-										isCollapsed
-											? "justify-center"
-											: "flex-1 justify-between gap-2.5",
-									)}
-								>
-									<span
-										className={cn(
-											"flex min-w-0 items-center",
-											!isCollapsed && "gap-2.5",
-										)}
-									>
-										<SidebarNavIcon
-											name={iconName}
-											isSpecial={isSpecial}
-											isActive={activeMainIndex === index}
-										/>
-										{!isCollapsed && (
-											<span
-												className={cn(
-													"truncate font-medium text-[13px] transition-colors",
-													isSpecial
-														? "bg-gradient-to-r from-[#A855F7] to-[#EC4899] bg-clip-text text-transparent"
-														: activeMainIndex === index
-															? "text-text-strong-950"
-															: "text-text-sub-600 group-hover:text-text-strong-950",
-												)}
-											>
-												{label}
-											</span>
-										)}
-									</span>
-									{!isCollapsed && shortcut && (
-										<ShortcutHint>{shortcut.label}</ShortcutHint>
-									)}
-								</span>
-
-								{hasSubNav && !isCollapsed && (
-									<button
-										type="button"
-										tabIndex={0}
-										aria-expanded={isExpanded}
-										aria-label={
-											isExpanded ? `Collapse ${label}` : `Expand ${label}`
-										}
-										onClick={(e) => {
-											e.preventDefault();
-											e.stopPropagation();
-											setExpandedItems((prev) => {
-												const willOpen = !prev[path];
-												if (willOpen) {
-													userCollapsedRef.current.delete(path);
-												} else {
-													const isActiveSection = items?.some((sub) =>
-														pathWithoutSlug.startsWith(sub.path),
-													);
-													if (isActiveSection) {
-														userCollapsedRef.current.add(path);
-													}
-												}
-												return { ...prev, [path]: willOpen };
-											});
-										}}
-										className="flex h-5 w-5 items-center justify-center rounded-md transition-colors hover:bg-bg-weak-50"
-									>
-										<Icon
-											name="chevron-right"
+									<SidebarNavIcon
+										name={iconName}
+										isSpecial={isSpecial}
+										isActive={activeMainIndex === index}
+									/>
+									{!isCollapsed && (
+										<span
 											className={cn(
-												"h-3 w-3 shrink-0 text-text-sub-600 opacity-60 transition-transform duration-200",
-												isExpanded && "rotate-90",
+												"truncate font-medium text-[13px] transition-colors",
+												isSpecial
+													? "bg-gradient-to-r from-[#A855F7] to-[#EC4899] bg-clip-text text-transparent"
+													: activeMainIndex === index
+														? "text-text-strong-950"
+														: "text-text-sub-600 group-hover:text-text-strong-950",
 											)}
-										/>
-									</button>
+										>
+											{label}
+										</span>
+									)}
+								</span>
+								{!isCollapsed && shortcut && (
+									<ShortcutHint>{shortcut.label}</ShortcutHint>
 								)}
-							</SidebarNavLink>
-						)}
+							</span>
+
+							{hasSubNav && !isCollapsed && (
+								<button
+									type="button"
+									tabIndex={0}
+									aria-expanded={isExpanded}
+									aria-label={
+										isExpanded ? `Collapse ${label}` : `Expand ${label}`
+									}
+									onClick={(e) => {
+										e.preventDefault();
+										e.stopPropagation();
+										setExpandedItems((prev) => {
+											const willOpen = !prev[path];
+											if (willOpen) {
+												userCollapsedRef.current.delete(path);
+											} else {
+												const isActiveSection = items?.some((sub) =>
+													pathWithoutSlug.startsWith(sub.path),
+												);
+												if (isActiveSection) {
+													userCollapsedRef.current.add(path);
+												}
+											}
+											return { ...prev, [path]: willOpen };
+										});
+									}}
+									className="flex h-5 w-5 items-center justify-center rounded-md transition-colors hover:bg-bg-weak-50"
+								>
+									<Icon
+										name="chevron-right"
+										className={cn(
+											"h-3 w-3 shrink-0 text-text-sub-600 opacity-60 transition-transform duration-200",
+											isExpanded && "rotate-90",
+										)}
+									/>
+								</button>
+							)}
+						</SidebarNavLink>
 
 						{hasSubNav && !isCollapsed && (
 							<AnimatePresence initial={false}>


### PR DESCRIPTION
## Summary
- Desktop sidebar **Settings** and **Back to app** previously only swapped nav chrome, so the URL stayed on whatever page the user was already on.
- Settings now navigates to `/settings` (Usage). Members without billing access still get redirected to profile from that page.
- Back to app now navigates to `/` (Emails / dashboard home). Sidebar mode follows the route instead of a peek-only toggle.

## Test plan
- [x] Sign in and open any app route (Inbox, Contacts, Campaigns, etc.).
- [x] Click **Settings** in the sidebar: URL should become `/dashboard/settings` and Usage should render (or Profile for members).
- [x] From Usage, Billing, Profile, or any other settings page, click **Back to app**: URL should become `/dashboard` and Emails should render.
- [x] Confirm sidebar animation still switches between app nav and settings nav with the route change.

## Issue
#114 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Navigation**
  - Simplified sidebar behavior by displaying the appropriate main or settings navigation based on the current route.
  - Added direct “Back to app” navigation from the settings sidebar.
  - Unified navigation item behavior, including consistent expand/collapse controls for settings.
  - Standardized settings navigation styling with the rest of the sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes the desktop sidebar follow the current route instead of maintaining a separate settings-preview state.
- Settings now navigates to the Usage entry route, where existing permission handling can redirect members to Profile.
- Back to app now navigates to the dashboard Emails home.
- The Contacts expansion control is separated from its navigation link, avoiding nested interactive elements.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the updated links and route-driven sidebar state align with the dashboard routing configuration.

No actionable correctness, security, or repository-rule violations remain. The root link resolves through Next.js's configured dashboard base path, settings routes select the settings sidebar, and the revised expansion control preserves navigation and expansion as separate actions.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/frontend/dashboard/src/features/dashboard/sidebar/main-sidebar.tsx | Removes sidebar-only settings state and derives the displayed navigation directly from the current route. |
| apps/frontend/dashboard/src/features/dashboard/sidebar/settings-sidebar-items.tsx | Converts Back to app into a route link targeting the dashboard Emails home. |
| apps/frontend/dashboard/src/features/dashboard/sidebar/sidebar-items.tsx | Makes Settings use standard link behavior and separates nested-navigation expansion controls from their destination links. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: stop nesting the sidebar expand con..."](https://github.com/reloop-labs/reloop/commit/a337169bc50e08cae7812132868aab2c0d882ac5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61221306)</sub>

**Context used:**

- Knowledge Base — [Product interfaces](https://app.greptile.com/rellop/-/custom-context/knowledge-base/reloop-labs/reloop/-/docs/product-interfaces.md)
- Knowledge Base — [Dashboard and console applications](https://app.greptile.com/rellop/-/custom-context/knowledge-base/reloop-labs/reloop/-/docs/dashboard-and-console-applications.md)

<!-- /greptile_comment -->