### PR TITLE
fix: light mode across use-case pages, and revamp /compare/mailgun

### DIFF
--- a/apps/frontend/web/src/app/(home)/components/agent-cards.tsx
+++ b/apps/frontend/web/src/app/(home)/components/agent-cards.tsx
@@ -198,7 +198,7 @@ function ApiCard() {
 			<div className="mt-6 mb-4">
 				<ApiDiagram />
 			</div>
-			<div className="mt-auto flex items-center justify-start border-stroke-soft-100 border-t pt-4 dark:border-white/10">
+			<div className="mt-auto flex items-center justify-start border-stroke-soft-200 border-t pt-4 dark:border-white/10">
 				<span className="inline-flex items-center gap-1.5 font-medium text-[13px] text-text-strong-950 transition-colors group-hover:text-blue-600 dark:text-white dark:group-hover:text-blue-400">
 					<span>Explore API Reference</span>
 					<Icon
@@ -336,7 +336,7 @@ function CliCard() {
 			<div className="mt-6 mb-4">
 				<CliDiagram />
 			</div>
-			<div className="mt-auto flex items-center justify-start border-stroke-soft-100 border-t pt-4 dark:border-white/10">
+			<div className="mt-auto flex items-center justify-start border-stroke-soft-200 border-t pt-4 dark:border-white/10">
 				<span className="inline-flex items-center gap-1.5 font-medium text-[13px] text-text-strong-950 transition-colors group-hover:text-blue-600 dark:text-white dark:group-hover:text-blue-400">
 					<span>CLI Reference</span>
 					<Icon
@@ -412,7 +412,7 @@ function SkillsDiagram() {
 					width="62"
 					height="24"
 					rx="12"
-					fill="#fff1f2"
+					fill="#eff6ff"
 					className="dark:fill-blue-500/20"
 				/>
 				<text
@@ -430,7 +430,7 @@ function SkillsDiagram() {
 					width="56"
 					height="24"
 					rx="12"
-					fill="#fff1f2"
+					fill="#eff6ff"
 					className="dark:fill-blue-500/20"
 				/>
 				<text
@@ -448,7 +448,7 @@ function SkillsDiagram() {
 					width="66"
 					height="24"
 					rx="12"
-					fill="#fff1f2"
+					fill="#eff6ff"
 					className="dark:fill-blue-500/20"
 				/>
 				<text
@@ -499,7 +499,7 @@ function SkillsCard() {
 			<div className="mt-6 mb-4">
 				<SkillsDiagram />
 			</div>
-			<div className="mt-auto flex items-center justify-start border-stroke-soft-100 border-t pt-4 dark:border-white/10">
+			<div className="mt-auto flex items-center justify-start border-stroke-soft-200 border-t pt-4 dark:border-white/10">
 				<span className="inline-flex items-center gap-1.5 font-medium text-[13px] text-text-strong-950 transition-colors group-hover:text-blue-600 dark:text-white dark:group-hover:text-blue-400">
 					<span>Install Agent Skills</span>
 					<Icon
@@ -531,7 +531,7 @@ function CardHeader({
 					height="48"
 					viewBox="0 0 22 48"
 					fill="none"
-					className="stroke-stroke-soft-100 dark:stroke-white/10"
+					className="stroke-stroke-soft-200 dark:stroke-white/10"
 					strokeWidth="1.5"
 					strokeLinecap="round"
 				>
@@ -702,7 +702,7 @@ function McpCard() {
 			<div className="mt-6 mb-4">
 				<McpDiagram />
 			</div>
-			<div className="mt-auto flex items-center justify-start border-stroke-soft-100 border-t pt-4 dark:border-white/10">
+			<div className="mt-auto flex items-center justify-start border-stroke-soft-200 border-t pt-4 dark:border-white/10">
 				<span className="inline-flex items-center gap-1.5 font-medium text-[13px] text-text-strong-950 transition-colors group-hover:text-blue-600 dark:text-white dark:group-hover:text-blue-400">
 					<span>Explore MCP Server</span>
 					<Icon
@@ -732,8 +732,8 @@ export function AgentCards() {
 						Connect Reloop to anything
 					</h2>
 					<p className="mx-auto mt-4 max-w-xl text-[15px] text-text-sub-600 leading-relaxed sm:text-[16px] dark:text-white/50">
-						AI agents, terminals, and your own stack — pick the surface
-						that fits how you build.
+						AI agents, terminals, and your own stack. Pick the surface that fits
+						how you build.
 					</p>
 				</div>
 			</div>

--- a/apps/frontend/web/src/app/compare/components/compare-migrate.tsx
+++ b/apps/frontend/web/src/app/compare/components/compare-migrate.tsx
@@ -65,7 +65,7 @@ export function CompareMigrate({
 				</h2>
 				<p className="mx-auto mt-4 max-w-xl text-balance font-medium text-[15px] text-text-sub-600 leading-relaxed sm:text-[17px] dark:text-white/50">
 					Switching from {competitorName} to Reloop is straightforward. Keep
-					your templates, swap the send path, and re-wire webhooks—without
+					your templates, swap the send path, and re-wire webhooks, without
 					rewriting your product.
 				</p>
 

--- a/apps/frontend/web/src/app/compare/mailgun/comparison-data.ts
+++ b/apps/frontend/web/src/app/compare/mailgun/comparison-data.ts
@@ -1,0 +1,265 @@
+import type { ComparisonCategory } from "../compare-types";
+
+export const mailgunComparisonCategories: ComparisonCategory[] = [
+	{
+		id: "pricing-volume",
+		label: "Pricing & Email Volume",
+		icon: "invoice",
+		intro:
+			"Mailgun prices in plan tiers: Basic at $15/mo for 10,000 emails, Foundation at $35/mo for 50,000, with overage billed from $1.30 per 1,000. Reloop Cloud Pro is $10/mo for 50,000 emails and $0.50 per 1,000 after that. Self-hosting Reloop carries no Reloop license fee; you pay your own infrastructure.",
+		features: [
+			{
+				label: "Free tier",
+				icon: "send-2",
+				reloop: {
+					value: "3,000 / mo",
+					note: "200 / day cap",
+				},
+				competitor: {
+					value: "100 / day",
+					note: "Trial period only",
+				},
+			},
+			{
+				label: "Entry paid plan",
+				icon: "invoice",
+				reloop: {
+					value: "$10 / mo",
+					note: "50,000 emails included",
+				},
+				competitor: {
+					value: "$15 / mo",
+					note: "Basic · 10,000 emails",
+				},
+			},
+			{
+				label: "50,000 emails / mo",
+				icon: "mega-phone",
+				reloop: "$10 / mo",
+				competitor: {
+					value: "$35 / mo",
+					note: "Foundation",
+				},
+			},
+			{
+				label: "Overage rate (per 1k emails)",
+				icon: "arrow-swap",
+				reloop: "$0.50 / 1k",
+				competitor: {
+					value: "From $1.30 / 1k",
+					note: "Basic from $1.80 / 1k",
+				},
+			},
+			{
+				label: "Email validation",
+				icon: "user-circle",
+				reloop: "Yes",
+				competitor: {
+					value: "Yes",
+					note: "Priced as a separate add-on",
+				},
+			},
+			{
+				label: "Self-hosted email sends",
+				icon: "server",
+				reloop: {
+					value: "Unlimited",
+					note: "Free open-source software (own infra)",
+				},
+				competitor: {
+					value: "N/A",
+					note: "Hosted SaaS only",
+				},
+			},
+		],
+	},
+	{
+		id: "sending-receiving",
+		label: "Sending & Receiving",
+		icon: "send-2",
+		intro:
+			"The sending surface overlaps closely: both speak REST and SMTP, both parse inbound mail. The split is what sits behind it. Reloop runs its own MTA and MX stack (KumoMTA, Rspamd, two-way agent inbox) and hands you the source; Mailgun is managed sending with regex-matched inbound routes.",
+		features: [
+			{
+				label: "REST API",
+				icon: "webhook",
+				reloop: "Yes",
+				competitor: "Yes",
+			},
+			{
+				label: "SMTP relay",
+				icon: "smtp",
+				reloop: "Yes",
+				competitor: "Yes",
+			},
+			{
+				label: "Inbound / reply handling",
+				icon: "mail-receive",
+				reloop: {
+					value: "Agent inbox",
+					note: "AI triage plus webhooks",
+				},
+				competitor: {
+					value: "Inbound routes",
+					note: "Regex match and forward",
+				},
+			},
+			{
+				label: "Agent / AI inbox",
+				icon: "robot",
+				reloop: "Yes",
+				competitor: "No",
+			},
+			{
+				label: "Stored templates",
+				icon: "file-text",
+				reloop: {
+					value: "Yes",
+					note: "React Email or HTML",
+				},
+				competitor: {
+					value: "Yes",
+					note: "Handlebars templates",
+				},
+			},
+			{
+				label: "Batch / broadcast sending",
+				icon: "mega-phone",
+				reloop: "Yes",
+				competitor: "Yes",
+			},
+			{
+				label: "Scheduled delivery",
+				icon: "calendar",
+				reloop: "Yes",
+				competitor: "Yes",
+			},
+			{
+				label: "Marketing campaigns",
+				icon: "workflow",
+				reloop: "Yes",
+				competitor: {
+					value: "Limited",
+					note: "Campaign tooling is a separate Sinch product",
+				},
+			},
+		],
+	},
+	{
+		id: "analytics-security",
+		label: "Data & Security",
+		icon: "graph-up",
+		intro:
+			"Delivery telemetry is comparable. We only mark what Reloop ships today, with no geolocation or client fingerprinting claims.",
+		features: [
+			{
+				label: "Delivery events",
+				icon: "send-2",
+				reloop: "Yes",
+				competitor: "Yes",
+			},
+			{
+				label: "Bounce & complaint handling",
+				icon: "refresh-cw",
+				reloop: "Yes",
+				competitor: "Yes",
+			},
+			{
+				label: "Open & click tracking",
+				icon: "eye-outline",
+				reloop: "Yes",
+				competitor: "Yes",
+			},
+			{
+				label: "Suppression lists",
+				icon: "bell-off",
+				reloop: "Yes",
+				competitor: "Yes",
+			},
+			{
+				label: "Dashboard activity / logs",
+				icon: "logs",
+				reloop: "Yes",
+				competitor: "Yes",
+			},
+			{
+				label: "Webhook signature verification",
+				icon: "webhook",
+				reloop: {
+					value: "Yes",
+					note: "HMAC-SHA256 (X-Webhook-Signature)",
+				},
+				competitor: {
+					value: "Yes",
+					note: "HMAC with account signing key",
+				},
+			},
+			{
+				label: "SPF / DKIM / DMARC",
+				icon: "lock",
+				reloop: "Yes",
+				competitor: "Yes",
+			},
+		],
+	},
+	{
+		id: "ownership",
+		label: "Ownership & Exit",
+		icon: "server",
+		intro:
+			"This is the section that decides most Mailgun migrations. Mailgun is hosted-only under Sinch, so leaving means rebuilding on someone else's stack. Reloop ships the source and a self-host path, so the exit is a deployment target rather than a rewrite.",
+		features: [
+			{
+				label: "Open-source codebase",
+				icon: "github",
+				reloop: {
+					value: "Yes",
+					note: "Apache 2.0 plus Reloop Labs terms",
+				},
+				competitor: "No",
+			},
+			{
+				label: "Self-hostable",
+				icon: "server",
+				reloop: "Yes",
+				competitor: "No",
+			},
+			{
+				label: "Direct MTA control",
+				icon: "mail-server",
+				reloop: {
+					value: "Yes",
+					note: "KumoMTA under your control",
+				},
+				competitor: {
+					value: "No",
+					note: "Managed sending only",
+				},
+			},
+			{
+				label: "Dedicated IPs",
+				icon: "globe",
+				reloop: {
+					value: "1 included",
+					note: "Growth plan; bring your own when self-hosted",
+				},
+				competitor: {
+					value: "Paid add-on",
+					note: "Plan-tiered availability",
+				},
+			},
+			{
+				label: "Vendor lock-in risk",
+				icon: "invoice",
+				reloop: {
+					value: "Lower",
+					note: "Source plus self-host path; still evaluate license terms",
+				},
+				competitor: {
+					value: "Higher",
+					note: "Hosted-only proprietary stack",
+				},
+			},
+		],
+	},
+];

--- a/apps/frontend/web/src/app/compare/mailgun/page.tsx
+++ b/apps/frontend/web/src/app/compare/mailgun/page.tsx
@@ -1,16 +1,17 @@
 import { FaqSection } from "@reloop/web/components/faq-section";
-import { PageSection, SectionHeading } from "@reloop/web/components/page-shell";
-import {
-	getComparePage,
-	mailgunFeatures,
-} from "@reloop/web/lib/compare-content";
+import { getComparePage } from "@reloop/web/lib/compare-content";
 import { getSiteUrl } from "@reloop/web/lib/site";
 import type { Metadata } from "next";
 import Link from "next/link";
+import { competitorBrands } from "../competitor-brands";
+import { CompareHeroStatStrip } from "../components/compare-hero-stat-strip";
 import { ComparePageJsonLd } from "../components/compare-json-ld";
+import { CompareMigrate } from "../components/compare-migrate";
 import { CompareOtherLinks } from "../components/compare-other-links";
+import { CompareSection } from "../components/compare-section";
+import { ComparisonMatrix } from "../components/comparison-matrix";
 import { ComparisonPageShell } from "../components/comparison-page-shell";
-import { ComparisonTable } from "../components/comparison-table";
+import { mailgunComparisonCategories } from "./comparison-data";
 
 // TODO: Cache Components adoption. Refactor this route so this opt-out can be removed.
 // See: https://nextjs.org/docs/app/guides/migrating-to-cache-components
@@ -47,135 +48,175 @@ export const metadata: Metadata = {
 	alternates: { canonical: pageUrl },
 };
 
+const mailgunStats = [
+	{
+		label: "50,000 Emails",
+		value: "$10",
+		detail: "Reloop Pro monthly; Mailgun Foundation lists at $35",
+	},
+	{
+		label: "Overage Rate",
+		value: "$0.50",
+		detail: "Per 1,000 extra emails; Mailgun starts at $1.30",
+	},
+	{
+		label: "SMTP Cutover",
+		value: "3 fields",
+		detail: "Host, port, credentials. Existing SMTP senders keep their code",
+	},
+	{
+		label: "Self-Hosting",
+		value: "$0",
+		detail: "Apache 2.0 core on your own Docker or Kubernetes",
+	},
+];
+
+const mailgunMigrateSteps = [
+	{
+		step: 1,
+		title: "Step 1",
+		body: "Create a Reloop account and verify the domains you already send from with Mailgun. Keep both providers live while DKIM and SPF propagate.",
+		duration: "5 min",
+		visual: "signin" as const,
+	},
+	{
+		step: 2,
+		title: "Step 2",
+		body: "SMTP senders change host, port, and credentials, with no application rewrite. API senders swap the endpoint and map Mailgun inbound routes to Reloop handlers.",
+		duration: "15 min",
+		visual: "domains" as const,
+	},
+	{
+		step: 3,
+		title: "Step 3",
+		body: "Re-point event webhooks at Reloop, move suppression lists across, then shift traffic domain by domain until Mailgun is idle.",
+		duration: "1 afternoon",
+		visual: "success" as const,
+	},
+];
+
 const MailgunComparisonPage = () => {
+	const mailgunBrand = competitorBrands.find((b) => b.name === "Mailgun");
 	const compare = getComparePage("mailgun");
+
 	return (
 		<>
 			<ComparePageJsonLd slug="mailgun" />
 			<ComparisonPageShell
 				pagePath={pagePath}
 				titleLines={["Reloop vs Mailgun"]}
-				description="Learn how Reloop compares to Mailgun and why Reloop is the best Mailgun alternative for all your developer email API needs."
+				description="Mailgun gives you REST, SMTP, and inbound routes as a hosted service under Sinch. Reloop gives you the same sending surface with the source code and a self-host path behind it."
+				primaryCta={{
+					label: "Get Started ",
+					href: "/dashboard/signup",
+				}}
+				secondaryCta={{
+					label: "Migrate from Mailgun",
+					href: "/compare/mailgun#migrate",
+				}}
 			>
-				<PageSection flushTop narrow>
-					<div className="mx-auto max-w-3xl space-y-6 text-[15px] text-text-sub-600 leading-7 sm:text-[17px] dark:text-white/50">
-						<p>
-							Mailgun remains a common choice for teams that need REST + SMTP,
-							domain-level configuration, and inbound parsing. Under Twilio, the
-							product also carries enterprise packaging, usage-based billing,
-							and the usual question:{" "}
-							<em>
-								what happens to our sending reputation and data if we leave?
-							</em>
-						</p>
-						<p>
-							Reloop is built for teams that want Mailgun-class
-							capabilities—API, SMTP, webhooks, validation—but with{" "}
-							<strong className="font-semibold text-text-strong-950 dark:text-white">
-								source access and a self-host path
-							</strong>{" "}
-							so email infrastructure is not a permanent external dependency.
-						</p>
-					</div>
-				</PageSection>
+				<CompareSection flushTop maxWidth="full">
+					<CompareHeroStatStrip stats={mailgunStats} />
+				</CompareSection>
 
-				<PageSection>
-					<SectionHeading
-						title="Mailgun in production today"
-						description="What we hear from teams running Mailgun for years."
-						compact
-					/>
-					<div className="grid gap-4 sm:grid-cols-3">
-						<div className="rounded-2xl border border-stroke-soft-200 p-5 dark:border-white/10">
-							<p className="font-semibold text-text-strong-950 dark:text-white">
-								Legacy SMTP apps
-							</p>
-							<p className="mt-2 text-[14px] text-text-sub-600 leading-relaxed dark:text-white/50">
-								Cron jobs and services still send via SMTP credentials—not the
-								REST API. Mailgun supports both; so does Reloop.
-							</p>
-						</div>
-						<div className="rounded-2xl border border-stroke-soft-200 p-5 dark:border-white/10">
-							<p className="font-semibold text-text-strong-950 dark:text-white">
-								Inbound routes
-							</p>
-							<p className="mt-2 text-[14px] text-text-sub-600 leading-relaxed dark:text-white/50">
-								Support inboxes and reply parsing often depend on Mailgun
-								inbound. Reloop&apos;s agent inbox targets the same workflows
-								with modern AI tooling.
-							</p>
-						</div>
-						<div className="rounded-2xl border border-stroke-soft-200 p-5 dark:border-white/10">
-							<p className="font-semibold text-text-strong-950 dark:text-white">
-								Billing surprises
-							</p>
-							<p className="mt-2 text-[14px] text-text-sub-600 leading-relaxed dark:text-white/50">
-								Validation, dedicated IPs, and overages stack on base send
-								volume. Reloop publishes tiered send-based pricing and a
-								self-host escape hatch.
-							</p>
+				<CompareSection maxWidth="full">
+					<div className="mx-auto max-w-3xl space-y-6 text-center">
+						<span className="font-bold text-[12px] text-text-sub-600 uppercase tracking-widest dark:text-white/50">
+							The Exit Question
+						</span>
+						<h2 className="font-serif text-[2rem] text-text-strong-950 leading-tight tracking-tight sm:text-[2.5rem] dark:text-white">
+							Mailgun works. Leaving it is the hard part.
+						</h2>
+						<p className="text-[16px] text-text-sub-600 leading-relaxed dark:text-white/60">
+							Teams rarely move off Mailgun because the API stopped working.
+							They move because the plan tier jumped, because inbound routes
+							grew into a parsing layer nobody owns, or because the answer to
+							&ldquo;what happens if we leave?&rdquo; is a rewrite. Reloop keeps
+							the same sending surface and removes that last answer.
+						</p>
+
+						<div className="mt-8 grid grid-cols-1 gap-4 text-left sm:grid-cols-3">
+							<div className="rounded-2xl border border-stroke-soft-200/80 bg-bg-weak-50/50 p-6 dark:border-white/10 dark:bg-white/[0.02]">
+								<p className="font-semibold text-text-strong-950 dark:text-white">
+									Plan tiers, not usage
+								</p>
+								<p className="mt-2 text-[14px] text-text-sub-600 leading-relaxed dark:text-white/60">
+									Basic covers 10,000 emails at $15/mo; the next real step is
+									Foundation at $35/mo. Validation and dedicated IPs are priced
+									on top. Reloop bills per send, and self-hosting removes the
+									tier entirely.
+								</p>
+							</div>
+							<div className="rounded-2xl border border-stroke-soft-200/80 bg-bg-weak-50/50 p-6 dark:border-white/10 dark:bg-white/[0.02]">
+								<p className="font-semibold text-text-strong-950 dark:text-white">
+									Inbound that outgrew routes
+								</p>
+								<p className="mt-2 text-[14px] text-text-sub-600 leading-relaxed dark:text-white/60">
+									Support inboxes and reply parsing start as one Mailgun route
+									and end as a service. Reloop&apos;s agent inbox handles
+									triage, spam scoring, and threading before the webhook fires.
+								</p>
+							</div>
+							<div className="rounded-2xl border border-stroke-soft-200/80 bg-bg-white-0 p-6 shadow-sm dark:border-white/10 dark:bg-white/[0.03]">
+								<p className="font-semibold text-primary-base">
+									Reputation you can take with you
+								</p>
+								<p className="mt-2 text-[14px] text-text-sub-600 leading-relaxed dark:text-white/60">
+									Deliverability follows your domains and IPs, not the
+									dashboard. Self-hosted Reloop attaches your own IPs directly
+									to the MTA, so the sending identity stays yours.
+								</p>
+							</div>
 						</div>
 					</div>
-				</PageSection>
+				</CompareSection>
 
-				<PageSection alt>
-					<SectionHeading title="Capability matrix" compact />
-					<ComparisonTable
+				<CompareSection maxWidth="full" flushX>
+					<div className="mb-10 text-center">
+						<h2 className="mt-3 font-serif text-[2rem] text-text-strong-950 leading-[1.1] tracking-tighter sm:text-[2.4rem] lg:text-[2.8rem] dark:text-white">
+							Reloop &nbsp;&nbsp;vs&nbsp;&nbsp;&nbsp;Mailgun
+						</h2>
+						<p className="mx-auto mt-3 max-w-xl font-medium text-[15px] text-text-sub-600 leading-7 sm:text-[17px] dark:text-white/50">
+							List prices, sending surface, and what you keep if you walk away.
+						</p>
+					</div>
+
+					<ComparisonMatrix
 						competitorName="Mailgun"
-						features={mailgunFeatures}
+						categories={mailgunComparisonCategories}
 					/>
-				</PageSection>
 
-				<PageSection narrow>
-					<SectionHeading
-						title="Mailgun → Reloop migration"
-						description="A sequence that works for API and SMTP senders."
-						compact
-					/>
-					<ol className="mx-auto max-w-2xl list-none space-y-3">
-						<li className="rounded-2xl border border-stroke-soft-200 px-5 py-4 dark:border-white/10">
-							<span className="font-semibold text-primary-base">Step 1 —</span>
-							<span className="text-[15px] text-text-sub-600 dark:text-white/60">
-								{" "}
-								Export domain DNS records and document current Mailgun routes
-								(inbound, webhooks, suppression lists).
-							</span>
-						</li>
-						<li className="rounded-2xl border border-stroke-soft-200 px-5 py-4 dark:border-white/10">
-							<span className="font-semibold text-primary-base">Step 2 —</span>
-							<span className="text-[15px] text-text-sub-600 dark:text-white/60">
-								{" "}
-								Provision the same domains in Reloop; verify DKIM/SPF before
-								production cutover.
-							</span>
-						</li>
-						<li className="rounded-2xl border border-stroke-soft-200 px-5 py-4 dark:border-white/10">
-							<span className="font-semibold text-primary-base">Step 3 —</span>
-							<span className="text-[15px] text-text-sub-600 dark:text-white/60">
-								{" "}
-								For SMTP workloads, update host, port, and credentials only—no
-								app rewrite required.
-							</span>
-						</li>
-						<li className="rounded-2xl border border-stroke-soft-200 px-5 py-4 dark:border-white/10">
-							<span className="font-semibold text-primary-base">Step 4 —</span>
-							<span className="text-[15px] text-text-sub-600 dark:text-white/60">
-								{" "}
-								For API workloads, swap endpoints and map Mailgun event webhooks
-								to Reloop delivery events.
-							</span>
-						</li>
-					</ol>
-					<p className="mx-auto mt-6 max-w-2xl text-center text-[14px] text-text-sub-600 dark:text-white/50">
+					<p className="mt-6 text-center text-[13px] text-text-sub-600 dark:text-white/40">
+						Seen something inaccurate?{" "}
+						<Link href="/contact" className="font-semibold text-primary-base">
+							Tell us
+						</Link>
+						. We correct comparison pages when public features change.
+					</p>
+				</CompareSection>
+
+				<CompareSection maxWidth="full">
+					{mailgunBrand ? (
+						<CompareMigrate
+							competitorName="Mailgun"
+							competitorIcon={mailgunBrand.icon}
+							primaryHref="/dashboard/signup"
+							guideHref="/docs"
+							steps={mailgunMigrateSteps}
+						/>
+					) : null}
+					<p className="mx-auto mt-10 max-w-2xl px-4 text-center text-[14px] text-text-sub-600 dark:text-white/50">
+						The{" "}
 						<Link
 							href="/features/smtp"
 							className="font-semibold text-primary-base"
 						>
-							Reloop SMTP docs
+							Reloop SMTP guide
 						</Link>{" "}
-						cover credential rotation without downtime.
+						covers credential rotation without downtime. Reloop is not a drop-in
+						Mailgun proxy, so plan a small client adapter for API senders.
 					</p>
-				</PageSection>
+				</CompareSection>
 
 				<FaqSection
 					id="compare-mailgun-faq"
@@ -185,9 +226,9 @@ const MailgunComparisonPage = () => {
 					flush
 				/>
 
-				<PageSection>
+				<CompareSection maxWidth="full" noDivider>
 					<CompareOtherLinks currentHref={pagePath} />
-				</PageSection>
+				</CompareSection>
 			</ComparisonPageShell>
 		</>
 	);

--- a/apps/frontend/web/src/components/footer-brand.tsx
+++ b/apps/frontend/web/src/components/footer-brand.tsx
@@ -97,14 +97,14 @@ function OpenSourceSeal({ accent }: { accent: FooterBrandAccent }) {
 			>
 				<polygon
 					points={SEAL_POINTS}
-					className="fill-bg-white-0 stroke-stroke-soft-100 dark:fill-black dark:stroke-white/15"
+					className="fill-bg-white-0 stroke-stroke-sub-300 dark:fill-black dark:stroke-white/15"
 					strokeWidth="1"
 				/>
 				<circle
 					cx="44"
 					cy="44"
 					r="31"
-					className="stroke-stroke-soft-100 dark:stroke-white/15"
+					className="stroke-stroke-sub-300 dark:stroke-white/15"
 					fill="none"
 					strokeWidth=".8"
 				/>

--- a/apps/frontend/web/src/components/landing/tools/tool-chrome.tsx
+++ b/apps/frontend/web/src/components/landing/tools/tool-chrome.tsx
@@ -89,30 +89,23 @@ export function ToolUpsell({
 	secondaryLabel?: string;
 }) {
 	return (
-		<div className="relative overflow-hidden border-stroke-soft-200 border-t bg-[#0d0d0f] dark:border-white/[0.06]">
+		<div className="relative overflow-hidden border-stroke-soft-200 border-t bg-bg-white-0 dark:border-white/10 dark:bg-black">
 			{/* Subtle grid overlay */}
 			<div
-				className="pointer-events-none absolute inset-0"
-				style={{
-					backgroundImage:
-						"linear-gradient(rgba(255,255,255,0.03) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,0.03) 1px, transparent 1px)",
-					backgroundSize: "40px 40px",
-				}}
+				aria-hidden
+				className="pointer-events-none absolute inset-0 bg-[linear-gradient(to_right,#80808014_1px,transparent_1px),linear-gradient(to_bottom,#80808014_1px,transparent_1px)] bg-[size:40px_40px]"
 			/>
 			{/* Radial glow */}
 			<div
-				className="pointer-events-none absolute inset-0"
-				style={{
-					background:
-						"radial-gradient(ellipse 60% 80% at 50% 50%, rgba(109,40,217,0.18) 0%, transparent 70%)",
-				}}
+				aria-hidden
+				className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_60%_80%_at_50%_50%,var(--color-primary-base)_0%,transparent_70%)] opacity-[0.10] dark:opacity-[0.18]"
 			/>
 			<div className="relative mx-auto flex max-w-4xl flex-col items-center gap-8 px-6 py-20 text-center sm:px-10">
 				<div className="flex flex-col items-center gap-4">
-					<p className="font-semibold text-3xl text-white leading-tight tracking-tight sm:text-4xl">
+					<p className="font-semibold text-3xl text-text-strong-950 leading-tight tracking-tight sm:text-4xl dark:text-white">
 						{title}
 					</p>
-					<p className="max-w-md text-[15px] text-white/50 leading-relaxed">
+					<p className="max-w-md text-[15px] text-text-sub-600 leading-relaxed dark:text-white/55">
 						{description}
 					</p>
 				</div>
@@ -120,8 +113,7 @@ export function ToolUpsell({
 					<Link
 						href={primaryHref}
 						className={Button.buttonVariants({ variant: "neutral" }).root({
-							className:
-								"rounded-full bg-white! px-6 text-black! hover:bg-white/90!",
+							className: "rounded-full px-6",
 						})}
 					>
 						{primaryLabel}
@@ -132,10 +124,7 @@ export function ToolUpsell({
 							className={Button.buttonVariants({
 								mode: "stroke",
 								variant: "neutral",
-							}).root({
-								className:
-									"rounded-full border-white/20! px-6 text-white! hover:border-white/40! hover:bg-white/5!",
-							})}
+							}).root({ className: "rounded-full px-6" })}
 						>
 							{secondaryLabel}
 						</Link>

--- a/apps/frontend/web/src/components/landing/use-cases/layouts.tsx
+++ b/apps/frontend/web/src/components/landing/use-cases/layouts.tsx
@@ -121,36 +121,38 @@ export function SplitScreenLayout({ config, children }: LayoutProps) {
 // 2. Console-First Dark Layout (API & Devops Ops)
 export function ConsoleFirstLayout({ config, children }: LayoutProps) {
 	const extra = getUseCaseEnrichment(config.slug);
-	const _accent = accentStyles[extra.accent];
+	const accent = accentStyles[extra.accent];
 
 	return (
-		<div className="min-h-screen bg-slate-950 text-left font-sans text-white">
+		<div className="min-h-screen bg-white text-left font-sans dark:bg-black">
 			{/* Hero & Terminal */}
-			<div className="relative overflow-hidden border-white/5 border-b pt-24 pb-16">
+			<div className="relative overflow-hidden border-stroke-soft-200 border-b pt-24 pb-16 dark:border-white/10">
 				{/* Background Glow */}
 				<div className="pointer-events-none absolute inset-0">
-					<div className="-translate-x-1/2 absolute top-0 left-1/2 h-[350px] w-[800px] rounded-full bg-gradient-to-r from-cyan-500/10 via-indigo-500/10 to-transparent blur-[100px]" />
+					<div className="-translate-x-1/2 absolute top-0 left-1/2 h-[350px] w-[800px] rounded-full bg-gradient-to-r from-primary-base/15 via-violet-500/10 to-transparent blur-[100px] dark:from-primary-base/20 dark:via-violet-500/15" />
 				</div>
 
 				<div className="relative mx-auto grid max-w-6xl items-center gap-12 px-4 sm:px-6 lg:grid-cols-12">
 					<div className="space-y-6 lg:col-span-5">
-						<nav className="flex gap-2 text-[13px] text-white/40">
-							<Link href="/use-cases" className="hover:text-cyan-400">
+						<nav className="flex gap-2 text-[13px] text-text-sub-600 dark:text-white/55">
+							<Link href="/use-cases" className="hover:text-primary-base">
 								Use cases
 							</Link>
 							<span>/</span>
 							<span>{config.titleLines.join(" ")}</span>
 						</nav>
 
-						<span className="inline-flex rounded-full border border-white/5 bg-white/10 px-3 py-1 font-mono text-[10px] text-cyan-400 uppercase tracking-wider">
+						<span
+							className={`inline-flex rounded-full px-3 py-1 font-mono text-[10px] uppercase tracking-wider ${accent.badge}`}
+						>
 							Developer API
 						</span>
 
-						<h1 className="font-semibold text-3xl text-white tracking-tight sm:text-4xl">
+						<h1 className="font-semibold text-3xl text-text-strong-950 tracking-tight sm:text-4xl dark:text-white">
 							{config.titleLines.join(" ")}
 						</h1>
 
-						<p className="text-[15px] text-white/60 leading-relaxed">
+						<p className="text-[15px] text-text-sub-600 leading-relaxed dark:text-white/55">
 							{config.description}
 						</p>
 
@@ -158,7 +160,11 @@ export function ConsoleFirstLayout({ config, children }: LayoutProps) {
 							{config.primaryCta && (
 								<Link
 									href={config.primaryCta.href}
-									className="rounded-full bg-white px-5 py-2.5 font-semibold text-black text-xs transition-colors hover:bg-slate-200"
+									className={Button.buttonVariants({ variant: "neutral" }).root(
+										{
+											className: "rounded-full",
+										},
+									)}
 								>
 									{config.primaryCta.label}
 								</Link>
@@ -166,7 +172,10 @@ export function ConsoleFirstLayout({ config, children }: LayoutProps) {
 							{config.secondaryCta && (
 								<Link
 									href={config.secondaryCta.href}
-									className="rounded-full border border-white/10 bg-slate-900 px-5 py-2.5 font-semibold text-white/80 text-xs transition-colors hover:bg-slate-800"
+									className={Button.buttonVariants({
+										mode: "stroke",
+										variant: "neutral",
+									}).root({ className: "rounded-full" })}
 								>
 									{config.secondaryCta.label}
 								</Link>
@@ -182,19 +191,19 @@ export function ConsoleFirstLayout({ config, children }: LayoutProps) {
 
 			{/* Technical Specs section */}
 			<div className="mx-auto max-w-6xl px-4 py-16 sm:px-6">
-				<h2 className="mb-8 font-bold text-white text-xl tracking-tight">
+				<h2 className="mb-8 font-bold text-text-strong-950 text-xl tracking-tight dark:text-white">
 					Technical specifications
 				</h2>
 				<div className="grid gap-6 sm:grid-cols-3">
 					{config.sections[0]?.items.map((item) => (
 						<div
 							key={item.title}
-							className="rounded-2xl border border-white/5 bg-slate-900/60 p-6"
+							className="rounded-2xl border border-stroke-soft-200 p-6 dark:border-white/10"
 						>
-							<h3 className="mb-2 font-semibold text-cyan-400 text-sm">
+							<h3 className={`mb-2 font-semibold text-sm ${accent.text}`}>
 								{item.title}
 							</h3>
-							<p className="text-white/50 text-xs leading-relaxed">
+							<p className="text-[13px] text-text-sub-600 leading-relaxed dark:text-white/55">
 								{item.description}
 							</p>
 						</div>

--- a/apps/frontend/web/src/components/landing/use-cases/widgets/ai-agent.tsx
+++ b/apps/frontend/web/src/components/landing/use-cases/widgets/ai-agent.tsx
@@ -12,82 +12,89 @@ export default function AiAgentWidget() {
 	);
 
 	return (
-		<div className="flex h-full min-h-[420px] flex-col overflow-hidden rounded-2xl border border-white/10 bg-slate-950 text-left font-sans shadow-2xl">
+		<div className="flex h-full min-h-[420px] flex-col overflow-hidden rounded-2xl border border-stroke-soft-200 bg-bg-white-0 text-left font-sans shadow-lg dark:border-white/10 dark:bg-slate-950 dark:shadow-2xl">
 			{/* Header */}
-			<div className="flex items-center justify-between border-white/5 border-b bg-slate-900 px-4 py-3">
+			<div className="flex items-center justify-between border-stroke-soft-200 border-b bg-bg-weak-50 px-4 py-3 dark:border-white/5 dark:bg-slate-900">
 				<div className="flex items-center gap-1.5">
-					<span className="h-2.5 w-2.5 rounded-full bg-indigo-500/80" />
+					<span className="h-2.5 w-2.5 rounded-full bg-red-500/80" />
 					<span className="h-2.5 w-2.5 rounded-full bg-yellow-500/80" />
 					<span className="h-2.5 w-2.5 rounded-full bg-green-500/80" />
-					<span className="ml-2 font-mono text-white/40 text-xs">
+					<span className="ml-2 font-mono text-text-sub-600 text-xs dark:text-white/40">
 						agent_inbox_monitor.ai
 					</span>
 				</div>
-				<span className="animate-pulse rounded border border-indigo-500/20 bg-indigo-500/10 px-2 py-0.5 font-mono text-[10px] text-indigo-400">
+				<span className="animate-pulse rounded border border-blue-500/20 bg-blue-500/10 px-2 py-0.5 font-mono text-[10px] text-blue-600 dark:text-blue-400">
 					AI Copilot Active
 				</span>
 			</div>
 
 			<div className="flex flex-1 flex-col gap-4 p-4">
 				{/* Step 1: Customer Inbound Message */}
-				<div className="rounded-xl border border-white/5 bg-slate-900/40 p-3">
+				<div className="rounded-xl border border-stroke-soft-200 bg-bg-weak-50/60 p-3 dark:border-white/5 dark:bg-slate-900/40">
 					<div className="mb-2 flex items-center justify-between">
-						<span className="font-mono text-[10px] text-white/40">
+						<span className="font-mono text-[10px] text-text-sub-600 dark:text-white/40">
 							FROM: alex.smith@acme.com
 						</span>
-						<span className="rounded-full bg-rose-500/10 px-2 py-0.5 font-mono text-[10px] text-rose-400">
+						<span className="rounded-full bg-rose-500/10 px-2 py-0.5 font-mono text-[10px] text-rose-600 dark:text-rose-400">
 							Billing Issue
 						</span>
 					</div>
-					<p className="font-sans text-white/80 text-xs leading-relaxed">
-						"Hey, my invoice #1024 was charged twice today. Can you check and
-						process a refund? Thanks."
+					<p className="font-sans text-text-strong-950 text-xs leading-relaxed dark:text-white/80">
+						&ldquo;Hey, my invoice #1024 was charged twice today. Can you check
+						and process a refund? Thanks.&rdquo;
 					</p>
 				</div>
 
 				{/* Agent Classification Analytics */}
 				<div className="grid grid-cols-2 gap-3">
-					<div className="flex items-center justify-between rounded-lg border border-white/5 bg-slate-900/20 p-2">
-						<span className="font-mono text-[10px] text-white/40">
+					<div className="flex items-center justify-between rounded-lg border border-stroke-soft-200 bg-bg-weak-50/40 p-2 dark:border-white/5 dark:bg-slate-900/20">
+						<span className="font-mono text-[10px] text-text-sub-600 dark:text-white/40">
 							SENTIMENT
 						</span>
-						<span className="font-bold font-mono text-orange-400 text-xs">
-							⚠️ Annoyed (88%)
+						<span className="font-bold font-mono text-orange-600 text-xs dark:text-orange-400">
+							Annoyed (88%)
 						</span>
 					</div>
-					<div className="flex items-center justify-between rounded-lg border border-white/5 bg-slate-900/20 p-2">
-						<span className="font-mono text-[10px] text-white/40">INTENT</span>
-						<span className="font-bold font-mono text-indigo-400 text-xs">
-							💸 refund_request
+					<div className="flex items-center justify-between rounded-lg border border-stroke-soft-200 bg-bg-weak-50/40 p-2 dark:border-white/5 dark:bg-slate-900/20">
+						<span className="font-mono text-[10px] text-text-sub-600 dark:text-white/40">
+							INTENT
+						</span>
+						<span className="font-bold font-mono text-blue-600 text-xs dark:text-blue-400">
+							refund_request
 						</span>
 					</div>
 				</div>
 
 				{/* Draft Response Area */}
-				<div className="flex min-h-[160px] flex-1 flex-col justify-between rounded-xl border border-white/5 bg-slate-950 p-3">
+				<div className="flex min-h-[160px] flex-1 flex-col justify-between rounded-xl border border-stroke-soft-200 bg-bg-white-0 p-3 dark:border-white/5 dark:bg-slate-950">
 					<div className="flex flex-1 flex-col gap-2">
-						<div className="mb-1.5 flex items-center justify-between border-white/5 border-b pb-1.5 font-mono text-[10px] text-white/40">
+						<div className="mb-1.5 flex items-center justify-between border-stroke-soft-200 border-b pb-1.5 font-mono text-[10px] text-text-sub-600 dark:border-white/5 dark:text-white/40">
 							<span>AGENT AUTO-DRAFT RESPONSE:</span>
-							<span className="font-bold text-indigo-400">Confidence: 94%</span>
+							<span className="font-bold text-blue-600 dark:text-blue-400">
+								Confidence: 94%
+							</span>
 						</div>
 
 						{status === "pending" ? (
 							<textarea
 								value={draftBody}
 								onChange={(e) => setDraftBody(e.target.value)}
-								className="min-h-[100px] flex-1 resize-none border-0 bg-transparent font-mono text-white/70 text-xs leading-relaxed focus:outline-none"
+								className="min-h-[100px] flex-1 resize-none border-0 bg-transparent font-mono text-text-sub-600 text-xs leading-relaxed focus:outline-none dark:text-white/70"
 							/>
 						) : status === "approved" ? (
-							<div className="flex flex-1 flex-col items-center justify-center gap-2 font-mono text-emerald-400/90 text-xs italic">
-								<Icon name="CheckCircle" className="h-8 w-8 text-emerald-500" />
+							<div className="flex flex-1 flex-col items-center justify-center gap-2 font-mono text-emerald-600 text-xs italic dark:text-emerald-400/90">
+								<Icon
+									name="check-circle"
+									className="h-8 w-8 text-emerald-500"
+								/>
 								<span>
 									Draft approved & sent successfully! Webhook notification
 									fired.
 								</span>
 							</div>
 						) : (
-							<div className="flex flex-1 flex-col items-center justify-center gap-2 font-mono text-rose-400/90 text-xs italic">
-								<Icon name="XCircle" className="h-8 w-8 text-rose-500" />
+							<div className="flex flex-1 flex-col items-center justify-center gap-2 font-mono text-rose-600 text-xs italic dark:text-rose-400/90">
+								<Icon name="cross-circle" className="h-8 w-8 text-rose-500" />
 								<span>
 									Draft rejected. Thread handed over to human support agent.
 								</span>
@@ -96,19 +103,21 @@ export default function AiAgentWidget() {
 					</div>
 
 					{status === "pending" && (
-						<div className="mt-2 flex gap-2 border-white/5 border-t pt-2">
+						<div className="mt-2 flex gap-2 border-stroke-soft-200 border-t pt-2 dark:border-white/5">
 							<button
+								type="button"
 								onClick={() => setStatus("approved")}
-								className="flex flex-1 cursor-pointer items-center justify-center gap-1 rounded-lg bg-indigo-600 py-2 font-semibold text-white text-xs transition-colors hover:bg-indigo-500"
+								className="flex flex-1 cursor-pointer items-center justify-center gap-1 rounded-lg bg-blue-600 py-2 font-semibold text-white text-xs transition-colors hover:bg-blue-500"
 							>
-								<Icon name="Check" className="h-3.5 w-3.5" />
+								<Icon name="check" className="h-3.5 w-3.5" />
 								<span>Approve & Send</span>
 							</button>
 							<button
+								type="button"
 								onClick={() => setStatus("rejected")}
-								className="flex cursor-pointer items-center justify-center gap-1 rounded-lg border border-white/10 bg-slate-900 px-3 py-2 font-semibold text-white/70 text-xs transition-colors hover:bg-slate-800"
+								className="flex cursor-pointer items-center justify-center gap-1 rounded-lg border border-stroke-soft-200 bg-bg-white-0 px-3 py-2 font-semibold text-text-sub-600 text-xs transition-colors hover:bg-bg-weak-50 dark:border-white/10 dark:bg-slate-900 dark:text-white/70 dark:hover:bg-slate-800"
 							>
-								<Icon name="Trash2" className="h-3.5 w-3.5" />
+								<Icon name="trash-2" className="h-3.5 w-3.5" />
 								<span>Escalate</span>
 							</button>
 						</div>

--- a/apps/frontend/web/src/components/landing/use-cases/widgets/automated.tsx
+++ b/apps/frontend/web/src/components/landing/use-cases/widgets/automated.tsx
@@ -45,28 +45,30 @@ export default function AutomatedWidget() {
 	};
 
 	return (
-		<div className="flex h-full min-h-[420px] flex-col overflow-hidden rounded-2xl border border-white/10 bg-slate-950 text-left font-sans shadow-2xl">
+		<div className="flex h-full min-h-[420px] flex-col overflow-hidden rounded-2xl border border-stroke-soft-200 bg-bg-white-0 text-left font-sans shadow-lg dark:border-white/10 dark:bg-slate-950 dark:shadow-2xl">
 			{/* Designer Header */}
-			<div className="flex items-center justify-between border-white/5 border-b bg-slate-900 px-4 py-3">
+			<div className="flex items-center justify-between border-stroke-soft-200 border-b bg-bg-weak-50 px-4 py-3 dark:border-white/5 dark:bg-slate-900">
 				<div className="flex items-center gap-1.5">
 					<span className="h-2.5 w-2.5 rounded-full bg-violet-500/80" />
 					<span className="h-2.5 w-2.5 rounded-full bg-yellow-500/80" />
 					<span className="h-2.5 w-2.5 rounded-full bg-green-500/80" />
-					<span className="ml-2 font-mono text-white/40 text-xs">
+					<span className="ml-2 font-mono text-text-sub-600 text-xs dark:text-white/40">
 						welcome_series_drip.workflow
 					</span>
 				</div>
-				<span className="rounded border border-violet-500/20 bg-violet-500/10 px-2 py-0.5 font-mono text-[10px] text-violet-400">
+				<span className="rounded border border-violet-500/20 bg-violet-500/10 px-2 py-0.5 font-mono text-[10px] text-violet-600 dark:text-violet-400">
 					Drip Engine
 				</span>
 			</div>
 
 			<div className="flex flex-1 flex-col gap-6 p-5">
 				{/* Header & Control Button */}
-				<div className="flex items-center justify-between rounded-xl border border-white/5 bg-slate-900/40 p-3">
+				<div className="flex items-center justify-between rounded-xl border border-stroke-soft-200 bg-bg-weak-50/60 p-3 dark:border-white/5 dark:bg-slate-900/40">
 					<div>
-						<div className="font-mono text-white/40 text-xs">TRIGGER EVENT</div>
-						<div className="mt-0.5 font-mono font-semibold text-white/70 text-xs">
+						<div className="font-mono text-text-sub-600 text-xs dark:text-white/40">
+							TRIGGER EVENT
+						</div>
+						<div className="mt-0.5 font-mono font-semibold text-text-sub-600 text-xs dark:text-white/70">
 							user.registered
 						</div>
 					</div>
@@ -75,7 +77,7 @@ export default function AutomatedWidget() {
 						disabled={isRunning}
 						className={`cursor-pointer rounded-lg px-4 py-2 font-medium text-xs transition-all ${
 							isRunning
-								? "cursor-not-allowed bg-slate-800 text-white/40"
+								? "cursor-not-allowed bg-stroke-soft-200 text-text-sub-600 dark:bg-slate-800 dark:text-white/40"
 								: "bg-violet-600 text-white shadow-lg shadow-violet-500/20 hover:bg-violet-500 active:scale-95"
 						}`}
 					>
@@ -84,7 +86,7 @@ export default function AutomatedWidget() {
 				</div>
 
 				{/* SVG Flow canvas */}
-				<div className="relative flex min-h-[220px] flex-1 flex-col items-center justify-center overflow-hidden rounded-xl border border-white/5 bg-slate-900/20 p-4">
+				<div className="relative flex min-h-[220px] flex-1 flex-col items-center justify-center overflow-hidden rounded-xl border border-stroke-soft-200 bg-bg-weak-50/40 p-4 dark:border-white/5 dark:bg-slate-900/20">
 					{/* SVG Connector Paths */}
 					<svg
 						className="pointer-events-none absolute inset-0 h-full w-full"
@@ -140,8 +142,8 @@ export default function AutomatedWidget() {
 						<div
 							className={`flex items-center gap-1.5 rounded-lg border px-3 py-1.5 font-mono text-xs transition-all ${
 								activeNode === 0
-									? "border-violet-500 bg-violet-950 text-violet-300 ring-2 ring-violet-500/20"
-									: "border-white/5 bg-slate-900 text-white/50"
+									? "border-violet-500 bg-violet-50 text-violet-600 ring-2 ring-violet-500/20 dark:bg-violet-950 dark:text-violet-300"
+									: "border-stroke-soft-200 bg-bg-weak-50 text-text-sub-600 dark:border-white/5 dark:bg-slate-900 dark:text-white/50"
 							}`}
 						>
 							<Icon name="Activity" className="h-3.5 w-3.5" />
@@ -152,8 +154,8 @@ export default function AutomatedWidget() {
 						<div
 							className={`flex items-center gap-1.5 rounded-lg border px-3 py-1.5 font-mono text-xs transition-all ${
 								activeNode === 1
-									? "border-violet-500 bg-violet-950 text-violet-300 ring-2 ring-violet-500/20"
-									: "border-white/5 bg-slate-900 text-white/50"
+									? "border-violet-500 bg-violet-50 text-violet-600 ring-2 ring-violet-500/20 dark:bg-violet-950 dark:text-violet-300"
+									: "border-stroke-soft-200 bg-bg-weak-50 text-text-sub-600 dark:border-white/5 dark:bg-slate-900 dark:text-white/50"
 							}`}
 						>
 							<Icon name="Clock" className="h-3.5 w-3.5" />
@@ -164,8 +166,8 @@ export default function AutomatedWidget() {
 						<div
 							className={`flex items-center gap-1.5 rounded-lg border px-3 py-1.5 font-mono text-xs transition-all ${
 								activeNode === 2
-									? "border-violet-500 bg-violet-950 text-violet-300 ring-2 ring-violet-500/20"
-									: "border-white/5 bg-slate-900 text-white/50"
+									? "border-violet-500 bg-violet-50 text-violet-600 ring-2 ring-violet-500/20 dark:bg-violet-950 dark:text-violet-300"
+									: "border-stroke-soft-200 bg-bg-weak-50 text-text-sub-600 dark:border-white/5 dark:bg-slate-900 dark:text-white/50"
 							}`}
 						>
 							<Icon name="Mail" className="h-3.5 w-3.5" />
@@ -176,8 +178,8 @@ export default function AutomatedWidget() {
 						<div
 							className={`flex items-center gap-1.5 rounded-lg border px-3 py-1.5 font-mono text-xs transition-all ${
 								activeNode >= 3
-									? "border-violet-500 bg-violet-950 text-violet-300 ring-2 ring-violet-500/20"
-									: "border-white/5 bg-slate-900 text-white/50"
+									? "border-violet-500 bg-violet-50 text-violet-600 ring-2 ring-violet-500/20 dark:bg-violet-950 dark:text-violet-300"
+									: "border-stroke-soft-200 bg-bg-weak-50 text-text-sub-600 dark:border-white/5 dark:bg-slate-900 dark:text-white/50"
 							}`}
 						>
 							<Icon name="GitFork" className="h-3.5 w-3.5" />
@@ -190,11 +192,14 @@ export default function AutomatedWidget() {
 							<div
 								className={`flex items-center gap-1 rounded-lg border px-3 py-1.5 font-mono text-[11px] transition-all ${
 									activeNode === 5
-										? "border-emerald-500 bg-emerald-950 text-emerald-300 ring-2 ring-emerald-500/20"
-										: "border-white/5 bg-slate-900/60 text-white/30"
+										? "border-emerald-500 bg-emerald-50 text-emerald-600 ring-2 ring-emerald-500/20 dark:bg-emerald-950 dark:text-emerald-300"
+										: "border-stroke-soft-200 bg-bg-weak-50/60 text-text-soft-400 dark:border-white/5 dark:bg-slate-900/60 dark:text-white/30"
 								}`}
 							>
-								<Icon name="Percent" className="h-3 w-3 text-emerald-400" />
+								<Icon
+									name="Percent"
+									className="h-3 w-3 text-emerald-600 dark:text-emerald-400"
+								/>
 								<span>Yes: Send 20% Off coupon</span>
 							</div>
 
@@ -202,11 +207,14 @@ export default function AutomatedWidget() {
 							<div
 								className={`flex items-center gap-1 rounded-lg border px-3 py-1.5 font-mono text-[11px] transition-all ${
 									activeNode === 6
-										? "border-rose-500 bg-rose-950 text-rose-300 ring-2 ring-rose-500/20"
-										: "border-white/5 bg-slate-900/60 text-white/30"
+										? "border-rose-500 bg-rose-50 text-rose-600 ring-2 ring-rose-500/20 dark:bg-rose-950 dark:text-rose-300"
+										: "border-stroke-soft-200 bg-bg-weak-50/60 text-text-soft-400 dark:border-white/5 dark:bg-slate-900/60 dark:text-white/30"
 								}`}
 							>
-								<Icon name="Tag" className="h-3 w-3 text-rose-400" />
+								<Icon
+									name="Tag"
+									className="h-3 w-3 text-rose-600 dark:text-rose-400"
+								/>
 								<span>No: Tag "Unengaged"</span>
 							</div>
 						</div>

--- a/apps/frontend/web/src/components/landing/use-cases/widgets/email-verification.tsx
+++ b/apps/frontend/web/src/components/landing/use-cases/widgets/email-verification.tsx
@@ -31,27 +31,27 @@ export default function EmailVerificationWidget() {
 	return (
 		<div className="flex h-full min-h-[420px] flex-col justify-between overflow-hidden rounded-2xl border border-stroke-soft-200 bg-bg-white-0 text-left font-sans shadow-lg dark:border-white/10 dark:bg-slate-950 dark:shadow-2xl">
 			{/* Header */}
-			<div className="flex items-center justify-between border-stroke-soft-200 border-b bg-bg-weak-50 px-4 py-3 dark:border-white/5 dark:bg-slate-900">
-				<div className="flex items-center gap-1.5">
-					<span className="h-2.5 w-2.5 rounded-full bg-violet-500/80" />
-					<span className="h-2.5 w-2.5 rounded-full bg-yellow-500/80" />
-					<span className="h-2.5 w-2.5 rounded-full bg-green-500/80" />
-					<span className="ml-2 font-mono text-text-sub-600 text-xs dark:text-white/40">
+			<div className="flex items-center justify-between gap-3 border-stroke-soft-200 border-b bg-bg-weak-50 px-4 py-3 dark:border-white/5 dark:bg-slate-900">
+				<div className="flex min-w-0 items-center gap-1.5">
+					<span className="h-2.5 w-2.5 shrink-0 rounded-full bg-violet-500/80" />
+					<span className="h-2.5 w-2.5 shrink-0 rounded-full bg-yellow-500/80" />
+					<span className="h-2.5 w-2.5 shrink-0 rounded-full bg-green-500/80" />
+					<span className="ml-2 truncate font-mono text-text-sub-600 text-xs dark:text-white/40">
 						secure_magic_authenticator.json
 					</span>
 				</div>
-				<span className="rounded border border-violet-500/20 bg-violet-500/10 px-2 py-0.5 font-mono text-[10px] text-violet-600 dark:text-violet-400">
+				<span className="ml-auto shrink-0 rounded border border-violet-500/20 bg-violet-500/10 px-2 py-0.5 font-mono text-[10px] text-violet-600 dark:text-violet-400">
 					Identity OTP
 				</span>
 			</div>
 
 			{/* Main Content Area */}
 			<div className="flex flex-1 flex-col items-center justify-center p-5">
-				<div className="flex w-full max-w-[280px] flex-col gap-4 rounded-2xl border border-stroke-soft-200 bg-bg-weak-50 p-5 text-center shadow-xl dark:border-white/5 dark:bg-slate-900">
+				<div className="mt-10 flex w-full max-w-[280px] flex-col gap-4 rounded-2xl border border-stroke-soft-200 bg-bg-weak-50 p-5 text-center shadow-xl dark:border-white/5 dark:bg-slate-900">
 					{step === "request" && (
 						<>
 							<div className="mx-auto flex h-10 w-10 items-center justify-center rounded-full border border-violet-500/20 bg-violet-500/10 text-violet-600 dark:text-violet-400">
-								<Icon name="ShieldAlert" className="h-5 w-5" />
+								<Icon name="fingerprint" className="h-5 w-5" />
 							</div>
 							<div>
 								<h3 className="font-bold text-text-strong-950 text-xs dark:text-white">
@@ -91,7 +91,7 @@ export default function EmailVerificationWidget() {
 					{step === "verify" && (
 						<>
 							<div className="mx-auto flex h-10 w-10 items-center justify-center rounded-full border border-violet-500/20 bg-violet-500/10 text-violet-600 dark:text-violet-400">
-								<Icon name="KeyRound" className="h-5 w-5" />
+								<Icon name="key" className="h-5 w-5" />
 							</div>
 							<div>
 								<h3 className="font-bold text-text-strong-950 text-xs dark:text-white">
@@ -129,7 +129,7 @@ export default function EmailVerificationWidget() {
 					{step === "success" && (
 						<>
 							<div className="mx-auto flex h-10 w-10 items-center justify-center rounded-full border border-emerald-500/50 bg-emerald-500/20 text-emerald-600 dark:text-emerald-400">
-								<Icon name="Check" className="h-5 w-5" />
+								<Icon name="check" className="h-5 w-5" />
 							</div>
 							<div>
 								<h3 className="font-bold text-text-strong-950 text-xs dark:text-white">

--- a/apps/frontend/web/src/components/landing/use-cases/widgets/email-verification.tsx
+++ b/apps/frontend/web/src/components/landing/use-cases/widgets/email-verification.tsx
@@ -29,35 +29,35 @@ export default function EmailVerificationWidget() {
 	};
 
 	return (
-		<div className="flex h-full min-h-[420px] flex-col justify-between overflow-hidden rounded-2xl border border-white/10 bg-slate-950 text-left font-sans shadow-2xl">
+		<div className="flex h-full min-h-[420px] flex-col justify-between overflow-hidden rounded-2xl border border-stroke-soft-200 bg-bg-white-0 text-left font-sans shadow-lg dark:border-white/10 dark:bg-slate-950 dark:shadow-2xl">
 			{/* Header */}
-			<div className="flex items-center justify-between border-white/5 border-b bg-slate-900 px-4 py-3">
+			<div className="flex items-center justify-between border-stroke-soft-200 border-b bg-bg-weak-50 px-4 py-3 dark:border-white/5 dark:bg-slate-900">
 				<div className="flex items-center gap-1.5">
 					<span className="h-2.5 w-2.5 rounded-full bg-violet-500/80" />
 					<span className="h-2.5 w-2.5 rounded-full bg-yellow-500/80" />
 					<span className="h-2.5 w-2.5 rounded-full bg-green-500/80" />
-					<span className="ml-2 font-mono text-white/40 text-xs">
+					<span className="ml-2 font-mono text-text-sub-600 text-xs dark:text-white/40">
 						secure_magic_authenticator.json
 					</span>
 				</div>
-				<span className="rounded border border-violet-500/20 bg-violet-500/10 px-2 py-0.5 font-mono text-[10px] text-violet-400">
+				<span className="rounded border border-violet-500/20 bg-violet-500/10 px-2 py-0.5 font-mono text-[10px] text-violet-600 dark:text-violet-400">
 					Identity OTP
 				</span>
 			</div>
 
 			{/* Main Content Area */}
 			<div className="flex flex-1 flex-col items-center justify-center p-5">
-				<div className="flex w-full max-w-[280px] flex-col gap-4 rounded-2xl border border-white/5 bg-slate-900 p-5 text-center shadow-xl">
+				<div className="flex w-full max-w-[280px] flex-col gap-4 rounded-2xl border border-stroke-soft-200 bg-bg-weak-50 p-5 text-center shadow-xl dark:border-white/5 dark:bg-slate-900">
 					{step === "request" && (
 						<>
-							<div className="mx-auto flex h-10 w-10 items-center justify-center rounded-full border border-violet-500/20 bg-violet-500/10 text-violet-400">
+							<div className="mx-auto flex h-10 w-10 items-center justify-center rounded-full border border-violet-500/20 bg-violet-500/10 text-violet-600 dark:text-violet-400">
 								<Icon name="ShieldAlert" className="h-5 w-5" />
 							</div>
 							<div>
-								<h3 className="font-bold text-white text-xs">
+								<h3 className="font-bold text-text-strong-950 text-xs dark:text-white">
 									Secure Verification
 								</h3>
-								<p className="mt-1 text-[10px] text-white/40">
+								<p className="mt-1 text-[10px] text-text-sub-600 dark:text-white/40">
 									We'll send a 6-digit magic code to your email.
 								</p>
 							</div>
@@ -71,9 +71,13 @@ export default function EmailVerificationWidget() {
 										setError("");
 									}}
 									placeholder="enter email address"
-									className="w-full rounded-lg border border-white/10 bg-slate-950 px-3 py-1.5 text-center text-white text-xs focus:border-violet-500/50 focus:outline-none"
+									className="w-full rounded-lg border border-stroke-soft-200 bg-bg-white-0 px-3 py-1.5 text-center text-text-strong-950 text-xs focus:border-violet-500/50 focus:outline-none dark:border-white/10 dark:bg-slate-950 dark:text-white"
 								/>
-								{error && <p className="text-[9px] text-red-400">{error}</p>}
+								{error && (
+									<p className="text-[9px] text-red-600 dark:text-red-400">
+										{error}
+									</p>
+								)}
 								<button
 									onClick={sendCode}
 									className="w-full cursor-pointer rounded-lg bg-violet-600 py-1.5 font-semibold text-white text-xs transition-colors hover:bg-violet-500"
@@ -86,12 +90,14 @@ export default function EmailVerificationWidget() {
 
 					{step === "verify" && (
 						<>
-							<div className="mx-auto flex h-10 w-10 items-center justify-center rounded-full border border-violet-500/20 bg-violet-500/10 text-violet-400">
+							<div className="mx-auto flex h-10 w-10 items-center justify-center rounded-full border border-violet-500/20 bg-violet-500/10 text-violet-600 dark:text-violet-400">
 								<Icon name="KeyRound" className="h-5 w-5" />
 							</div>
 							<div>
-								<h3 className="font-bold text-white text-xs">Verify Account</h3>
-								<p className="mt-1 text-[10px] text-white/40">
+								<h3 className="font-bold text-text-strong-950 text-xs dark:text-white">
+									Verify Account
+								</h3>
+								<p className="mt-1 text-[10px] text-text-sub-600 dark:text-white/40">
 									Enter the 6-digit verification code sent below.
 								</p>
 							</div>
@@ -103,12 +109,16 @@ export default function EmailVerificationWidget() {
 									value={otp}
 									onChange={(e) => checkOtp(e.target.value)}
 									placeholder="------"
-									className="w-full rounded-lg border border-white/10 bg-slate-950 px-3 py-2 text-center font-bold font-mono text-sm text-white tracking-widest focus:border-violet-500/50 focus:outline-none"
+									className="w-full rounded-lg border border-stroke-soft-200 bg-bg-white-0 px-3 py-2 text-center font-bold font-mono text-sm text-text-strong-950 tracking-widest focus:border-violet-500/50 focus:outline-none dark:border-white/10 dark:bg-slate-950 dark:text-white"
 								/>
-								{error && <p className="text-[9px] text-red-400">{error}</p>}
+								{error && (
+									<p className="text-[9px] text-red-600 dark:text-red-400">
+										{error}
+									</p>
+								)}
 								<button
 									onClick={() => setStep("request")}
-									className="cursor-pointer font-mono text-[9px] text-white/40 transition-colors hover:text-white/60"
+									className="cursor-pointer font-mono text-[9px] text-text-sub-600 transition-colors hover:text-text-sub-600 dark:text-white/40 dark:hover:text-white/60"
 								>
 									← Go Back
 								</button>
@@ -118,14 +128,14 @@ export default function EmailVerificationWidget() {
 
 					{step === "success" && (
 						<>
-							<div className="mx-auto flex h-10 w-10 items-center justify-center rounded-full border border-emerald-500/50 bg-emerald-500/20 text-emerald-400">
+							<div className="mx-auto flex h-10 w-10 items-center justify-center rounded-full border border-emerald-500/50 bg-emerald-500/20 text-emerald-600 dark:text-emerald-400">
 								<Icon name="Check" className="h-5 w-5" />
 							</div>
 							<div>
-								<h3 className="font-bold text-white text-xs">
+								<h3 className="font-bold text-text-strong-950 text-xs dark:text-white">
 									Identity Verified
 								</h3>
-								<p className="mt-1 text-[10px] text-white/40">
+								<p className="mt-1 text-[10px] text-text-sub-600 dark:text-white/40">
 									Token confirmed. You have successfully authenticated.
 								</p>
 							</div>
@@ -134,7 +144,7 @@ export default function EmailVerificationWidget() {
 									setStep("request");
 									setOtp("");
 								}}
-								className="w-full cursor-pointer rounded-lg bg-slate-800 py-1.5 font-medium text-white text-xs transition-colors hover:bg-slate-700"
+								className="w-full cursor-pointer rounded-lg bg-stroke-soft-200 py-1.5 font-medium text-text-strong-950 text-xs transition-colors hover:bg-stroke-sub-300 dark:bg-slate-800 dark:text-white dark:hover:bg-slate-700"
 							>
 								Test Again
 							</button>
@@ -145,21 +155,25 @@ export default function EmailVerificationWidget() {
 
 			{/* Mock Inbox Message Notification Area */}
 			{step === "verify" && (
-				<div className="flex flex-col gap-1.5 border-white/5 border-t bg-slate-900 p-3">
-					<div className="font-mono text-[9px] text-white/30">
+				<div className="flex flex-col gap-1.5 border-stroke-soft-200 border-t bg-bg-weak-50 p-3 dark:border-white/5 dark:bg-slate-900">
+					<div className="font-mono text-[9px] text-text-soft-400 dark:text-white/30">
 						SIMULATED RECIPIENT INBOX ({email})
 					</div>
-					<div className="flex items-center justify-between rounded-lg border border-white/5 bg-slate-950 p-2.5 text-[10px]">
+					<div className="flex items-center justify-between rounded-lg border border-stroke-soft-200 bg-bg-white-0 p-2.5 text-[10px] dark:border-white/5 dark:bg-slate-950">
 						<div>
-							<div className="font-bold text-white/80">
+							<div className="font-bold text-text-strong-950 dark:text-white/80">
 								🛡️ Reloop Verification System
 							</div>
-							<div className="mt-0.5 text-[9px] text-white/45">
+							<div className="mt-0.5 text-[9px] text-text-sub-600 dark:text-white/45">
 								Your Reloop login code is:{" "}
-								<strong className="font-mono text-violet-400">728109</strong>
+								<strong className="font-mono text-violet-600 dark:text-violet-400">
+									728109
+								</strong>
 							</div>
 						</div>
-						<span className="font-mono text-[8px] text-white/30">Just Now</span>
+						<span className="font-mono text-[8px] text-text-soft-400 dark:text-white/30">
+							Just Now
+						</span>
 					</div>
 				</div>
 			)}

--- a/apps/frontend/web/src/components/landing/use-cases/widgets/inbound.tsx
+++ b/apps/frontend/web/src/components/landing/use-cases/widgets/inbound.tsx
@@ -49,64 +49,64 @@ export default function InboundWidget() {
 	);
 
 	return (
-		<div className="flex h-full min-h-[420px] flex-col overflow-hidden rounded-2xl border border-white/10 bg-slate-950 text-left font-sans shadow-2xl">
+		<div className="flex h-full min-h-[420px] flex-col overflow-hidden rounded-2xl border border-stroke-soft-200 bg-bg-white-0 text-left font-sans shadow-lg dark:border-white/10 dark:bg-slate-950 dark:shadow-2xl">
 			{/* Header */}
-			<div className="flex items-center justify-between border-white/5 border-b bg-slate-900 px-4 py-3">
+			<div className="flex items-center justify-between border-stroke-soft-200 border-b bg-bg-weak-50 px-4 py-3 dark:border-white/5 dark:bg-slate-900">
 				<div className="flex items-center gap-1.5">
 					<span className="h-2.5 w-2.5 rounded-full bg-cyan-500/80" />
 					<span className="h-2.5 w-2.5 rounded-full bg-yellow-500/80" />
 					<span className="h-2.5 w-2.5 rounded-full bg-green-500/80" />
-					<span className="ml-2 font-mono text-white/40 text-xs">
+					<span className="ml-2 font-mono text-text-sub-600 text-xs dark:text-white/40">
 						inbound_router.json
 					</span>
 				</div>
-				<span className="rounded border border-cyan-500/20 bg-cyan-500/10 px-2 py-0.5 font-mono text-[10px] text-cyan-400">
+				<span className="rounded border border-cyan-500/20 bg-cyan-500/10 px-2 py-0.5 font-mono text-[10px] text-cyan-600 dark:text-cyan-400">
 					MX Webhook Relay
 				</span>
 			</div>
 
 			<div className="grid flex-1 grid-cols-1 overflow-hidden lg:grid-cols-2">
 				{/* Left Side: Mock Email Input Form */}
-				<div className="flex flex-col gap-3.5 border-white/5 border-b bg-slate-950/40 p-4 lg:border-r lg:border-b-0">
-					<h3 className="flex items-center gap-1 font-bold text-white/40 text-xs uppercase tracking-wider">
+				<div className="flex flex-col gap-3.5 border-stroke-soft-200 border-b bg-bg-weak-50/40 p-4 lg:border-r lg:border-b-0 dark:border-white/5 dark:bg-slate-950/40">
+					<h3 className="flex items-center gap-1 font-bold text-text-sub-600 text-xs uppercase tracking-wider dark:text-white/40">
 						<Icon name="Mail" className="h-3.5 w-3.5" />
 						<span>Compose Inbound Email</span>
 					</h3>
 
 					<div className="flex flex-col gap-2.5">
 						<div>
-							<label className="mb-1 block font-mono text-[10px] text-white/40">
+							<label className="mb-1 block font-mono text-[10px] text-text-sub-600 dark:text-white/40">
 								FROM SENDER
 							</label>
 							<input
 								type="text"
 								value={sender}
 								onChange={(e) => setSender(e.target.value)}
-								className="w-full rounded-lg border border-white/10 bg-slate-900 px-3 py-1.5 font-mono text-white/80 text-xs focus:border-cyan-500/50 focus:outline-none"
+								className="w-full rounded-lg border border-stroke-soft-200 bg-bg-weak-50 px-3 py-1.5 font-mono text-text-strong-950 text-xs focus:border-cyan-500/50 focus:outline-none dark:border-white/10 dark:bg-slate-900 dark:text-white/80"
 							/>
 						</div>
 
 						<div>
-							<label className="mb-1 block font-mono text-[10px] text-white/40">
+							<label className="mb-1 block font-mono text-[10px] text-text-sub-600 dark:text-white/40">
 								SUBJECT LINE
 							</label>
 							<input
 								type="text"
 								value={subject}
 								onChange={(e) => setSubject(e.target.value)}
-								className="w-full rounded-lg border border-white/10 bg-slate-900 px-3 py-1.5 text-white/80 text-xs focus:border-cyan-500/50 focus:outline-none"
+								className="w-full rounded-lg border border-stroke-soft-200 bg-bg-weak-50 px-3 py-1.5 text-text-strong-950 text-xs focus:border-cyan-500/50 focus:outline-none dark:border-white/10 dark:bg-slate-900 dark:text-white/80"
 							/>
 						</div>
 
 						<div>
-							<label className="mb-1 block font-mono text-[10px] text-white/40">
+							<label className="mb-1 block font-mono text-[10px] text-text-sub-600 dark:text-white/40">
 								MESSAGE BODY
 							</label>
 							<textarea
 								value={body}
 								onChange={(e) => setBody(e.target.value)}
 								rows={3}
-								className="w-full resize-none rounded-lg border border-white/10 bg-slate-900 px-3 py-1.5 text-white/80 text-xs leading-relaxed focus:border-cyan-500/50 focus:outline-none"
+								className="w-full resize-none rounded-lg border border-stroke-soft-200 bg-bg-weak-50 px-3 py-1.5 text-text-strong-950 text-xs leading-relaxed focus:border-cyan-500/50 focus:outline-none dark:border-white/10 dark:bg-slate-900 dark:text-white/80"
 							/>
 						</div>
 
@@ -115,8 +115,8 @@ export default function InboundWidget() {
 							onClick={() => setHasAttachment(!hasAttachment)}
 							className={`flex cursor-pointer items-center justify-between rounded-lg border p-2 text-left transition-all ${
 								hasAttachment
-									? "border-cyan-500/30 bg-cyan-950/20 text-cyan-300"
-									: "border-white/5 bg-slate-900 text-white/40"
+									? "border-cyan-500/30 bg-cyan-50 text-cyan-600 dark:bg-cyan-950/20 dark:text-cyan-300"
+									: "border-stroke-soft-200 bg-bg-weak-50 text-text-sub-600 dark:border-white/5 dark:bg-slate-900 dark:text-white/40"
 							}`}
 						>
 							<div className="flex items-center gap-1.5 text-xs">
@@ -124,7 +124,7 @@ export default function InboundWidget() {
 								<span>Include 100KB Screenshot</span>
 							</div>
 							<div
-								className={`h-3 w-3 rounded-full border transition-colors ${hasAttachment ? "border-cyan-400 bg-cyan-400" : "border-white/20"}`}
+								className={`h-3 w-3 rounded-full border transition-colors ${hasAttachment ? "border-cyan-400 bg-cyan-400" : "border-stroke-soft-200 dark:border-white/20"}`}
 							/>
 						</button>
 					</div>
@@ -132,16 +132,16 @@ export default function InboundWidget() {
 
 				{/* Right Side: Parsed Webhook JSON Output */}
 				<div className="flex flex-col gap-2.5 overflow-hidden p-4">
-					<h3 className="flex items-center justify-between gap-1 font-bold text-white/40 text-xs uppercase tracking-wider">
+					<h3 className="flex items-center justify-between gap-1 font-bold text-text-sub-600 text-xs uppercase tracking-wider dark:text-white/40">
 						<span className="flex items-center gap-1">
 							<Icon name="Code" className="h-3.5 w-3.5" />
 							<span>Webhook Payload Delivery</span>
 						</span>
-						<span className="font-mono text-[10px] text-emerald-400">
+						<span className="font-mono text-[10px] text-emerald-600 dark:text-emerald-400">
 							POST 200 OK
 						</span>
 					</h3>
-					<pre className="max-h-[260px] flex-1 overflow-auto rounded-xl border border-white/5 bg-slate-900 p-3 text-left font-mono text-[10px] text-cyan-300/80 leading-relaxed">
+					<pre className="max-h-[260px] flex-1 overflow-auto rounded-xl border border-stroke-soft-200 bg-bg-weak-50 p-3 text-left font-mono text-[10px] text-cyan-700 leading-relaxed dark:border-white/5 dark:bg-slate-900 dark:text-cyan-300/80">
 						{generatedJson}
 					</pre>
 				</div>

--- a/apps/frontend/web/src/components/landing/use-cases/widgets/marketing.tsx
+++ b/apps/frontend/web/src/components/landing/use-cases/widgets/marketing.tsx
@@ -14,18 +14,18 @@ export default function MarketingWidget() {
 	const clickRate = 2.4 + (hasCTA ? 1.8 : 0) + (hasPromo ? 2.5 : 0);
 
 	return (
-		<div className="flex h-full min-h-[420px] flex-col overflow-hidden rounded-2xl border border-white/10 bg-slate-950 font-sans shadow-2xl">
+		<div className="flex h-full min-h-[420px] flex-col overflow-hidden rounded-2xl border border-stroke-soft-200 bg-bg-white-0 font-sans shadow-lg dark:border-white/10 dark:bg-slate-950 dark:shadow-2xl">
 			{/* Designer Header */}
-			<div className="flex items-center justify-between border-white/5 border-b bg-slate-900 px-4 py-3">
+			<div className="flex items-center justify-between border-stroke-soft-200 border-b bg-bg-weak-50 px-4 py-3 dark:border-white/5 dark:bg-slate-900">
 				<div className="flex items-center gap-1.5">
 					<span className="h-2.5 w-2.5 rounded-full bg-rose-500/80" />
 					<span className="h-2.5 w-2.5 rounded-full bg-yellow-500/80" />
 					<span className="h-2.5 w-2.5 rounded-full bg-green-500/80" />
-					<span className="ml-2 font-mono text-white/40 text-xs">
+					<span className="ml-2 font-mono text-text-sub-600 text-xs dark:text-white/40">
 						campaign_builder_v2.email
 					</span>
 				</div>
-				<span className="rounded border border-rose-500/20 bg-rose-500/10 px-2 py-0.5 font-mono text-[10px] text-rose-400">
+				<span className="rounded border border-rose-500/20 bg-rose-500/10 px-2 py-0.5 font-mono text-[10px] text-rose-600 dark:text-rose-400">
 					Builder Mode
 				</span>
 			</div>
@@ -33,8 +33,8 @@ export default function MarketingWidget() {
 			<div className="grid flex-1 grid-cols-1 gap-4 p-4 md:grid-cols-2">
 				{/* Editor & Stats Control */}
 				<div className="flex flex-col justify-between gap-4">
-					<div className="flex flex-col gap-3 rounded-xl border border-white/5 bg-slate-900/40 p-4">
-						<h3 className="font-bold text-white/40 text-xs uppercase tracking-wider">
+					<div className="flex flex-col gap-3 rounded-xl border border-stroke-soft-200 bg-bg-weak-50/60 p-4 dark:border-white/5 dark:bg-slate-900/40">
+						<h3 className="font-bold text-text-sub-600 text-xs uppercase tracking-wider dark:text-white/40">
 							Email Elements
 						</h3>
 
@@ -44,8 +44,8 @@ export default function MarketingWidget() {
 								onClick={() => setHasHero(!hasHero)}
 								className={`flex cursor-pointer items-center justify-between rounded-lg border p-2.5 text-left transition-all ${
 									hasHero
-										? "border-rose-500/30 bg-rose-950/20 text-rose-300"
-										: "border-white/5 bg-slate-900/60 text-white/40"
+										? "border-rose-500/30 bg-rose-50 text-rose-600 dark:bg-rose-950/20 dark:text-rose-300"
+										: "border-stroke-soft-200 bg-bg-weak-50/60 text-text-sub-600 dark:border-white/5 dark:bg-slate-900/60 dark:text-white/40"
 								}`}
 							>
 								<div className="flex items-center gap-2">
@@ -53,7 +53,7 @@ export default function MarketingWidget() {
 									<span className="font-medium text-xs">Hero Image Block</span>
 								</div>
 								<div
-									className={`h-4 w-6 rounded-full p-0.5 transition-colors ${hasHero ? "bg-rose-500" : "bg-slate-800"}`}
+									className={`h-4 w-6 rounded-full p-0.5 transition-colors ${hasHero ? "bg-rose-500" : "bg-stroke-soft-200 dark:bg-slate-800"}`}
 								>
 									<div
 										className={`h-3 w-3 rounded-full bg-white transition-transform ${hasHero ? "translate-x-2" : "translate-x-0"}`}
@@ -65,8 +65,8 @@ export default function MarketingWidget() {
 								onClick={() => setHasPromo(!hasPromo)}
 								className={`flex cursor-pointer items-center justify-between rounded-lg border p-2.5 text-left transition-all ${
 									hasPromo
-										? "border-rose-500/30 bg-rose-950/20 text-rose-300"
-										: "border-white/5 bg-slate-900/60 text-white/40"
+										? "border-rose-500/30 bg-rose-50 text-rose-600 dark:bg-rose-950/20 dark:text-rose-300"
+										: "border-stroke-soft-200 bg-bg-weak-50/60 text-text-sub-600 dark:border-white/5 dark:bg-slate-900/60 dark:text-white/40"
 								}`}
 							>
 								<div className="flex items-center gap-2">
@@ -76,7 +76,7 @@ export default function MarketingWidget() {
 									</span>
 								</div>
 								<div
-									className={`h-4 w-6 rounded-full p-0.5 transition-colors ${hasPromo ? "bg-rose-500" : "bg-slate-800"}`}
+									className={`h-4 w-6 rounded-full p-0.5 transition-colors ${hasPromo ? "bg-rose-500" : "bg-stroke-soft-200 dark:bg-slate-800"}`}
 								>
 									<div
 										className={`h-3 w-3 rounded-full bg-white transition-transform ${hasPromo ? "translate-x-2" : "translate-x-0"}`}
@@ -88,8 +88,8 @@ export default function MarketingWidget() {
 								onClick={() => setHasCTA(!hasCTA)}
 								className={`flex cursor-pointer items-center justify-between rounded-lg border p-2.5 text-left transition-all ${
 									hasCTA
-										? "border-rose-500/30 bg-rose-950/20 text-rose-300"
-										: "border-white/5 bg-slate-900/60 text-white/40"
+										? "border-rose-500/30 bg-rose-50 text-rose-600 dark:bg-rose-950/20 dark:text-rose-300"
+										: "border-stroke-soft-200 bg-bg-weak-50/60 text-text-sub-600 dark:border-white/5 dark:bg-slate-900/60 dark:text-white/40"
 								}`}
 							>
 								<div className="flex items-center gap-2">
@@ -99,7 +99,7 @@ export default function MarketingWidget() {
 									</span>
 								</div>
 								<div
-									className={`h-4 w-6 rounded-full p-0.5 transition-colors ${hasCTA ? "bg-rose-500" : "bg-slate-800"}`}
+									className={`h-4 w-6 rounded-full p-0.5 transition-colors ${hasCTA ? "bg-rose-500" : "bg-stroke-soft-200 dark:bg-slate-800"}`}
 								>
 									<div
 										className={`h-3 w-3 rounded-full bg-white transition-transform ${hasCTA ? "translate-x-2" : "translate-x-0"}`}
@@ -110,30 +110,30 @@ export default function MarketingWidget() {
 					</div>
 
 					{/* Campaign Analytics Simulation */}
-					<div className="rounded-xl border border-white/5 bg-slate-900/40 p-4">
-						<h3 className="mb-3 font-bold text-white/40 text-xs uppercase tracking-wider">
+					<div className="rounded-xl border border-stroke-soft-200 bg-bg-weak-50/60 p-4 dark:border-white/5 dark:bg-slate-900/40">
+						<h3 className="mb-3 font-bold text-text-sub-600 text-xs uppercase tracking-wider dark:text-white/40">
 							Estimated Impact
 						</h3>
 						<div className="grid grid-cols-2 gap-3">
-							<div className="rounded-lg border border-white/5 bg-slate-950/60 p-3">
-								<div className="font-mono text-[10px] text-white/40">
+							<div className="rounded-lg border border-stroke-soft-200 bg-bg-weak-50/60 p-3 dark:border-white/5 dark:bg-slate-950/60">
+								<div className="font-mono text-[10px] text-text-sub-600 dark:text-white/40">
 									AVG. OPEN RATE
 								</div>
-								<div className="mt-1 font-bold font-mono text-lg text-white">
+								<div className="mt-1 font-bold font-mono text-lg text-text-strong-950 dark:text-white">
 									{openRate.toFixed(1)}%
 								</div>
-								<div className="mt-0.5 font-mono text-[9px] text-emerald-400">
+								<div className="mt-0.5 font-mono text-[9px] text-emerald-600 dark:text-emerald-400">
 									🚀 +{(openRate - 22).toFixed(1)}% optimization
 								</div>
 							</div>
-							<div className="rounded-lg border border-white/5 bg-slate-950/60 p-3">
-								<div className="font-mono text-[10px] text-white/40">
+							<div className="rounded-lg border border-stroke-soft-200 bg-bg-weak-50/60 p-3 dark:border-white/5 dark:bg-slate-950/60">
+								<div className="font-mono text-[10px] text-text-sub-600 dark:text-white/40">
 									CLICK RATE (CTR)
 								</div>
-								<div className="mt-1 font-bold font-mono text-lg text-white">
+								<div className="mt-1 font-bold font-mono text-lg text-text-strong-950 dark:text-white">
 									{clickRate.toFixed(1)}%
 								</div>
-								<div className="mt-0.5 font-mono text-[9px] text-emerald-400">
+								<div className="mt-0.5 font-mono text-[9px] text-emerald-600 dark:text-emerald-400">
 									📈 +{(clickRate - 2.4).toFixed(1)}% conversions
 								</div>
 							</div>
@@ -142,14 +142,14 @@ export default function MarketingWidget() {
 				</div>
 
 				{/* Visual Email Canvas Preview */}
-				<div className="flex min-h-[220px] select-none flex-col rounded-xl border border-white/5 bg-slate-900 p-3">
-					<div className="flex flex-1 flex-col gap-3 overflow-hidden rounded-lg border border-white/5 bg-slate-950 p-3 text-left">
+				<div className="flex min-h-[220px] select-none flex-col rounded-xl border border-stroke-soft-200 bg-bg-weak-50 p-3 dark:border-white/5 dark:bg-slate-900">
+					<div className="flex flex-1 flex-col gap-3 overflow-hidden rounded-lg border border-stroke-soft-200 bg-bg-white-0 p-3 text-left dark:border-white/5 dark:bg-slate-950">
 						{/* Email Header */}
-						<div className="border-white/5 border-b pb-2">
-							<div className="font-mono text-[9px] text-white/40">
+						<div className="border-stroke-soft-200 border-b pb-2 dark:border-white/5">
+							<div className="font-mono text-[9px] text-text-sub-600 dark:text-white/40">
 								To: active_subscribers_list
 							</div>
-							<div className="mt-1 font-bold text-[11px] text-white/80">
+							<div className="mt-1 font-bold text-[11px] text-text-strong-950 dark:text-white/80">
 								✨ March Reloop Updates!
 							</div>
 						</div>
@@ -166,7 +166,7 @@ export default function MarketingWidget() {
 									animate={{ opacity: 1, scale: 1 }}
 									className="relative flex aspect-[3/1] items-center justify-center overflow-hidden rounded-md border border-rose-500/20 bg-gradient-to-tr from-rose-600/35 to-violet-600/35"
 								>
-									<span className="font-mono font-semibold text-[9px] text-white/60 tracking-wider">
+									<span className="font-mono font-semibold text-[9px] text-text-sub-600 tracking-wider dark:text-white/60">
 										MARCH PRODUCT LAUNCH
 									</span>
 								</motion.div>
@@ -186,7 +186,7 @@ export default function MarketingWidget() {
 									animate={{ opacity: 1, y: 0 }}
 									className="rounded border border-rose-500/30 border-dashed bg-rose-500/10 p-2 text-center"
 								>
-									<span className="font-bold font-mono text-[8px] text-rose-400 tracking-widest">
+									<span className="font-bold font-mono text-[8px] text-rose-600 tracking-widest dark:text-rose-400">
 										USE CODE: RELOOP20
 									</span>
 								</motion.div>

--- a/apps/frontend/web/src/components/landing/use-cases/widgets/order-confirmation.tsx
+++ b/apps/frontend/web/src/components/landing/use-cases/widgets/order-confirmation.tsx
@@ -39,32 +39,32 @@ export default function OrderConfirmationWidget() {
 	const total = Number.parseFloat((subtotal + shipping + tax).toFixed(2));
 
 	return (
-		<div className="flex h-full min-h-[420px] flex-col overflow-hidden rounded-2xl border border-white/10 bg-slate-950 text-left font-sans shadow-2xl">
+		<div className="flex h-full min-h-[420px] flex-col overflow-hidden rounded-2xl border border-stroke-soft-200 bg-bg-white-0 text-left font-sans shadow-lg dark:border-white/10 dark:bg-slate-950 dark:shadow-2xl">
 			{/* Header */}
-			<div className="flex items-center justify-between border-white/5 border-b bg-slate-900 px-4 py-3">
+			<div className="flex items-center justify-between border-stroke-soft-200 border-b bg-bg-weak-50 px-4 py-3 dark:border-white/5 dark:bg-slate-900">
 				<div className="flex items-center gap-1.5">
 					<span className="h-2.5 w-2.5 rounded-full bg-blue-500/80" />
 					<span className="h-2.5 w-2.5 rounded-full bg-yellow-500/80" />
 					<span className="h-2.5 w-2.5 rounded-full bg-green-500/80" />
-					<span className="ml-2 font-mono text-white/40 text-xs">
+					<span className="ml-2 font-mono text-text-sub-600 text-xs dark:text-white/40">
 						ecommerce_receipt_pipeline.invoice
 					</span>
 				</div>
-				<span className="rounded border border-blue-500/20 bg-blue-500/10 px-2 py-0.5 font-mono text-[10px] text-blue-400">
+				<span className="rounded border border-blue-500/20 bg-blue-500/10 px-2 py-0.5 font-mono text-[10px] text-blue-600 dark:text-blue-400">
 					Checkout SMTP
 				</span>
 			</div>
 
 			<div className="grid flex-1 grid-cols-1 gap-4 p-4 md:grid-cols-2">
 				{/* Left Side: Cart checkout */}
-				<div className="flex flex-col justify-between rounded-xl border border-white/5 bg-slate-900/40 p-4">
+				<div className="flex flex-col justify-between rounded-xl border border-stroke-soft-200 bg-bg-weak-50/60 p-4 dark:border-white/5 dark:bg-slate-900/40">
 					<div className="flex flex-col gap-3">
-						<h3 className="font-bold text-white/40 text-xs uppercase tracking-wider">
+						<h3 className="font-bold text-text-sub-600 text-xs uppercase tracking-wider dark:text-white/40">
 							Shopping Cart
 						</h3>
 
 						{cart.length === 0 ? (
-							<div className="py-6 text-center text-white/30 text-xs italic">
+							<div className="py-6 text-center text-text-soft-400 text-xs italic dark:text-white/30">
 								Your cart is empty. Add items to test receipt.
 							</div>
 						) : (
@@ -72,29 +72,29 @@ export default function OrderConfirmationWidget() {
 								{cart.map((item) => (
 									<div
 										key={item.id}
-										className="flex items-center justify-between rounded border border-white/5 bg-slate-950/60 p-2.5"
+										className="flex items-center justify-between rounded border border-stroke-soft-200 bg-bg-weak-50/60 p-2.5 dark:border-white/5 dark:bg-slate-950/60"
 									>
 										<div>
-											<div className="font-semibold text-white/80 text-xs">
+											<div className="font-semibold text-text-strong-950 text-xs dark:text-white/80">
 												{item.name}
 											</div>
-											<div className="mt-0.5 text-[10px] text-white/40">
+											<div className="mt-0.5 text-[10px] text-text-sub-600 dark:text-white/40">
 												${item.price.toFixed(2)} each
 											</div>
 										</div>
 										<div className="flex items-center gap-2">
 											<button
 												onClick={() => updateQty(item.id, -1)}
-												className="flex h-5 w-5 cursor-pointer items-center justify-center rounded bg-slate-800 font-bold text-white text-xs hover:bg-slate-700"
+												className="flex h-5 w-5 cursor-pointer items-center justify-center rounded bg-stroke-soft-200 font-bold text-text-strong-950 text-xs hover:bg-stroke-sub-300 dark:bg-slate-800 dark:text-white dark:hover:bg-slate-700"
 											>
 												-
 											</button>
-											<span className="w-4 text-center font-mono text-white/80 text-xs">
+											<span className="w-4 text-center font-mono text-text-strong-950 text-xs dark:text-white/80">
 												{item.quantity}
 											</span>
 											<button
 												onClick={() => updateQty(item.id, 1)}
-												className="flex h-5 w-5 cursor-pointer items-center justify-center rounded bg-slate-800 font-bold text-white text-xs hover:bg-slate-700"
+												className="flex h-5 w-5 cursor-pointer items-center justify-center rounded bg-stroke-soft-200 font-bold text-text-strong-950 text-xs hover:bg-stroke-sub-300 dark:bg-slate-800 dark:text-white dark:hover:bg-slate-700"
 											>
 												+
 											</button>
@@ -105,22 +105,22 @@ export default function OrderConfirmationWidget() {
 						)}
 					</div>
 
-					<div className="mt-4 space-y-3 border-white/5 border-t pt-3">
-						<div className="flex justify-between font-mono text-[11px] text-white/50">
+					<div className="mt-4 space-y-3 border-stroke-soft-200 border-t pt-3 dark:border-white/5">
+						<div className="flex justify-between font-mono text-[11px] text-text-sub-600 dark:text-white/50">
 							<span>Subtotal:</span>
 							<span>${subtotal.toFixed(2)}</span>
 						</div>
-						<div className="flex justify-between font-mono text-[11px] text-white/50">
+						<div className="flex justify-between font-mono text-[11px] text-text-sub-600 dark:text-white/50">
 							<span>Shipping:</span>
 							<span>${shipping.toFixed(2)}</span>
 						</div>
-						<div className="flex justify-between font-mono text-[11px] text-white/50">
+						<div className="flex justify-between font-mono text-[11px] text-text-sub-600 dark:text-white/50">
 							<span>Tax (8%):</span>
 							<span>${tax.toFixed(2)}</span>
 						</div>
-						<div className="flex justify-between border-white/5 border-t pt-2 font-bold text-white text-xs">
+						<div className="flex justify-between border-stroke-soft-200 border-t pt-2 font-bold text-text-strong-950 text-xs dark:border-white/5 dark:text-white">
 							<span>Total:</span>
-							<span className="font-mono text-blue-400">
+							<span className="font-mono text-blue-600 dark:text-blue-400">
 								${total.toFixed(2)}
 							</span>
 						</div>
@@ -130,7 +130,7 @@ export default function OrderConfirmationWidget() {
 							disabled={subtotal === 0}
 							className={`w-full cursor-pointer rounded-lg py-2 font-semibold text-xs transition-all ${
 								subtotal === 0
-									? "cursor-not-allowed border border-white/5 bg-slate-800 text-white/30"
+									? "cursor-not-allowed border border-stroke-soft-200 bg-stroke-soft-200 text-text-soft-400 dark:border-white/5 dark:bg-slate-800 dark:text-white/30"
 									: "bg-blue-600 text-white shadow-blue-600/20 shadow-lg hover:bg-blue-500 active:scale-95"
 							}`}
 						>
@@ -140,32 +140,32 @@ export default function OrderConfirmationWidget() {
 				</div>
 
 				{/* Right Side: Receipt Email Template Preview */}
-				<div className="flex flex-col justify-between rounded-xl border border-white/5 bg-slate-900 p-3">
-					<div className="flex flex-1 flex-col gap-3.5 overflow-hidden rounded-lg border border-white/5 bg-slate-950 p-3.5 text-left">
-						<div className="flex items-center justify-between border-white/5 border-b pb-2">
-							<span className="font-mono text-[9px] text-white/40">
+				<div className="flex flex-col justify-between rounded-xl border border-stroke-soft-200 bg-bg-weak-50 p-3 dark:border-white/5 dark:bg-slate-900">
+					<div className="flex flex-1 flex-col gap-3.5 overflow-hidden rounded-lg border border-stroke-soft-200 bg-bg-white-0 p-3.5 text-left dark:border-white/5 dark:bg-slate-950">
+						<div className="flex items-center justify-between border-stroke-soft-200 border-b pb-2 dark:border-white/5">
+							<span className="font-mono text-[9px] text-text-sub-600 dark:text-white/40">
 								SUBJECT: Reloop Shop Receipt #87291
 							</span>
 							{checkoutDone && (
-								<span className="rounded border border-emerald-500/20 bg-emerald-500/10 px-1.5 py-0.5 font-mono text-[8px] text-emerald-400">
+								<span className="rounded border border-emerald-500/20 bg-emerald-500/10 px-1.5 py-0.5 font-mono text-[8px] text-emerald-600 dark:text-emerald-400">
 									SENT
 								</span>
 							)}
 						</div>
 
 						{checkoutDone ? (
-							<div className="flex-1 space-y-3.5 overflow-y-auto text-white/80 text-xs leading-relaxed">
+							<div className="flex-1 space-y-3.5 overflow-y-auto text-text-strong-950 text-xs leading-relaxed dark:text-white/80">
 								<div className="py-1 text-center">
-									<div className="font-bold text-[13px] text-white">
+									<div className="font-bold text-[13px] text-text-strong-950 dark:text-white">
 										Thank you for your order!
 									</div>
-									<div className="mt-0.5 font-mono text-[9px] text-white/40">
+									<div className="mt-0.5 font-mono text-[9px] text-text-sub-600 dark:text-white/40">
 										ORDER ID: #87291-RELOOP
 									</div>
 								</div>
 
 								{/* Dynamic Line items in receipt email */}
-								<div className="space-y-2 border-white/5 border-t border-b py-2">
+								<div className="space-y-2 border-stroke-soft-200 border-t border-b py-2 dark:border-white/5">
 									{cart.map((item) => (
 										<div
 											key={item.id}
@@ -173,11 +173,11 @@ export default function OrderConfirmationWidget() {
 										>
 											<span>
 												{item.name}{" "}
-												<strong className="text-white/40">
+												<strong className="text-text-sub-600 dark:text-white/40">
 													x{item.quantity}
 												</strong>
 											</span>
-											<span className="font-mono text-white/70">
+											<span className="font-mono text-text-sub-600 dark:text-white/70">
 												${(item.price * item.quantity).toFixed(2)}
 											</span>
 										</div>
@@ -186,20 +186,23 @@ export default function OrderConfirmationWidget() {
 
 								{/* Invoice Total stack */}
 								<div className="space-y-1 text-right">
-									<div className="text-[10px] text-white/40">
+									<div className="text-[10px] text-text-sub-600 dark:text-white/40">
 										Subtotal: ${subtotal.toFixed(2)}
 									</div>
-									<div className="text-[10px] text-white/40">
+									<div className="text-[10px] text-text-sub-600 dark:text-white/40">
 										Tax (8%): ${tax.toFixed(2)}
 									</div>
-									<div className="font-bold text-[11px] text-white">
+									<div className="font-bold text-[11px] text-text-strong-950 dark:text-white">
 										Total Paid: ${total.toFixed(2)}
 									</div>
 								</div>
 							</div>
 						) : (
-							<div className="flex flex-1 flex-col items-center justify-center gap-1.5 text-center text-white/35 text-xs italic">
-								<Icon name="Inbox" className="h-8 w-8 text-white/10" />
+							<div className="flex flex-1 flex-col items-center justify-center gap-1.5 text-center text-text-soft-400 text-xs italic dark:text-white/35">
+								<Icon
+									name="Inbox"
+									className="h-8 w-8 text-text-soft-400/40 dark:text-white/10"
+								/>
 								<span>
 									Click 'Purchase & Send Receipt' to generate and deliver your
 									transactional invoice email.

--- a/apps/frontend/web/src/components/landing/use-cases/widgets/password-reset.tsx
+++ b/apps/frontend/web/src/components/landing/use-cases/widgets/password-reset.tsx
@@ -43,154 +43,209 @@ export default function PasswordResetWidget() {
 	};
 
 	return (
-		<div className="flex h-full min-h-[420px] flex-col items-center justify-center overflow-hidden rounded-2xl border border-white/10 bg-slate-950 p-6 text-left font-sans shadow-2xl">
+		<div className="flex h-full min-h-[420px] flex-col items-center justify-center overflow-hidden rounded-2xl border border-stroke-soft-200 bg-bg-white-0 p-6 text-left font-sans shadow-lg dark:border-white/10 dark:bg-slate-950 dark:shadow-2xl">
 			{/* Controls outside phone */}
-			<div className="mb-4 flex w-full items-center justify-between rounded-xl border border-white/5 bg-slate-900/60 p-3">
-				<div>
-					<span className="font-mono text-[10px] text-white/40">AUTH TYPE</span>
-					<div className="font-bold font-mono text-white/80 text-xs">
+			<div className="mb-4 flex w-full items-center justify-between gap-3 rounded-xl border border-stroke-soft-200 bg-bg-weak-50/60 p-3 dark:border-white/5 dark:bg-slate-900/60">
+				<div className="min-w-0 flex-1">
+					<span className="font-mono text-[10px] text-text-sub-600 dark:text-white/40">
+						AUTH TYPE
+					</span>
+					<div className="truncate font-bold font-mono text-text-strong-950 text-xs dark:text-white/80">
 						Transactional JWT Drip
 					</div>
 				</div>
 				{step === "idle" ? (
 					<button
+						type="button"
 						onClick={requestReset}
-						className="cursor-pointer rounded-lg bg-orange-600 px-4 py-2 font-medium text-white text-xs shadow-lg shadow-orange-600/20 transition-all hover:bg-orange-500 active:scale-95"
+						className="flex shrink-0 cursor-pointer items-center gap-1.5 rounded-lg bg-orange-600 px-3 py-1.5 font-medium text-[11px] text-white transition-colors hover:bg-orange-500 active:scale-95"
 					>
-						🔑 Request Reset Link
+						<Icon name="lock" className="h-3 w-3" />
+						<span>Request link</span>
 					</button>
 				) : (
 					<button
+						type="button"
 						onClick={resetAll}
-						className="cursor-pointer rounded bg-slate-800 px-3 py-1.5 text-white text-xs transition-colors hover:bg-slate-700"
+						className="flex shrink-0 cursor-pointer items-center gap-1.5 rounded-lg border border-stroke-soft-200 bg-bg-white-0 px-3 py-1.5 font-medium text-[11px] text-text-sub-600 transition-colors hover:bg-bg-weak-50 hover:text-text-strong-950 dark:border-white/10 dark:bg-slate-900 dark:text-white/70 dark:hover:bg-slate-800"
 					>
-						Reset Simulation
+						<Icon name="refresh-cw" className="h-3 w-3" />
+						<span>Reset</span>
 					</button>
 				)}
 			</div>
 
-			{/* Smartphone Case Mockup */}
-			<div className="relative flex h-[340px] w-[210px] flex-col justify-between overflow-hidden rounded-[28px] border-[6px] border-slate-800 bg-slate-950 shadow-xl ring-2 ring-white/10">
-				{/* Camera Notch */}
-				<div className="-translate-x-1/2 absolute top-1.5 left-1/2 z-30 flex h-3.5 w-16 items-center justify-center rounded-full bg-slate-800">
-					<div className="ml-6 h-1.5 w-1.5 rounded-full bg-slate-900" />
-				</div>
+			{/* iPhone Mockup */}
+			<div className="relative h-[372px] w-[172px] rounded-[2.4rem] bg-gradient-to-b from-slate-600 via-slate-800 to-slate-700 p-[3px] shadow-[0_20px_45px_-15px_rgba(0,0,0,0.5)]">
+				{/* Side buttons */}
+				<span className="-left-[2px] absolute top-[68px] h-4 w-[2px] rounded-l bg-slate-700" />
+				<span className="-left-[2px] absolute top-[96px] h-7 w-[2px] rounded-l bg-slate-700" />
+				<span className="-left-[2px] absolute top-[132px] h-7 w-[2px] rounded-l bg-slate-700" />
+				<span className="-right-[2px] absolute top-[110px] h-11 w-[2px] rounded-r bg-slate-700" />
 
-				{/* Smartphone Screen Content */}
-				<div className="flex flex-1 select-none flex-col justify-between px-3 pt-6 pb-4 text-xs">
-					{/* Status Bar */}
-					<div className="flex items-center justify-between px-1 font-mono text-[8px] text-white/50">
-						<span>08:14 AM</span>
-						<div className="flex items-center gap-1">
-							<Icon name="Wifi" className="h-2 w-2" />
-							<Icon name="BatteryCharging" className="h-2.5 w-2.5" />
-						</div>
+				<div className="relative flex h-full w-full flex-col justify-between overflow-hidden rounded-[2.2rem] bg-bg-white-0 dark:bg-black">
+					{/* Dynamic Island */}
+					<div className="-translate-x-1/2 absolute top-2 left-1/2 z-30 flex h-[19px] w-[56px] items-center justify-end rounded-full bg-black pr-2">
+						<span className="h-[7px] w-[7px] rounded-full bg-slate-700 ring-1 ring-slate-600" />
 					</div>
 
-					{/* Step Screens */}
-					<div className="relative mt-4 flex flex-1 flex-col items-center justify-center">
-						{step === "idle" && (
-							<div className="space-y-2 text-center">
-								<Icon name="Lock" className="mx-auto h-8 w-8 text-white/20" />
-								<p className="text-[10px] text-white/40">
-									Waiting for trigger request...
-								</p>
-							</div>
-						)}
+					{/* Home indicator */}
+					<div className="-translate-x-1/2 absolute bottom-1.5 left-1/2 z-30 h-[3px] w-[68px] rounded-full bg-text-strong-950/25 dark:bg-white/35" />
 
-						{step === "notified" && (
-							<div className="flex h-full w-full flex-col items-center justify-between py-4">
-								{/* Locked Screen Wallpaper Details */}
-								<div className="pt-2 text-center">
-									<div className="font-bold text-2xl text-white/95">08:14</div>
-									<div className="text-[9px] text-white/60">
-										Tuesday, July 7
-									</div>
-								</div>
-
-								{/* Animated Dropdown Push Notification Banner */}
-								<motion.div
-									initial={{ y: -60, opacity: 0 }}
-									animate={{ y: 0, opacity: 1 }}
-									onClick={openResetForm}
-									className="flex w-full cursor-pointer flex-col gap-1 rounded-xl border border-white/10 bg-slate-900/90 p-2.5 text-left shadow-2xl transition-colors hover:border-orange-500/30"
+					{/* Smartphone Screen Content */}
+					<div className="flex flex-1 select-none flex-col justify-between px-3 pt-2.5 pb-5 text-xs">
+						{/* Status Bar */}
+						<div className="flex items-center justify-between px-2 font-medium text-[9px] text-text-strong-950 dark:text-white">
+							<span className="w-10">08:14</span>
+							<div className="flex w-10 items-center justify-end gap-1">
+								<Icon name="wifi" className="h-2.5 w-2.5" />
+								<svg
+									viewBox="0 0 26 13"
+									className="h-2.5 w-[19px]"
+									fill="none"
+									aria-hidden
 								>
-									<div className="flex items-center justify-between">
-										<span className="font-bold text-[9px] text-orange-400">
-											🛡️ Reloop Identity
-										</span>
-										<span className="text-[8px] text-white/30">now</span>
-									</div>
-									<p className="font-medium text-[10px] text-white">
-										Reset your password
+									<rect
+										x="0.5"
+										y="0.5"
+										width="22"
+										height="12"
+										rx="3.5"
+										stroke="currentColor"
+										strokeOpacity="0.4"
+									/>
+									<rect
+										x="2"
+										y="2"
+										width="15"
+										height="9"
+										rx="2"
+										fill="currentColor"
+									/>
+									<path
+										d="M24.5 4.5v4a2.5 2.5 0 0 0 0-4Z"
+										fill="currentColor"
+										fillOpacity="0.4"
+									/>
+								</svg>
+							</div>
+						</div>
+
+						{/* Step Screens */}
+						<div className="relative mt-4 flex flex-1 flex-col items-center justify-center">
+							{step === "idle" && (
+								<div className="space-y-2 text-center">
+									<Icon
+										name="lock"
+										className="mx-auto h-8 w-8 text-text-soft-400 dark:text-white/20"
+									/>
+									<p className="text-[10px] text-text-sub-600 dark:text-white/40">
+										Waiting for trigger request...
 									</p>
-									<p className="text-[9px] text-white/60">
-										Click here to complete password update token verification.
+								</div>
+							)}
+
+							{step === "notified" && (
+								<div className="flex h-full w-full flex-col items-center justify-between py-4">
+									{/* Locked Screen Wallpaper Details */}
+									<div className="pt-2 text-center">
+										<div className="font-bold text-2xl text-text-strong-950 dark:text-white/95">
+											08:14
+										</div>
+										<div className="text-[9px] text-text-sub-600 dark:text-white/60">
+											Tuesday, July 7
+										</div>
+									</div>
+
+									{/* Animated Dropdown Push Notification Banner */}
+									<motion.div
+										initial={{ y: -60, opacity: 0 }}
+										animate={{ y: 0, opacity: 1 }}
+										onClick={openResetForm}
+										className="flex w-full cursor-pointer flex-col gap-1 rounded-xl border border-stroke-soft-200 bg-bg-weak-50/90 p-2.5 text-left shadow-lg transition-colors hover:border-orange-500/30 dark:border-white/10 dark:bg-slate-900/90 dark:shadow-2xl"
+									>
+										<div className="flex items-center justify-between">
+											<span className="font-bold text-[9px] text-orange-600 dark:text-orange-400">
+												Reloop Identity
+											</span>
+											<span className="text-[8px] text-text-soft-400 dark:text-white/30">
+												now
+											</span>
+										</div>
+										<p className="font-medium text-[10px] text-text-strong-950 dark:text-white">
+											Reset your password
+										</p>
+										<p className="text-[9px] text-text-sub-600 dark:text-white/60">
+											Click here to complete password update token verification.
+										</p>
+									</motion.div>
+
+									<span className="mt-2 animate-pulse text-[8px] text-text-soft-400 dark:text-white/30">
+										Tap notification to open
+									</span>
+								</div>
+							)}
+
+							{step === "form" && (
+								<form
+									onSubmit={submitNewPassword}
+									className="flex w-full flex-col gap-2"
+								>
+									<h4 className="mb-1 text-center font-bold text-[11px] text-text-strong-950 dark:text-white/95">
+										Set New Password
+									</h4>
+
+									<input
+										type="password"
+										placeholder="New Password"
+										value={pass}
+										onChange={(e) => setPass(e.target.value)}
+										className="w-full rounded border border-stroke-soft-200 bg-bg-weak-50 px-2 py-1 text-[10px] text-text-strong-950 focus:border-orange-500/50 focus:outline-none dark:border-white/10 dark:bg-slate-900 dark:text-white"
+									/>
+									<input
+										type="password"
+										placeholder="Confirm Password"
+										value={confirm}
+										onChange={(e) => setConfirm(e.target.value)}
+										className="w-full rounded border border-stroke-soft-200 bg-bg-weak-50 px-2 py-1 text-[10px] text-text-strong-950 focus:border-orange-500/50 focus:outline-none dark:border-white/10 dark:bg-slate-900 dark:text-white"
+									/>
+
+									{error && (
+										<p className="text-center text-[8px] text-red-600 leading-normal dark:text-red-400">
+											{error}
+										</p>
+									)}
+
+									<button
+										type="submit"
+										className="w-full cursor-pointer rounded bg-orange-600 py-1 font-semibold text-[10px] text-white transition-colors hover:bg-orange-500"
+									>
+										Update Password
+									</button>
+								</form>
+							)}
+
+							{step === "done" && (
+								<motion.div
+									initial={{ scale: 0.8, opacity: 0 }}
+									animate={{ scale: 1, opacity: 1 }}
+									className="flex flex-col items-center space-y-2 text-center"
+								>
+									<div className="flex h-10 w-10 items-center justify-center rounded-full border border-green-500/50 bg-green-500/20">
+										<Icon
+											name="check"
+											className="h-5 w-5 text-green-600 dark:text-green-400"
+										/>
+									</div>
+									<h4 className="font-bold text-[11px] text-text-strong-950 dark:text-white">
+										Password Updated
+									</h4>
+									<p className="text-[9px] text-text-sub-600 leading-relaxed dark:text-white/50">
+										Secure credentials successfully updated.
 									</p>
 								</motion.div>
-
-								<span className="mt-2 animate-pulse text-[8px] text-white/30">
-									Tap notification to open
-								</span>
-							</div>
-						)}
-
-						{step === "form" && (
-							<form
-								onSubmit={submitNewPassword}
-								className="flex w-full flex-col gap-2"
-							>
-								<h4 className="mb-1 text-center font-bold text-[11px] text-white/95">
-									Set New Password
-								</h4>
-
-								<input
-									type="password"
-									placeholder="New Password"
-									value={pass}
-									onChange={(e) => setPass(e.target.value)}
-									className="w-full rounded border border-white/10 bg-slate-900 px-2 py-1 text-[10px] text-white focus:border-orange-500/50 focus:outline-none"
-								/>
-								<input
-									type="password"
-									placeholder="Confirm Password"
-									value={confirm}
-									onChange={(e) => setConfirm(e.target.value)}
-									className="w-full rounded border border-white/10 bg-slate-900 px-2 py-1 text-[10px] text-white focus:border-orange-500/50 focus:outline-none"
-								/>
-
-								{error && (
-									<p className="text-center text-[8px] text-red-400 leading-normal">
-										{error}
-									</p>
-								)}
-
-								<button
-									type="submit"
-									className="w-full cursor-pointer rounded bg-orange-600 py-1 font-semibold text-[10px] text-white transition-colors hover:bg-orange-500"
-								>
-									Update Password
-								</button>
-							</form>
-						)}
-
-						{step === "done" && (
-							<motion.div
-								initial={{ scale: 0.8, opacity: 0 }}
-								animate={{ scale: 1, opacity: 1 }}
-								className="flex flex-col items-center space-y-2 text-center"
-							>
-								<div className="flex h-10 w-10 items-center justify-center rounded-full border border-green-500/50 bg-green-500/20">
-									<Icon name="Check" className="h-5 w-5 text-green-400" />
-								</div>
-								<h4 className="font-bold text-[11px] text-white">
-									Password Updated
-								</h4>
-								<p className="text-[9px] text-white/50 leading-relaxed">
-									Secure credentials successfully updated.
-								</p>
-							</motion.div>
-						)}
+							)}
+						</div>
 					</div>
 				</div>
 			</div>

--- a/apps/frontend/web/src/components/landing/use-cases/widgets/payment-receipt.tsx
+++ b/apps/frontend/web/src/components/landing/use-cases/widgets/payment-receipt.tsx
@@ -19,26 +19,26 @@ export default function PaymentReceiptWidget() {
 	};
 
 	return (
-		<div className="flex h-full min-h-[420px] flex-col justify-between overflow-hidden rounded-2xl border border-white/10 bg-slate-950 text-left font-sans shadow-2xl">
+		<div className="flex h-full min-h-[420px] flex-col justify-between overflow-hidden rounded-2xl border border-stroke-soft-200 bg-bg-white-0 text-left font-sans shadow-lg dark:border-white/10 dark:bg-slate-950 dark:shadow-2xl">
 			{/* Header */}
-			<div className="flex items-center justify-between border-white/5 border-b bg-slate-900 px-4 py-3">
+			<div className="flex items-center justify-between border-stroke-soft-200 border-b bg-bg-weak-50 px-4 py-3 dark:border-white/5 dark:bg-slate-900">
 				<div className="flex items-center gap-1.5">
 					<span className="h-2.5 w-2.5 rounded-full bg-emerald-500/80" />
 					<span className="h-2.5 w-2.5 rounded-full bg-yellow-500/80" />
 					<span className="h-2.5 w-2.5 rounded-full bg-green-500/80" />
-					<span className="ml-2 font-mono text-white/40 text-xs">
+					<span className="ml-2 font-mono text-text-sub-600 text-xs dark:text-white/40">
 						stripe_webhook_listener.ledger
 					</span>
 				</div>
-				<span className="rounded border border-emerald-500/20 bg-emerald-500/10 px-2 py-0.5 font-mono text-[10px] text-emerald-400">
+				<span className="rounded border border-emerald-500/20 bg-emerald-500/10 px-2 py-0.5 font-mono text-[10px] text-emerald-600 dark:text-emerald-400">
 					Stripe API Hook
 				</span>
 			</div>
 
 			<div className="grid flex-1 grid-cols-1 gap-4 p-4 md:grid-cols-2">
 				{/* Left Side: Webhook event simulator */}
-				<div className="flex flex-col gap-4 rounded-xl border border-white/5 bg-slate-900/40 p-4">
-					<h3 className="font-bold text-white/40 text-xs uppercase tracking-wider">
+				<div className="flex flex-col gap-4 rounded-xl border border-stroke-soft-200 bg-bg-weak-50/60 p-4 dark:border-white/5 dark:bg-slate-900/40">
+					<h3 className="font-bold text-text-sub-600 text-xs uppercase tracking-wider dark:text-white/40">
 						Simulate billing event
 					</h3>
 
@@ -48,15 +48,15 @@ export default function PaymentReceiptWidget() {
 							disabled={status === "listening"}
 							className={`flex cursor-pointer items-center justify-between rounded-lg border p-2.5 text-left text-xs transition-all ${
 								activeWebhook === "invoice.payment_succeeded"
-									? "border-emerald-500/40 bg-emerald-950/20 text-emerald-300"
-									: "border-white/5 bg-slate-950 text-white/55 hover:border-white/15"
+									? "border-emerald-500/40 bg-emerald-50 text-emerald-600 dark:bg-emerald-950/20 dark:text-emerald-300"
+									: "border-stroke-soft-200 bg-bg-white-0 text-text-sub-600 hover:border-stroke-soft-200 dark:border-white/5 dark:bg-slate-950 dark:text-white/55 dark:hover:border-white/15"
 							}`}
 						>
 							<div className="flex items-center gap-2">
 								<Icon name="Activity" className="h-3.5 w-3.5" />
 								<span>invoice.payment_succeeded</span>
 							</div>
-							<span className="font-mono text-[9px] text-emerald-400">
+							<span className="font-mono text-[9px] text-emerald-600 dark:text-emerald-400">
 								Trigger
 							</span>
 						</button>
@@ -66,79 +66,90 @@ export default function PaymentReceiptWidget() {
 							disabled={status === "listening"}
 							className={`flex cursor-pointer items-center justify-between rounded-lg border p-2.5 text-left text-xs transition-all ${
 								activeWebhook === "customer.subscription.created"
-									? "border-emerald-500/40 bg-emerald-950/20 text-emerald-300"
-									: "border-white/5 bg-slate-950 text-white/55 hover:border-white/15"
+									? "border-emerald-500/40 bg-emerald-50 text-emerald-600 dark:bg-emerald-950/20 dark:text-emerald-300"
+									: "border-stroke-soft-200 bg-bg-white-0 text-text-sub-600 hover:border-stroke-soft-200 dark:border-white/5 dark:bg-slate-950 dark:text-white/55 dark:hover:border-white/15"
 							}`}
 						>
 							<div className="flex items-center gap-2">
 								<Icon name="Activity" className="h-3.5 w-3.5" />
 								<span>subscription.created</span>
 							</div>
-							<span className="font-mono text-[9px] text-emerald-400">
+							<span className="font-mono text-[9px] text-emerald-600 dark:text-emerald-400">
 								Trigger
 							</span>
 						</button>
 					</div>
 
 					{status === "listening" && (
-						<div className="mt-2 flex items-center gap-2 rounded border border-white/5 bg-slate-950 p-2.5 font-mono text-white/50 text-xs">
-							<div className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-white/20 border-t-white" />
+						<div className="mt-2 flex items-center gap-2 rounded border border-stroke-soft-200 bg-bg-white-0 p-2.5 font-mono text-text-sub-600 text-xs dark:border-white/5 dark:bg-slate-950 dark:text-white/50">
+							<div className="h-3.5 w-3.5 animate-spin rounded-full border-2 border-stroke-soft-200 border-t-text-strong-950 dark:border-white/20 dark:border-t-white" />
 							<span>Reloop parsing webhook & generating invoice PDF...</span>
 						</div>
 					)}
 				</div>
 
 				{/* Right Side: Ledger / compiled receipt email */}
-				<div className="flex flex-col justify-between rounded-xl border border-white/5 bg-slate-900 p-3">
-					<div className="flex flex-1 flex-col gap-3.5 overflow-hidden rounded-lg border border-white/5 bg-slate-950 p-3.5 text-left">
+				<div className="flex flex-col justify-between rounded-xl border border-stroke-soft-200 bg-bg-weak-50 p-3 dark:border-white/5 dark:bg-slate-900">
+					<div className="flex flex-1 flex-col gap-3.5 overflow-hidden rounded-lg border border-stroke-soft-200 bg-bg-white-0 p-3.5 text-left dark:border-white/5 dark:bg-slate-950">
 						{status === "compiled" ? (
-							<div className="space-y-3.5 overflow-y-auto text-white/80 text-xs leading-relaxed">
-								<div className="flex items-center justify-between border-white/5 border-b pb-2">
-									<span className="font-bold text-white">Payment Receipt</span>
-									<span className="font-mono text-[9px] text-white/40">
+							<div className="space-y-3.5 overflow-y-auto text-text-strong-950 text-xs leading-relaxed dark:text-white/80">
+								<div className="flex items-center justify-between border-stroke-soft-200 border-b pb-2 dark:border-white/5">
+									<span className="font-bold text-text-strong-950 dark:text-white">
+										Payment Receipt
+									</span>
+									<span className="font-mono text-[9px] text-text-sub-600 dark:text-white/40">
 										Invoice #INV-2901
 									</span>
 								</div>
 
 								<div>
-									<p className="text-[10px] text-white/40">CUSTOMER</p>
-									<p className="font-semibold text-white">
+									<p className="text-[10px] text-text-sub-600 dark:text-white/40">
+										CUSTOMER
+									</p>
+									<p className="font-semibold text-text-strong-950 dark:text-white">
 										billing-admin@acme.com
 									</p>
 								</div>
 
-								<div className="space-y-1 border-white/5 border-t border-b py-2">
+								<div className="space-y-1 border-stroke-soft-200 border-t border-b py-2 dark:border-white/5">
 									<div className="flex justify-between text-[11px]">
 										<span>Reloop Developer Plan (1 month)</span>
-										<span className="font-mono text-white/70">$29.00</span>
+										<span className="font-mono text-text-sub-600 dark:text-white/70">
+											$29.00
+										</span>
 									</div>
-									<div className="flex justify-between text-[10px] text-white/40">
+									<div className="flex justify-between text-[10px] text-text-sub-600 dark:text-white/40">
 										<span>Tax (0%):</span>
 										<span className="font-mono">$0.00</span>
 									</div>
 								</div>
 
-								<div className="flex items-center justify-between font-bold text-white text-xs">
+								<div className="flex items-center justify-between font-bold text-text-strong-950 text-xs dark:text-white">
 									<span>Paid Total:</span>
-									<span className="font-mono text-emerald-400">$29.00</span>
+									<span className="font-mono text-emerald-600 dark:text-emerald-400">
+										$29.00
+									</span>
 								</div>
 
-								<div className="flex items-center justify-between rounded border border-white/5 bg-slate-900/60 p-2 text-[10px] text-white/60">
+								<div className="flex items-center justify-between rounded border border-stroke-soft-200 bg-bg-weak-50/60 p-2 text-[10px] text-text-sub-600 dark:border-white/5 dark:bg-slate-900/60 dark:text-white/60">
 									<span className="flex items-center gap-1">
 										<Icon
 											name="FileText"
-											className="h-3 w-3 text-emerald-400"
+											className="h-3 w-3 text-emerald-600 dark:text-emerald-400"
 										/>
 										<span>invoice_pdf_2901.pdf</span>
 									</span>
-									<span className="cursor-pointer font-mono text-[9px] text-emerald-400 hover:underline">
+									<span className="cursor-pointer font-mono text-[9px] text-emerald-600 hover:underline dark:text-emerald-400">
 										Download
 									</span>
 								</div>
 							</div>
 						) : (
-							<div className="flex flex-1 flex-col items-center justify-center gap-1.5 text-center text-white/35 text-xs italic">
-								<Icon name="Inbox" className="h-8 w-8 text-white/10" />
+							<div className="flex flex-1 flex-col items-center justify-center gap-1.5 text-center text-text-soft-400 text-xs italic dark:text-white/35">
+								<Icon
+									name="Inbox"
+									className="h-8 w-8 text-text-soft-400/40 dark:text-white/10"
+								/>
 								<span>
 									Select a billing event trigger on the left to watch webhook
 									compilation flow.

--- a/apps/frontend/web/src/components/landing/use-cases/widgets/system-monitoring.tsx
+++ b/apps/frontend/web/src/components/landing/use-cases/widgets/system-monitoring.tsx
@@ -51,14 +51,16 @@ export default function SystemMonitoringWidget() {
 		<div
 			className={`flex h-full min-h-[420px] flex-col overflow-hidden rounded-2xl border font-sans shadow-2xl transition-all duration-300 ${
 				isSpiking
-					? "border-red-500/30 bg-red-950/20"
-					: "border-white/10 bg-slate-950"
+					? "border-red-500/30 bg-red-50 dark:bg-red-950/20"
+					: "border-stroke-soft-200 bg-bg-white-0 dark:border-white/10 dark:bg-slate-950"
 			}`}
 		>
 			{/* Header */}
 			<div
 				className={`flex items-center justify-between border-white/5 border-b px-4 py-3 transition-colors ${
-					isSpiking ? "bg-red-950/50" : "bg-slate-900"
+					isSpiking
+						? "bg-red-50 dark:bg-red-950/50"
+						: "bg-bg-weak-50 dark:bg-slate-900"
 				}`}
 			>
 				<div className="flex items-center gap-1.5">
@@ -67,15 +69,15 @@ export default function SystemMonitoringWidget() {
 					) : (
 						<span className="h-2.5 w-2.5 rounded-full bg-slate-500" />
 					)}
-					<span className="ml-2 font-mono text-white/40 text-xs">
+					<span className="ml-2 font-mono text-text-sub-600 text-xs dark:text-white/40">
 						sys_monitor_watchdog.sh
 					</span>
 				</div>
 				<span
 					className={`rounded border px-2 py-0.5 font-mono text-[10px] ${
 						isSpiking
-							? "border-red-500/20 bg-red-500/10 text-red-400"
-							: "border-white/10 bg-slate-500/10 text-slate-400"
+							? "border-red-500/20 bg-red-500/10 text-red-600 dark:text-red-400"
+							: "border-stroke-soft-200 bg-slate-500/10 text-text-sub-600 dark:border-white/10 dark:text-slate-400"
 					}`}
 				>
 					{isSpiking ? "ALERTING STATE" : "MONITORING ACTIVE"}
@@ -84,33 +86,33 @@ export default function SystemMonitoringWidget() {
 
 			<div className="flex flex-1 flex-col gap-5 p-5 text-left text-sm">
 				{/* Top Status Cards */}
-				<div className="grid grid-cols-3 gap-3 text-white">
-					<div className="flex flex-col justify-between rounded-xl border border-white/5 bg-slate-900/40 p-3">
-						<span className="font-mono text-[10px] text-white/40">
+				<div className="grid grid-cols-3 gap-3 text-text-strong-950 dark:text-white">
+					<div className="flex flex-col justify-between rounded-xl border border-stroke-soft-200 bg-bg-weak-50/60 p-3 dark:border-white/5 dark:bg-slate-900/40">
+						<span className="font-mono text-[10px] text-text-sub-600 dark:text-white/40">
 							NODE HEALTH
 						</span>
 						<span
-							className={`mt-1 font-bold font-mono text-xs ${isSpiking ? "text-red-400" : "text-emerald-400"}`}
+							className={`mt-1 font-bold font-mono text-xs ${isSpiking ? "text-red-600 dark:text-red-400" : "text-emerald-600 dark:text-emerald-400"}`}
 						>
 							{isSpiking ? "⚠️ UNHEALTHY" : "🟢 HEALTHY"}
 						</span>
 					</div>
-					<div className="flex flex-col justify-between rounded-xl border border-white/5 bg-slate-900/40 p-3">
-						<span className="font-mono text-[10px] text-white/40">
+					<div className="flex flex-col justify-between rounded-xl border border-stroke-soft-200 bg-bg-weak-50/60 p-3 dark:border-white/5 dark:bg-slate-900/40">
+						<span className="font-mono text-[10px] text-text-sub-600 dark:text-white/40">
 							CPU LOAD
 						</span>
 						<span
-							className={`mt-1 font-bold font-mono text-xs ${isSpiking ? "text-red-400" : "text-slate-300"}`}
+							className={`mt-1 font-bold font-mono text-xs ${isSpiking ? "text-red-600 dark:text-red-400" : "text-text-sub-600 dark:text-slate-300"}`}
 						>
 							{isSpiking ? "🔥 98.4%" : "12.6%"}
 						</span>
 					</div>
-					<div className="flex flex-col justify-between rounded-xl border border-white/5 bg-slate-900/40 p-3">
-						<span className="font-mono text-[10px] text-white/40">
+					<div className="flex flex-col justify-between rounded-xl border border-stroke-soft-200 bg-bg-weak-50/60 p-3 dark:border-white/5 dark:bg-slate-900/40">
+						<span className="font-mono text-[10px] text-text-sub-600 dark:text-white/40">
 							P99 LATENCY
 						</span>
 						<span
-							className={`mt-1 font-bold font-mono text-xs ${isSpiking ? "text-red-400" : "text-slate-300"}`}
+							className={`mt-1 font-bold font-mono text-xs ${isSpiking ? "text-red-600 dark:text-red-400" : "text-text-sub-600 dark:text-slate-300"}`}
 						>
 							{isSpiking ? "⚡ 2410ms" : "14ms"}
 						</span>
@@ -118,12 +120,12 @@ export default function SystemMonitoringWidget() {
 				</div>
 
 				{/* Incident Control Section */}
-				<div className="flex items-center justify-between rounded-xl border border-white/5 bg-slate-900/40 p-3.5">
+				<div className="flex items-center justify-between rounded-xl border border-stroke-soft-200 bg-bg-weak-50/60 p-3.5 dark:border-white/5 dark:bg-slate-900/40">
 					<div>
-						<div className="font-mono text-white/40 text-xs">
+						<div className="font-mono text-text-sub-600 text-xs dark:text-white/40">
 							INCIDENT DISPATCHER
 						</div>
-						<div className="mt-0.5 font-mono text-[11px] text-white/60">
+						<div className="mt-0.5 font-mono text-[11px] text-text-sub-600 dark:text-white/60">
 							Send alerts automatically on CPU Spike
 						</div>
 					</div>
@@ -131,7 +133,7 @@ export default function SystemMonitoringWidget() {
 						{isSpiking ? (
 							<button
 								onClick={resetIncident}
-								className="cursor-pointer rounded-lg bg-slate-800 px-3.5 py-1.5 font-medium text-white text-xs transition-colors hover:bg-slate-700"
+								className="cursor-pointer rounded-lg bg-stroke-soft-200 px-3.5 py-1.5 font-medium text-text-strong-950 text-xs transition-colors hover:bg-stroke-sub-300 dark:bg-slate-800 dark:text-white dark:hover:bg-slate-700"
 							>
 								Resolve
 							</button>
@@ -147,8 +149,8 @@ export default function SystemMonitoringWidget() {
 				</div>
 
 				{/* Logger Outputs */}
-				<div className="flex min-h-[140px] flex-1 flex-col justify-between rounded-xl border border-white/5 bg-slate-950 p-3.5 text-left font-mono text-[11px]">
-					<div className="flex max-h-[120px] flex-col gap-1.5 overflow-y-auto text-white/60">
+				<div className="flex min-h-[140px] flex-1 flex-col justify-between rounded-xl border border-stroke-soft-200 bg-bg-white-0 p-3.5 text-left font-mono text-[11px] dark:border-white/5 dark:bg-slate-950">
+					<div className="flex max-h-[120px] flex-col gap-1.5 overflow-y-auto text-text-sub-600 dark:text-white/60">
 						{logs.map((log, index) => (
 							<motion.div
 								key={index}
@@ -157,12 +159,12 @@ export default function SystemMonitoringWidget() {
 								transition={{ duration: 0.1 }}
 								className={
 									log.includes("🚨") || log.includes("⚠️")
-										? "font-semibold text-red-400"
+										? "font-semibold text-red-600 dark:text-red-400"
 										: log.includes("📧") || log.includes("📬")
-											? "text-slate-300"
+											? "text-text-sub-600 dark:text-slate-300"
 											: log.includes("✅")
-												? "text-emerald-400"
-												: "text-white/45"
+												? "text-emerald-600 dark:text-emerald-400"
+												: "text-text-sub-600 dark:text-white/45"
 								}
 							>
 								{log}

--- a/apps/frontend/web/src/components/landing/use-cases/widgets/transactional.tsx
+++ b/apps/frontend/web/src/components/landing/use-cases/widgets/transactional.tsx
@@ -43,28 +43,30 @@ export default function TransactionalWidget() {
 	};
 
 	return (
-		<div className="flex h-full min-h-[420px] flex-col overflow-hidden rounded-2xl border border-white/10 bg-slate-950 font-sans shadow-2xl">
+		<div className="flex h-full min-h-[420px] flex-col overflow-hidden rounded-2xl border border-stroke-soft-200 bg-bg-white-0 font-sans shadow-lg dark:border-white/10 dark:bg-slate-950 dark:shadow-2xl">
 			{/* Terminal Header */}
-			<div className="flex items-center justify-between border-white/5 border-b bg-slate-900 px-4 py-3">
+			<div className="flex items-center justify-between border-stroke-soft-200 border-b bg-bg-weak-50 px-4 py-3 dark:border-white/5 dark:bg-slate-900">
 				<div className="flex items-center gap-1.5">
 					<span className="h-2.5 w-2.5 rounded-full bg-red-500/80" />
 					<span className="h-2.5 w-2.5 rounded-full bg-yellow-500/80" />
 					<span className="h-2.5 w-2.5 rounded-full bg-green-500/80" />
-					<span className="ml-2 font-mono text-white/40 text-xs">
+					<span className="ml-2 font-mono text-text-sub-600 text-xs dark:text-white/40">
 						transactional_debugger.sh
 					</span>
 				</div>
-				<span className="rounded border border-blue-500/20 bg-blue-500/10 px-2 py-0.5 font-mono text-[10px] text-blue-400">
+				<span className="rounded border border-blue-500/20 bg-blue-500/10 px-2 py-0.5 font-mono text-[10px] text-blue-600 dark:text-blue-400">
 					Latency API
 				</span>
 			</div>
 
-			<div className="flex flex-1 flex-col gap-5 p-5 text-sm text-white/90">
+			<div className="flex flex-1 flex-col gap-5 p-5 text-sm text-text-strong-950 dark:text-white/90">
 				{/* Top Controls */}
-				<div className="flex items-center justify-between rounded-xl border border-white/5 bg-slate-900/60 p-3">
+				<div className="flex items-center justify-between rounded-xl border border-stroke-soft-200 bg-bg-weak-50/60 p-3 dark:border-white/5 dark:bg-slate-900/60">
 					<div>
-						<div className="font-mono text-white/40 text-xs">ENDPOINT</div>
-						<div className="mt-0.5 font-mono text-white/70 text-xs">
+						<div className="font-mono text-text-sub-600 text-xs dark:text-white/40">
+							ENDPOINT
+						</div>
+						<div className="mt-0.5 font-mono text-text-sub-600 text-xs dark:text-white/70">
 							https://api.reloop.sh/v1/emails
 						</div>
 					</div>
@@ -73,13 +75,13 @@ export default function TransactionalWidget() {
 						disabled={status === "sending"}
 						className={`flex items-center gap-1.5 rounded-lg px-4 py-2 font-medium text-xs transition-all ${
 							status === "sending"
-								? "cursor-not-allowed bg-slate-800 text-white/40"
+								? "cursor-not-allowed bg-stroke-soft-200 text-text-sub-600 dark:bg-slate-800 dark:text-white/40"
 								: "cursor-pointer bg-blue-600 text-white shadow-blue-500/10 shadow-lg hover:bg-blue-500 active:scale-95"
 						}`}
 					>
 						{status === "sending" ? (
 							<>
-								<div className="h-3 w-3 animate-spin rounded-full border-2 border-white/20 border-t-white" />
+								<div className="h-3 w-3 animate-spin rounded-full border-2 border-stroke-soft-200 border-t-text-strong-950 dark:border-white/20 dark:border-t-white" />
 								Sending...
 							</>
 						) : (
@@ -89,9 +91,9 @@ export default function TransactionalWidget() {
 				</div>
 
 				{/* Visual Flow Timeline */}
-				<div className="relative flex items-center justify-between overflow-hidden rounded-xl border border-white/5 bg-slate-900/30 px-6 py-4">
+				<div className="relative flex items-center justify-between overflow-hidden rounded-xl border border-stroke-soft-200 bg-bg-weak-50/50 px-6 py-4 dark:border-white/5 dark:bg-slate-900/30">
 					{/* Flow Connector Line */}
-					<div className="-translate-y-1/2 absolute top-1/2 right-[15%] left-[15%] z-0 h-0.5 bg-slate-800">
+					<div className="-translate-y-1/2 absolute top-1/2 right-[15%] left-[15%] z-0 h-0.5 bg-stroke-soft-200 dark:bg-slate-800">
 						{status === "sending" && (
 							<motion.div
 								className="h-full origin-left bg-blue-500"
@@ -110,13 +112,13 @@ export default function TransactionalWidget() {
 						<div
 							className={`flex h-9 w-9 items-center justify-center rounded-full border transition-all ${
 								activeStep >= 0
-									? "border-blue-500 bg-blue-950 text-blue-400 shadow-blue-500/20 shadow-lg"
-									: "border-white/10 bg-slate-900 text-white/40"
+									? "border-blue-500 bg-blue-50 text-blue-600 shadow-blue-500/20 shadow-lg dark:bg-blue-950 dark:text-blue-400"
+									: "border-stroke-soft-200 bg-bg-weak-50 text-text-sub-600 dark:border-white/10 dark:bg-slate-900 dark:text-white/40"
 							}`}
 						>
 							<Icon name="laptop" className="h-4 w-4" />
 						</div>
-						<span className="font-mono text-[10px] text-white/60">
+						<span className="font-mono text-[10px] text-text-sub-600 dark:text-white/60">
 							App Send
 						</span>
 					</div>
@@ -126,15 +128,15 @@ export default function TransactionalWidget() {
 						<div
 							className={`flex h-9 w-9 items-center justify-center rounded-full border transition-all ${
 								activeStep >= 1
-									? "border-blue-500 bg-blue-950 text-blue-400 shadow-blue-500/20 shadow-lg"
+									? "border-blue-500 bg-blue-50 text-blue-600 shadow-blue-500/20 shadow-lg dark:bg-blue-950 dark:text-blue-400"
 									: activeStep === 0
-										? "animate-pulse border-blue-500/50 bg-slate-900 text-blue-400/60"
-										: "border-white/10 bg-slate-900 text-white/40"
+										? "animate-pulse border-blue-500/50 bg-bg-weak-50 text-blue-600/70 dark:bg-slate-900 dark:text-blue-400/60"
+										: "border-stroke-soft-200 bg-bg-weak-50 text-text-sub-600 dark:border-white/10 dark:bg-slate-900 dark:text-white/40"
 							}`}
 						>
 							<Icon name="Server" className="h-4 w-4" />
 						</div>
-						<span className="font-mono text-[10px] text-white/60">
+						<span className="font-mono text-[10px] text-text-sub-600 dark:text-white/60">
 							Reloop MTU
 						</span>
 					</div>
@@ -144,25 +146,25 @@ export default function TransactionalWidget() {
 						<div
 							className={`flex h-9 w-9 items-center justify-center rounded-full border transition-all ${
 								status === "success"
-									? "border-green-500 bg-green-950 text-green-400 shadow-green-500/20 shadow-lg"
+									? "border-green-500 bg-green-50 text-green-600 shadow-green-500/20 shadow-lg dark:bg-green-950 dark:text-green-400"
 									: activeStep === 2
-										? "animate-pulse border-blue-500/50 bg-slate-900 text-blue-400/60"
-										: "border-white/10 bg-slate-900 text-white/40"
+										? "animate-pulse border-blue-500/50 bg-bg-weak-50 text-blue-600/70 dark:bg-slate-900 dark:text-blue-400/60"
+										: "border-stroke-soft-200 bg-bg-weak-50 text-text-sub-600 dark:border-white/10 dark:bg-slate-900 dark:text-white/40"
 							}`}
 						>
 							<Icon name="CheckCircle" className="h-4 w-4" />
 						</div>
-						<span className="font-mono text-[10px] text-white/60">
+						<span className="font-mono text-[10px] text-text-sub-600 dark:text-white/60">
 							Delivered
 						</span>
 					</div>
 				</div>
 
 				{/* Terminal output */}
-				<div className="flex min-h-[160px] flex-1 flex-col justify-between rounded-xl border border-white/5 bg-slate-950 p-4 font-mono text-xs">
-					<div className="flex max-h-[140px] flex-col gap-1.5 overflow-y-auto text-white/50">
+				<div className="flex min-h-[160px] flex-1 flex-col justify-between rounded-xl border border-stroke-soft-200 bg-bg-white-0 p-4 font-mono text-xs dark:border-white/5 dark:bg-slate-950">
+					<div className="flex max-h-[140px] flex-col gap-1.5 overflow-y-auto text-text-sub-600 dark:text-white/50">
 						{logs.length === 0 && (
-							<span className="text-white/25 italic">
+							<span className="text-text-soft-400 italic dark:text-white/25">
 								Click 'Run API Request' to inspect SMTP and webhook delivery
 								lifecycle.
 							</span>
@@ -175,10 +177,10 @@ export default function TransactionalWidget() {
 								transition={{ duration: 0.15 }}
 								className={
 									log.startsWith("⚡")
-										? "text-blue-400"
+										? "text-blue-600 dark:text-blue-400"
 										: log.startsWith("📨") || log.startsWith("✅")
-											? "text-emerald-400"
-											: "text-white/60"
+											? "text-emerald-600 dark:text-emerald-400"
+											: "text-text-sub-600 dark:text-white/60"
 								}
 							>
 								{log}
@@ -190,7 +192,7 @@ export default function TransactionalWidget() {
 						<motion.div
 							initial={{ opacity: 0, y: 5 }}
 							animate={{ opacity: 1, y: 0 }}
-							className="mt-3 flex items-center justify-between rounded border-white/5 border-t bg-emerald-500/5 px-2 py-1 pt-3 font-mono text-[11px] text-emerald-400"
+							className="mt-3 flex items-center justify-between rounded border-stroke-soft-200 border-t bg-emerald-500/5 px-2 py-1 pt-3 font-mono text-[11px] text-emerald-600 dark:border-white/5 dark:text-emerald-400"
 						>
 							<span>🚀 delivery.confirmed</span>
 							<span>latency: 1.4s</span>

--- a/apps/frontend/web/src/components/landing/use-cases/widgets/welcome.tsx
+++ b/apps/frontend/web/src/components/landing/use-cases/widgets/welcome.tsx
@@ -22,39 +22,39 @@ export default function WelcomeWidget() {
 	const completedCount = tasks.filter((t) => t.completed).length;
 
 	return (
-		<div className="flex h-full min-h-[420px] flex-col overflow-hidden rounded-2xl border border-white/10 bg-slate-950 text-left font-sans shadow-2xl">
+		<div className="flex h-full min-h-[420px] flex-col overflow-hidden rounded-2xl border border-stroke-soft-200 bg-bg-white-0 text-left font-sans shadow-lg dark:border-white/10 dark:bg-slate-950 dark:shadow-2xl">
 			{/* Header */}
-			<div className="flex items-center justify-between border-white/5 border-b bg-slate-900 px-4 py-3">
+			<div className="flex items-center justify-between border-stroke-soft-200 border-b bg-bg-weak-50 px-4 py-3 dark:border-white/5 dark:bg-slate-900">
 				<div className="flex items-center gap-1.5">
 					<span className="h-2.5 w-2.5 rounded-full bg-emerald-500/80" />
 					<span className="h-2.5 w-2.5 rounded-full bg-yellow-500/80" />
 					<span className="h-2.5 w-2.5 rounded-full bg-green-500/80" />
-					<span className="ml-2 font-mono text-white/40 text-xs">
+					<span className="ml-2 font-mono text-text-sub-600 text-xs dark:text-white/40">
 						welcome_drip_variables.config
 					</span>
 				</div>
-				<span className="rounded border border-emerald-500/20 bg-emerald-500/10 px-2 py-0.5 font-mono text-[10px] text-emerald-400">
+				<span className="rounded border border-emerald-500/20 bg-emerald-500/10 px-2 py-0.5 font-mono text-[10px] text-emerald-600 dark:text-emerald-400">
 					Onboarding Drip
 				</span>
 			</div>
 
 			<div className="grid flex-1 grid-cols-1 gap-4 p-4 md:grid-cols-2">
 				{/* Left Side: Onboarding Settings */}
-				<div className="flex flex-col gap-4 rounded-xl border border-white/5 bg-slate-900/40 p-4">
+				<div className="flex flex-col gap-4 rounded-xl border border-stroke-soft-200 bg-bg-weak-50/60 p-4 dark:border-white/5 dark:bg-slate-900/40">
 					<div>
-						<label className="mb-1 block font-mono text-[10px] text-white/40">
+						<label className="mb-1 block font-mono text-[10px] text-text-sub-600 dark:text-white/40">
 							USER FIRST NAME
 						</label>
 						<input
 							type="text"
 							value={userName}
 							onChange={(e) => setUserName(e.target.value)}
-							className="w-full rounded border border-white/10 bg-slate-900 px-2.5 py-1.5 text-white text-xs focus:border-emerald-500/50 focus:outline-none"
+							className="w-full rounded border border-stroke-soft-200 bg-bg-weak-50 px-2.5 py-1.5 text-text-strong-950 text-xs focus:border-emerald-500/50 focus:outline-none dark:border-white/10 dark:bg-slate-900 dark:text-white"
 						/>
 					</div>
 
 					<div className="flex flex-1 flex-col gap-2">
-						<label className="block font-mono text-[10px] text-white/40">
+						<label className="block font-mono text-[10px] text-text-sub-600 dark:text-white/40">
 							SIMULATED CHECKLIST PROGRESS
 						</label>
 
@@ -64,15 +64,15 @@ export default function WelcomeWidget() {
 								onClick={() => toggleTask(task.id)}
 								className={`flex cursor-pointer items-center gap-2.5 rounded-lg border p-2 text-left text-xs transition-colors ${
 									task.completed
-										? "border-emerald-500/30 bg-emerald-950/20 text-emerald-300"
-										: "border-white/5 bg-slate-900 text-white/50"
+										? "border-emerald-500/30 bg-emerald-50 text-emerald-600 dark:bg-emerald-950/20 dark:text-emerald-300"
+										: "border-stroke-soft-200 bg-bg-weak-50 text-text-sub-600 dark:border-white/5 dark:bg-slate-900 dark:text-white/50"
 								}`}
 							>
 								<div
 									className={`flex h-3.5 w-3.5 items-center justify-center rounded border ${
 										task.completed
 											? "border-emerald-500 bg-emerald-500 text-white"
-											: "border-white/20"
+											: "border-stroke-soft-200 dark:border-white/20"
 									}`}
 								>
 									{task.completed && (
@@ -86,31 +86,33 @@ export default function WelcomeWidget() {
 				</div>
 
 				{/* Right Side: Welcome Email Preview with Variables */}
-				<div className="flex flex-col justify-between rounded-xl border border-white/5 bg-slate-900 p-3">
-					<div className="flex flex-1 flex-col gap-3 rounded-lg border border-white/5 bg-slate-950 p-3.5 text-left">
-						<div className="border-white/5 border-b pb-2">
-							<div className="font-mono text-[9px] text-white/40">
+				<div className="flex flex-col justify-between rounded-xl border border-stroke-soft-200 bg-bg-weak-50 p-3 dark:border-white/5 dark:bg-slate-900">
+					<div className="flex flex-1 flex-col gap-3 rounded-lg border border-stroke-soft-200 bg-bg-white-0 p-3.5 text-left dark:border-white/5 dark:bg-slate-950">
+						<div className="border-stroke-soft-200 border-b pb-2 dark:border-white/5">
+							<div className="font-mono text-[9px] text-text-sub-600 dark:text-white/40">
 								SUBJECT: Welcome to Reloop, {userName}!
 							</div>
 						</div>
 
-						<div className="flex-1 space-y-3 text-white/80 text-xs leading-relaxed">
-							<p className="font-semibold text-white">Hi {userName},</p>
+						<div className="flex-1 space-y-3 text-text-strong-950 text-xs leading-relaxed dark:text-white/80">
+							<p className="font-semibold text-text-strong-950 dark:text-white">
+								Hi {userName},
+							</p>
 							<p>
 								We're thrilled to have you here. You have completed{" "}
-								<strong className="font-mono text-emerald-400">
+								<strong className="font-mono text-emerald-600 dark:text-emerald-400">
 									{completedCount} of 3
 								</strong>{" "}
 								checklist onboarding steps.
 							</p>
 
 							{/* Checklist progress tracker card in email */}
-							<div className="space-y-1.5 rounded-lg border border-white/5 bg-slate-900 p-2.5">
-								<div className="flex items-center justify-between font-mono text-[9px] text-white/40">
+							<div className="space-y-1.5 rounded-lg border border-stroke-soft-200 bg-bg-weak-50 p-2.5 dark:border-white/5 dark:bg-slate-900">
+								<div className="flex items-center justify-between font-mono text-[9px] text-text-sub-600 dark:text-white/40">
 									<span>SETUP PROGRESS</span>
 									<span>{Math.round((completedCount / 3) * 100)}%</span>
 								</div>
-								<div className="h-1.5 w-full overflow-hidden rounded-full border border-white/5 bg-slate-950">
+								<div className="h-1.5 w-full overflow-hidden rounded-full border border-stroke-soft-200 bg-bg-white-0 dark:border-white/5 dark:bg-slate-950">
 									<div
 										className="h-full bg-emerald-500 transition-all duration-300"
 										style={{ width: `${(completedCount / 3) * 100}%` }}
@@ -123,7 +125,7 @@ export default function WelcomeWidget() {
 									Complete Your Setup
 								</div>
 							) : (
-								<div className="w-full rounded border border-white/5 bg-slate-800 py-1.5 text-center font-bold text-[9px] text-slate-400">
+								<div className="w-full rounded border border-stroke-soft-200 bg-stroke-soft-200 py-1.5 text-center font-bold text-[9px] text-text-sub-600 dark:border-white/5 dark:bg-slate-800 dark:text-slate-400">
 									Setup Completed! 🎉
 								</div>
 							)}

--- a/apps/frontend/web/src/lib/compare-content.ts
+++ b/apps/frontend/web/src/lib/compare-content.ts
@@ -4,6 +4,7 @@ import {
 	comparisonCellText,
 } from "@reloop/web/app/compare/compare-types";
 import { loopsComparisonCategories } from "@reloop/web/app/compare/loops/comparison-data";
+import { mailgunComparisonCategories } from "@reloop/web/app/compare/mailgun/comparison-data";
 import { resendComparisonCategories } from "@reloop/web/app/compare/resend/comparison-data";
 import { pricingFaqItems } from "@reloop/web/lib/pricing-faq";
 import {
@@ -45,34 +46,6 @@ const sendgridFeatures: ComparisonFeatureRow[] = [
 		label: "Contract flexibility",
 		reloop: "Monthly tiers + self-host",
 		competitor: "Often annual enterprise",
-	},
-];
-
-const mailgunFeatures: ComparisonFeatureRow[] = [
-	{
-		label: "Open-source codebase",
-		reloop: "Yes (Apache 2.0)",
-		competitor: "No",
-	},
-	{ label: "Self-hostable", reloop: "Yes", competitor: "No" },
-	{ label: "REST API", reloop: "Yes", competitor: "Yes" },
-	{ label: "SMTP relay", reloop: "Yes", competitor: "Yes" },
-	{
-		label: "Inbound / reply handling",
-		reloop: "Agent inbox",
-		competitor: "Inbound routes",
-	},
-	{ label: "Email validation API", reloop: "Yes", competitor: "Yes" },
-	{
-		label: "Marketing campaigns",
-		reloop: "Yes",
-		competitor: "Limited",
-	},
-	{ label: "Agent / AI workflows", reloop: "Yes", competitor: "No" },
-	{
-		label: "Free tier",
-		reloop: "3,000 emails / month · 200 / day",
-		competitor: "Trial-based",
 	},
 ];
 
@@ -242,7 +215,7 @@ export const comparePages: ComparePageContent[] = [
 			"Learn how Reloop compares to Mailgun for developer email APIs and SMTP.",
 		summary:
 			"Reloop offers REST + SMTP, inbound agent inbox, and Apache 2.0 self-host. Mailgun is hosted SaaS with inbound routes. Reloop Free is 3,000 emails/month (200/day).",
-		features: mailgunFeatures,
+		categories: mailgunComparisonCategories,
 		faqs: [
 			{
 				question: "Can Reloop replace Mailgun inbound routes?",
@@ -252,7 +225,17 @@ export const comparePages: ComparePageContent[] = [
 			{
 				question: "Do we lose deliverability moving off Mailgun?",
 				answer:
-					"Deliverability depends on domain reputation, content, and IPs—not the dashboard brand. Self-hosted Reloop lets you own IPs directly; hosted Reloop manages shared pools like other providers.",
+					"Deliverability depends on domain reputation, content, and IPs, not the dashboard brand. Self-hosted Reloop lets you own IPs directly; hosted Reloop manages shared pools like other providers.",
+			},
+			{
+				question: "How does Reloop Cloud pricing compare to Mailgun?",
+				answer:
+					"Mailgun Basic is $15/month for 10,000 emails and Foundation is $35/month for 50,000, with overage from $1.30 per 1,000. Reloop Pro is $10/month for 50,000 emails and Growth is $20/month for 100,000, with overage at $0.50 per 1,000. Self-hosted Reloop has no Reloop license fee; you pay your own infrastructure.",
+			},
+			{
+				question: "Do SMTP senders need code changes?",
+				answer:
+					"No. Applications sending over SMTP change host, port, and credentials only. API senders need a small client adapter, since Reloop is not a drop-in Mailgun proxy.",
 			},
 		],
 	},
@@ -497,7 +480,6 @@ export function buildCompareJsonLd(page: ComparePageContent) {
 
 export {
 	sendgridFeatures,
-	mailgunFeatures,
 	awsSesFeatures,
 	postmarkFeatures,
 	mailchimpFeatures,

--- a/apps/frontend/web/src/lib/landing/use-cases/ai-agent-inbox.ts
+++ b/apps/frontend/web/src/lib/landing/use-cases/ai-agent-inbox.ts
@@ -5,7 +5,7 @@ export const config: LandingPageDefinition = {
 	path: "/use-cases/ai-agent-inbox",
 	titleLines: ["AI Agent", "Email Inbox"],
 	description:
-		"Give your AI agents a real inbox — read threads, draft replies, and send on approval. Purpose-built APIs so agents handle email without going rogue.",
+		"Give your AI agents a real inbox: read threads, draft replies, and send on approval. Purpose-built APIs so agents handle email without going rogue.",
 	keywords: [
 		"AI email agent",
 		"agent inbox API",

--- a/apps/frontend/web/src/lib/landing/use-cases/automated-email.ts
+++ b/apps/frontend/web/src/lib/landing/use-cases/automated-email.ts
@@ -5,7 +5,7 @@ export const config: LandingPageDefinition = {
 	path: "/use-cases/automated-email",
 	titleLines: ["Automated", "Email Flows"],
 	description:
-		"Trigger welcome series, drip campaigns, and renewal reminders from any user event — then let Reloop handle sequencing, timing, and per-step analytics.",
+		"Trigger welcome series, drip campaigns, and renewal reminders from any user event, then let Reloop handle sequencing, timing, and per-step analytics.",
 	keywords: [
 		"email automation",
 		"drip campaign software",

--- a/apps/frontend/web/src/lib/landing/use-cases/email-verification.ts
+++ b/apps/frontend/web/src/lib/landing/use-cases/email-verification.ts
@@ -5,7 +5,7 @@ export const config: LandingPageDefinition = {
 	path: "/use-cases/email-verification",
 	titleLines: ["Email Verification", "API"],
 	description:
-		"Verify new accounts with a magic link or OTP code that lands in under 3 seconds — and block typos before they hit your list with address validation built in.",
+		"Verify new accounts with a magic link or OTP code that lands in under 3 seconds, and block typos before they hit your list with address validation built in.",
 	keywords: [
 		"email verification API",
 		"verify email address API",

--- a/apps/frontend/web/src/lib/landing/use-cases/inbound-email.ts
+++ b/apps/frontend/web/src/lib/landing/use-cases/inbound-email.ts
@@ -5,7 +5,7 @@ export const config: LandingPageDefinition = {
 	path: "/use-cases/inbound-email",
 	titleLines: ["Inbound", "Email API"],
 	description:
-		"Turn incoming email into app data. Reloop parses every message and POSTs a structured webhook to your endpoint — attachments, threads, and metadata included.",
+		"Turn incoming email into app data. Reloop parses every message and POSTs a structured webhook to your endpoint, attachments, threads, and metadata included.",
 	keywords: [
 		"inbound email API",
 		"receive email webhook",
@@ -45,7 +45,8 @@ export const config: LandingPageDefinition = {
 	cta: {
 		title: "Handle inbound email in your app",
 		titleMuted: "Start free today.",
-		description: "Send and receive on one platform—no separate inbound vendor.",
+		description:
+			"Send and receive on one platform, with no separate inbound vendor.",
 		primary: {
 			label: "Get started free",
 			href: "/dashboard/signup",

--- a/apps/frontend/web/src/lib/landing/use-cases/order-confirmation-email.ts
+++ b/apps/frontend/web/src/lib/landing/use-cases/order-confirmation-email.ts
@@ -5,7 +5,7 @@ export const config: LandingPageDefinition = {
 	path: "/use-cases/order-confirmation-email",
 	titleLines: ["Order Confirmation", "Emails"],
 	description:
-		"Send a polished receipt with line items and totals the second checkout completes — triggered from your order webhook, no extra service needed.",
+		"Send a polished receipt with line items and totals the second checkout completes, triggered from your order webhook with no extra service needed.",
 	keywords: [
 		"order confirmation email API",
 		"purchase receipt email",
@@ -37,7 +37,7 @@ export const config: LandingPageDefinition = {
 				{
 					title: "High deliverability",
 					description:
-						"Receipt emails must reach the inbox—authentication and monitoring built in.",
+						"Receipt emails must reach the inbox, so authentication and monitoring are built in.",
 				},
 			],
 		},

--- a/apps/frontend/web/src/lib/landing/use-cases/password-reset-email.ts
+++ b/apps/frontend/web/src/lib/landing/use-cases/password-reset-email.ts
@@ -5,7 +5,7 @@ export const config: LandingPageDefinition = {
 	path: "/use-cases/password-reset-email",
 	titleLines: ["Password Reset", "Email API"],
 	description:
-		"Deliver tokenized reset links in seconds — before the user gives up and contacts support. Bounce webhooks tell you when delivery fails so you can act.",
+		"Deliver tokenized reset links in seconds, before the user gives up and contacts support. Bounce webhooks tell you when delivery fails so you can act.",
 	keywords: [
 		"password reset email API",
 		"forgot password email",
@@ -27,7 +27,7 @@ export const config: LandingPageDefinition = {
 				{
 					title: "Instant delivery",
 					description:
-						"Users expect reset links in seconds—Reloop delivers with low latency.",
+						"Users expect reset links in seconds. Reloop delivers with low latency.",
 				},
 				{
 					title: "Template variables",

--- a/apps/frontend/web/src/lib/landing/use-cases/payment-receipt-email.ts
+++ b/apps/frontend/web/src/lib/landing/use-cases/payment-receipt-email.ts
@@ -5,7 +5,7 @@ export const config: LandingPageDefinition = {
 	path: "/use-cases/payment-receipt-email",
 	titleLines: ["Payment Receipt", "Emails"],
 	description:
-		"Hook into Stripe's invoice.paid and payment.succeeded events to fire branded receipts automatically — for one-time charges, renewals, and refunds alike.",
+		"Hook into Stripe's invoice.paid and payment.succeeded events to fire branded receipts automatically for one-time charges, renewals, and refunds alike.",
 	keywords: [
 		"payment receipt email API",
 		"invoice email service",

--- a/apps/frontend/web/src/lib/landing/use-cases/transactional-email.ts
+++ b/apps/frontend/web/src/lib/landing/use-cases/transactional-email.ts
@@ -5,7 +5,7 @@ export const config: LandingPageDefinition = {
 	path: "/use-cases/transactional-email",
 	titleLines: ["Transactional", "Email API"],
 	description:
-		"Receipts, password resets, and notifications that arrive in under 2 seconds — with webhook confirmation so your app always knows what landed.",
+		"Receipts, password resets, and notifications that arrive in under 2 seconds, with webhook confirmation so your app always knows what landed.",
 	keywords: [
 		"transactional email API",
 		"transactional email service",

--- a/apps/frontend/web/src/lib/landing/use-cases/welcome-email.ts
+++ b/apps/frontend/web/src/lib/landing/use-cases/welcome-email.ts
@@ -5,7 +5,7 @@ export const config: LandingPageDefinition = {
 	path: "/use-cases/welcome-email",
 	titleLines: ["Welcome Email", "Automation"],
 	description:
-		"Fire a branded welcome the moment someone signs up — then extend into a multi-step onboarding series without touching the trigger code again.",
+		"Fire a branded welcome the moment someone signs up, then extend into a multi-step onboarding series without touching the trigger code again.",
 	keywords: [
 		"welcome email automation",
 		"onboarding email API",


### PR DESCRIPTION
Revamps `/compare/mailgun` and fixes light mode across the use-case pages.

## Compare: Mailgun

Moves the page onto the same layout `/compare/resend` and `/compare/loops` use: stat strip, narrative section, `ComparisonMatrix`, `CompareMigrate`. The flat `mailgunFeatures` table is replaced by four categories in `mailgun/comparison-data.ts` (pricing, sending, data, ownership), which the `.md` route picks up too.

Mailgun is Sinch, not Twilio. The old copy said Twilio; corrected.

## Light mode

`ConsoleFirstLayout` was hardcoded `bg-slate-950` with no `dark:` variants, so `/use-cases/ai-agent-inbox`, `/inbound-email` and `/system-monitoring-email` stayed near-black while the header and footer went light. Its three sibling layouts were already theme-aware, so this ports it onto the same tokens. It was also computing `accentStyles[extra.accent]` into `_accent` and discarding it in favour of hardcoded cyan.

Same problem in `ToolUpsell` (a black slab with `!`-forced white buttons, shared by the tools and alternatives pages) and in all eleven console widgets. Each dark value now has a light counterpart:

| dark | light |
| --- | --- |
| `bg-slate-950` / `900` | `bg-bg-white-0` / `bg-bg-weak-50` |
| `bg-slate-800` / `700` | `stroke-soft-200` / `stroke-sub-300` |
| `border-white/5`–`/20` | `border-stroke-soft-200` |
| `text-white/40`–`/95` | `text-text-sub-600` / `text-text-strong-950` |
| `text-{hue}-300/400` | `text-{hue}-600` |
| `bg-{hue}-950` | `bg-{hue}-50` |

`text-white` stays only where it sits on a saturated button. The quantity chips and the disabled send button were `bg-slate-800 text-white`, which would have become white-on-light-gray. `slate-800` rails map to `stroke-soft-200` so the flow connectors still read against their cards.

Two spots had no `dark:` prefix at all and so were unreadable in light mode: the JSON payload in `inbound` (`text-cyan-300/80`, ~1.2:1 on the light card) and the in-flight timeline nodes in `transactional`.

## Broken sprite icons

`Icon` resolves `name` against a kebab-case sprite, but several widgets passed lucide-style PascalCase names, so `<use href="#CheckCircle">` matched nothing and rendered blank. Fixed in the widgets touched here: `CheckCircle`, `XCircle`, `Check`, `Trash2`, `Wifi`, `Lock`, `ShieldAlert`, `KeyRound`.

Around 20 more remain in the untouched widgets, three tools pages, and `packages/ui` (`tag`, `dropdown`, `context-menu`) — left for a follow-up.

## Smaller fixes

- Footer open-source seal and the agent card rules used `stroke-soft-100`, which is `#f5f5f5` on white and invisible.
- Agent Skills chips were pink in light mode and blue in dark.
- `password-reset`: the control button overflowed its card and covered the auth-type label (needed `min-w-0` + `shrink-0`); rebuilt the phone as an actual iPhone silhouette (19.5:9, Dynamic Island, side buttons, home indicator) instead of a 1:1.6 box with a notch pill.
- `email-verification`: the Identity OTP badge sat flush against the truncated filename; `fingerprint` now replaces the blank shield icon.
- Removed em dashes and emoji from the use-case and compare copy.

## Verification

`tsc --noEmit` exits 0. Biome clean on every changed file — the widget lint count is 20 before and after, i.e. all remaining findings are pre-existing `useButtonType` / `noLabelWithoutControl`. All ten `/use-cases/*` routes plus `/compare/mailgun`, `/compare/mailgun.md`, `/compare/resend`, `/compare/sendgrid`, `/compare`, and `/home` return 200 against `next dev`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a category-based Mailgun comparison experience with pricing, delivery, security, and ownership details.
  - Added migration guidance, pricing highlights, exit considerations, and expanded Mailgun FAQs.

- **Style**
  - Updated landing-page widgets and use-case sections to support consistent light and dark themes.
  - Refined colors, borders, icons, buttons, diagrams, and responsive visual details across marketing pages.

- **Documentation**
  - Improved landing-page and comparison-page wording for clearer, more consistent messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=62844080"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR appears safe to merge, with a non-blocking visual defect in two transactional-flow icons.

<h2>Findings</h2>

1. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Blank transactional flow icons** <a href="https://github.com/reloop-labs/reloop/pull/127#discussion_r3984099223">▶</a>

<h3>Summary</h3>

- Adds light-mode styling across `ConsoleFirstLayout`, `ToolUpsell`, and eleven interactive use-case widgets.
- Replaces Mailgun’s flat feature table with categorized pricing, sending, security, and ownership data shared with the Markdown route.
- Refreshes the Mailgun narrative, statistics, migration steps, and company attribution.
- Improves several responsive details, icon references, and light-mode borders, while two icons remain unresolved in the transactional widget.

<sub>Reviews (1) · Last reviewed commit: ["fix: email verification widget header an..."](https://github.com/reloop-labs/reloop/commit/f603ed3a0a3f66548d8336fd9ad3a3e106b4c913)</sub>

<!-- /greptile_comment -->