### PR TITLE
fix: add container health check so Coolify can do rolling updates

### DIFF
--- a/apps/frontend/console/Dockerfile
+++ b/apps/frontend/console/Dockerfile
@@ -39,4 +39,12 @@ RUN rm -rf apps
 
 EXPOSE 3002
 
+# Coolify needs a passing health check to do a rolling update (new container
+# becomes healthy before the old one is stopped). The Coolify UI check needs
+# curl/wget, which this alpine image does not ship, so define the check here
+# with bun instead. A Dockerfile HEALTHCHECK takes precedence over the UI one.
+# Next applies the configured base path to the health route.
+HEALTHCHECK --interval=5s --timeout=3s --start-period=20s --retries=6 \
+	CMD bun -e "fetch('http://127.0.0.1:'+(process.env.PORT||3002)+'/console/healthz').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+
 CMD ["bun", "run", "server.js"]

--- a/apps/frontend/console/src/app/healthz/route.ts
+++ b/apps/frontend/console/src/app/healthz/route.ts
@@ -1,0 +1,12 @@
+/**
+ * Liveness/readiness probe used by the Dockerfile HEALTHCHECK and Coolify.
+ * Coolify only performs a rolling update (start new container → wait for
+ * healthy → stop old container) when the health check passes, so this must
+ * stay cheap, dependency-free and always return 200 once the server is up.
+ */
+export function GET() {
+	return Response.json(
+		{ status: "ok" },
+		{ headers: { "Cache-Control": "no-store" } },
+	);
+}

--- a/apps/frontend/docs/Dockerfile
+++ b/apps/frontend/docs/Dockerfile
@@ -45,4 +45,12 @@ RUN rm -rf apps && \
 
 EXPOSE 3000
 
+# Coolify needs a passing health check to do a rolling update (new container
+# becomes healthy before the old one is stopped). The Coolify UI check needs
+# curl/wget, which this alpine image does not ship, so define the check here
+# with bun instead. A Dockerfile HEALTHCHECK takes precedence over the UI one.
+# Next applies the configured base path to the health route.
+HEALTHCHECK --interval=5s --timeout=3s --start-period=20s --retries=6 \
+	CMD bun -e "fetch('http://127.0.0.1:'+(process.env.PORT||3000)+'/docs/healthz').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+
 CMD ["bun", "run", "server.js"]

--- a/apps/frontend/docs/next.config.ts
+++ b/apps/frontend/docs/next.config.ts
@@ -155,7 +155,7 @@ const config = {
 			{
 				// Docs HTML/API/agent content — short cache so agents see updates promptly.
 				// Exclude hashed static assets.
-				source: "/:path((?!_next/static|_next/image|font/).*)",
+				source: "/:path((?!_next/static|_next/image|font/|healthz).*)",
 				headers: [
 					{
 						key: "Link",

--- a/apps/frontend/docs/src/app/healthz/route.ts
+++ b/apps/frontend/docs/src/app/healthz/route.ts
@@ -1,0 +1,12 @@
+/**
+ * Liveness/readiness probe used by the Dockerfile HEALTHCHECK and Coolify.
+ * Coolify only performs a rolling update (start new container → wait for
+ * healthy → stop old container) when the health check passes, so this must
+ * stay cheap, dependency-free and always return 200 once the server is up.
+ */
+export function GET() {
+	return Response.json(
+		{ status: "ok" },
+		{ headers: { "Cache-Control": "no-store" } },
+	);
+}

--- a/apps/frontend/links/Dockerfile
+++ b/apps/frontend/links/Dockerfile
@@ -50,4 +50,11 @@ RUN rm -rf apps
 
 EXPOSE 3005
 
+# Coolify needs a passing health check to do a rolling update (new container
+# becomes healthy before the old one is stopped). The Coolify UI check needs
+# curl/wget, which this alpine image does not ship, so define the check here
+# with bun instead. A Dockerfile HEALTHCHECK takes precedence over the UI one.
+HEALTHCHECK --interval=5s --timeout=3s --start-period=20s --retries=6 \
+	CMD bun -e "fetch('http://127.0.0.1:'+(process.env.PORT||3005)+'/healthz').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+
 CMD ["bun", "run", "server.js"]

--- a/apps/frontend/links/src/app/healthz/route.ts
+++ b/apps/frontend/links/src/app/healthz/route.ts
@@ -1,0 +1,12 @@
+/**
+ * Liveness/readiness probe used by the Dockerfile HEALTHCHECK and Coolify.
+ * Coolify only performs a rolling update (start new container → wait for
+ * healthy → stop old container) when the health check passes, so this must
+ * stay cheap, dependency-free and always return 200 once the server is up.
+ */
+export function GET() {
+	return Response.json(
+		{ status: "ok" },
+		{ headers: { "Cache-Control": "no-store" } },
+	);
+}

--- a/apps/frontend/web/Dockerfile
+++ b/apps/frontend/web/Dockerfile
@@ -59,4 +59,12 @@ RUN rm -rf apps
 
 EXPOSE 3000
 
+# Coolify needs a passing health check to do a rolling update (new container
+# becomes healthy before the old one is stopped). The Coolify UI check needs
+# curl/wget, which this alpine image does not ship, so define the check here
+# with bun instead. A Dockerfile HEALTHCHECK takes precedence over the UI one.
+# Short interval + retries keep the handover fast; start-period covers boot.
+HEALTHCHECK --interval=5s --timeout=3s --start-period=20s --retries=6 \
+	CMD bun -e "fetch('http://127.0.0.1:'+(process.env.PORT||3000)+'/healthz').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+
 CMD ["bun", "run", "server.js"]

--- a/apps/frontend/web/next.config.ts
+++ b/apps/frontend/web/next.config.ts
@@ -51,7 +51,8 @@ const nextConfig: NextConfig = {
 			},
 			{
 				// Marketing HTML + agent routes — short cache for AFDocs cache hygiene
-				source: "/:path((?!_next/static|_next/image|font/|manifest\\.json).*)",
+				source:
+					"/:path((?!_next/static|_next/image|font/|manifest\\.json|healthz).*)",
 				headers: [
 					{ key: "Link", value: agentLink },
 					{ key: "Cache-Control", value: agentCache },

--- a/apps/frontend/web/src/app/healthz/route.ts
+++ b/apps/frontend/web/src/app/healthz/route.ts
@@ -1,0 +1,12 @@
+/**
+ * Liveness/readiness probe used by the Dockerfile HEALTHCHECK and Coolify.
+ * Coolify only performs a rolling update (start new container → wait for
+ * healthy → stop old container) when the health check passes, so this must
+ * stay cheap, dependency-free and always return 200 once the server is up.
+ */
+export function GET() {
+	return Response.json(
+		{ status: "ok" },
+		{ headers: { "Cache-Control": "no-store" } },
+	);
+}

--- a/apps/frontend/web/src/app/robots.ts
+++ b/apps/frontend/web/src/app/robots.ts
@@ -9,7 +9,14 @@ export default function robots(): MetadataRoute.Robots {
 			{
 				userAgent: "*",
 				allow: "/",
-				disallow: ["/api/", "/preferences/", "/redirect/", "/twitter", "/home"],
+				disallow: [
+					"/api/",
+					"/healthz",
+					"/preferences/",
+					"/redirect/",
+					"/twitter",
+					"/home",
+				],
 			},
 			{
 				userAgent: [


### PR DESCRIPTION
## Summary

Fixes the 502 window on every deploy of the frontend apps by giving each container a working health check, which Coolify requires before it will perform a rolling update. Covers `web`, `console`, `docs`, and `links`.

## Problem

Coolify's rolling update flow (start new container → wait for healthy → stop old container) only runs when the health check passes. See https://coolify.io/docs/knowledge-base/rolling-updates.

The health check configured in the Coolify UI executes `curl`/`wget` inside the container. All four apps are built from `oven/bun:alpine`, which ships neither tool, and none of their Dockerfiles declared a `HEALTHCHECK`. The check could never pass, so every deploy fell back to stop-then-start and each site returned 502 until the new container booted. The `dashboard` app already had a bun-based `HEALTHCHECK` and was unaffected; this PR applies the same pattern everywhere else.

## Changes

| App | Route | Health check target |
|---|---|---|
| web | `src/app/healthz/route.ts` | `127.0.0.1:3000/healthz` |
| console | `src/app/healthz/route.ts` | `127.0.0.1:3002/console/healthz` |
| docs | `src/app/healthz/route.ts` | `127.0.0.1:3000/docs/healthz` |
| links | `src/app/healthz/route.ts` | `127.0.0.1:3005/healthz` |

- **Routes** return `{"status":"ok"}` with `Cache-Control: no-store`. No `dynamic` segment config, since that conflicts with `cacheComponents`.
- **Dockerfiles** add a `HEALTHCHECK` using `bun -e fetch(...)`, so no curl/wget is needed. Interval 5s, timeout 3s, start period 20s, 6 retries, so a healthy container is detected within seconds of boot. Paths honor each app's `basePath` and `PORT`. A Dockerfile health check takes precedence over the UI one.
- **web and docs `next.config.ts`** exclude `/healthz` from the catch-all marketing `Cache-Control` header rule so `no-store` sticks.
- **web `robots.ts`** disallows `/healthz` for crawlers. The other apps have no `robots.ts`.

Notes:
- The console route lives outside the `(protected)` route group, so it is not behind auth.
- In docs, the static route wins over the `[[...slug]]` catch-all, and the proxy passes it through unchanged.
- The web proxy only matches `/`, so `/healthz` is untouched.

## Verification

- All four endpoints return 200 with `Cache-Control: no-store` on the dev stack.
- The exact `HEALTHCHECK` command exits 0 against each app.
- Built the web image locally and ran it: Docker health status went `starting` → `healthy` in ~9s. The other three Dockerfiles use the identical block, adjusted only for port and path.
- Biome passes on the touched files.

## Coolify settings to confirm (not in repo)

For each of the four applications:

- UI health check enabled with the path from the table above and the matching port, expecting `200`.
- Default container name (no custom name).
- Ports Exposes set to the app's port only, no host port mapping such as `3000:3000`.
- Deployed as a Dockerfile/image app, not Docker Compose.

After the next deploy the log order should be: new container starts → health check passes → old container stops. If it still fails, check the coolify-proxy and app container logs, and confirm the server has memory for two containers per app during the overlap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added health-check endpoints to the Console, Docs, Links, and Web applications.
  * Added container health monitoring for improved deployment and rolling-update reliability.
  * Health-check responses are uncached and return a clear success status.

* **Configuration**
  * Prevented health-check routes from receiving standard page caching, headers, or search-engine indexing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds lightweight health endpoints and Bun-based Docker health checks to the web, console, docs, and links applications so Coolify can wait for replacement containers before stopping their predecessors.

- Uses each application’s configured port and base path.
- Prevents web and docs cache rules from overriding the probes’ `no-store` response.
- Updates web crawler rules, although the named-bot group still permits `/healthz`.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking crawler-rule gap that should be corrected if `/healthz` is intended to be excluded from every bot.

The container health checks, paths, ports, base paths, and cache exclusions are consistent; the only accepted concern is that named crawler groups still permit the web health endpoint.

**Files Needing Attention:** apps/frontend/web/src/app/robots.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/frontend/web/Dockerfile | Adds a Bun-based health check against the web application’s loopback health endpoint. |
| apps/frontend/console/Dockerfile | Adds a health check using the console port and `/console` base path. |
| apps/frontend/docs/Dockerfile | Adds a health check using the docs application’s `/docs` base path. |
| apps/frontend/links/Dockerfile | Adds a health check against the links application’s configured port. |
| apps/frontend/web/next.config.ts | Excludes the health endpoint from the marketing cache-header matcher. |
| apps/frontend/docs/next.config.ts | Excludes the base-path-aware health endpoint from the docs cache-header matcher. |
| apps/frontend/web/src/app/healthz/route.ts | Adds a dependency-free JSON server-health endpoint with caching disabled. |
| apps/frontend/console/src/app/healthz/route.ts | Adds the console server-health route used by its container probe. |
| apps/frontend/docs/src/app/healthz/route.ts | Adds the docs server-health route used by its container probe. |
| apps/frontend/links/src/app/healthz/route.ts | Adds the links server-health route used by its container probe. |
| apps/frontend/web/src/app/robots.ts | Disallows the health endpoint for wildcard crawlers but leaves it allowed for the explicitly named bot group. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Coolify
    participant O as Old container
    participant N as New container
    C->>N: Start replacement container
    loop Docker HEALTHCHECK
        N->>N: Bun fetches local /healthz
    end
    N-->>C: Healthy
    C->>O: Stop old container
    C->>N: Route production traffic
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(console,docs,links): add container h..."](https://github.com/reloop-labs/reloop/commit/ea34f6258db95113d0c55374c5a8f96e2d923307) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61619763)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->