### PR TITLE
fix: keep OTPs and DKIM private keys out of logs

### DIFF
--- a/apps/backend/email/src/subscribers/api-key.subscriber.ts
+++ b/apps/backend/email/src/subscribers/api-key.subscriber.ts
@@ -62,7 +62,7 @@ export async function initApiKeySubscribers() {
 				});
 			} catch (error) {
 				log.error({
-					...{ error, payload },
+					...{ error, apiKeyId: payload.api_key_id },
 					message: "Failed to send API key created email",
 				});
 			}

--- a/apps/backend/email/src/subscribers/auth.subscriber.ts
+++ b/apps/backend/email/src/subscribers/auth.subscriber.ts
@@ -47,7 +47,7 @@ export async function initAuthSubscribers() {
 				});
 			} catch (error) {
 				log.error({
-					...{ error, payload },
+					...{ error, email: payload.email },
 					message: "Failed to send welcome email",
 				});
 			}
@@ -60,19 +60,18 @@ export async function initAuthSubscribers() {
 		BusEvent.OTP_REQUESTED,
 		async (payload) => {
 			// Dedup OTP by email and OTP value to avoid double sends for the same request
-			const dedupKey = `email:otp:${payload.email}:${payload.otp}`;
+			const dedupKey = `email:otp:${payload.email}:${payload.type}`;
 			try {
-				const alreadySent = await redis.get(dedupKey);
-				if (alreadySent) {
+				const alreadySent = await redis.get<string | number>(dedupKey);
+				if (alreadySent !== undefined && String(alreadySent) === payload.otp) {
 					log.warn(
 						"server",
 						`Duplicate OTP_REQUESTED for ${payload.email}, skipping`,
 					);
 					return;
 				}
-				await redis.set(dedupKey, "1", 60);
+				await redis.set(dedupKey, payload.otp, 60);
 
-				console.log(payload, "OTP PAYLOAD");
 				const html = await render(
 					React.createElement(OtpEmail, {
 						otp: payload.otp,
@@ -99,7 +98,7 @@ export async function initAuthSubscribers() {
 				});
 			} catch (error) {
 				log.error({
-					...{ error, payload },
+					...{ error, email: payload.email, type: payload.type },
 					message: "Failed to send OTP email",
 				});
 			}
@@ -161,7 +160,7 @@ export async function initAuthSubscribers() {
 				});
 			} catch (error) {
 				log.error({
-					...{ error, payload },
+					...{ error, email: payload.email },
 					message: "Failed to send signin detected email",
 				});
 			}

--- a/apps/backend/email/src/subscribers/billing.subscriber.ts
+++ b/apps/backend/email/src/subscribers/billing.subscriber.ts
@@ -39,7 +39,7 @@ export async function initBillingSubscribers() {
 				});
 			} catch (error) {
 				log.error({
-					...{ error, payload },
+					...{ error, email: payload.email, planName: payload.planName },
 					message: "Failed to send payment failed email",
 				});
 			}
@@ -75,7 +75,11 @@ export async function initBillingSubscribers() {
 				});
 			} catch (error) {
 				log.error({
-					...{ error, payload },
+					...{
+						error,
+						email: payload.email,
+						resourceType: payload.resourceType,
+					},
 					message: "Failed to send quota warning email",
 				});
 			}
@@ -111,7 +115,7 @@ export async function initBillingSubscribers() {
 				});
 			} catch (error) {
 				log.error({
-					...{ error, payload },
+					...{ error, email: payload.email, daysLeft: payload.daysLeft },
 					message: "Failed to send trial ending email",
 				});
 			}

--- a/apps/backend/email/src/subscribers/domain.subscriber.ts
+++ b/apps/backend/email/src/subscribers/domain.subscriber.ts
@@ -138,7 +138,11 @@ export async function initDomainSubscribers() {
 				});
 			} catch (error) {
 				log.error({
-					...{ error, payload },
+					...{
+						error,
+						domainId: payload.domainId,
+						organizationId: payload.organizationId,
+					},
 					message: "Failed to send domain verified email",
 				});
 			}
@@ -183,7 +187,7 @@ export async function initDomainSubscribers() {
 				});
 			} catch (error) {
 				log.error({
-					...{ error, payload },
+					...{ error, email: payload.email, domain: payload.domain },
 					message: "Failed to send DNS config email",
 				});
 			}

--- a/apps/backend/email/src/subscribers/organization.subscriber.ts
+++ b/apps/backend/email/src/subscribers/organization.subscriber.ts
@@ -47,7 +47,11 @@ export async function initOrgSubscribers() {
 				});
 			} catch (error) {
 				log.error({
-					...{ error, payload },
+					...{
+						error,
+						email: payload.email,
+						organizationName: payload.organizationName,
+					},
 					message: "Failed to send invite email",
 				});
 			}
@@ -92,7 +96,7 @@ export async function initOrgSubscribers() {
 				});
 			} catch (error) {
 				log.error({
-					...{ error, payload },
+					...{ error, userEmail: payload.userEmail, orgName: payload.orgName },
 					message: "Failed to send org joined email",
 				});
 			}

--- a/apps/backend/email/src/subscribers/test-email.subscriber.ts
+++ b/apps/backend/email/src/subscribers/test-email.subscriber.ts
@@ -22,7 +22,7 @@ export async function initTestEmailSubscribers() {
 				});
 			} catch (error) {
 				log.error({
-					...{ error, payload },
+					...{ error, to: payload.to, subject: payload.subject },
 					message: "Failed to send test email in subscriber",
 				});
 			}

--- a/apps/backend/workflow/src/handlers/domain-verification.handler.ts
+++ b/apps/backend/workflow/src/handlers/domain-verification.handler.ts
@@ -75,6 +75,17 @@ export async function processDomainVerification({
 		with: {
 			dnsRecords: {
 				where: isNull(schema.domainDnsRecord.deletedAt),
+				columns: {
+					id: true,
+					recordType: true,
+					recordTypeName: true,
+					name: true,
+					value: true,
+					fqdn: true,
+					priority: true,
+					purpose: true,
+					status: true,
+				},
 			},
 		},
 	});
@@ -91,7 +102,12 @@ export async function processDomainVerification({
 	// (e.g. pending/failed → verified), never verified → verified on re-checks.
 	const wasAlreadyVerified = domainWithRecords.systemVerified;
 	const previousStatus = domainWithRecords.status;
-	log.info({ message: "Fetched DNS records from database", domainId, records });
+	log.info({
+		message: "Fetched DNS records from database",
+		domainId,
+		recordCount: records.length,
+		recordTypeNames: records.map((r) => r.recordTypeName),
+	});
 
 	// Find mandatory DKIM verification record
 	const dkimRecord = records.find(

--- a/packages/auth/src/server/auth.ts
+++ b/packages/auth/src/server/auth.ts
@@ -282,7 +282,7 @@ export const auth = betterAuth({
 			expiresIn: 60 * 15,
 			allowedAttempts: 3,
 			async sendVerificationOTP({ email, otp, type }) {
-				log.info("server", `Sending OTP (${type}) to: ${email} (OTP: ${otp})`);
+				log.info("server", `Sending OTP (${type}) to: ${email}`);
 				if (
 					authServerConfig.DEFAULT_OTP &&
 					authServerConfig.NODE_ENV !== "development"

--- a/packages/auth/test/secret-logging.test.ts
+++ b/packages/auth/test/secret-logging.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { Glob } from "bun";
+
+const repoRoot = fileURLToPath(new URL("../../../", import.meta.url));
+
+const SCANNED_ROOTS = ["apps/backend", "packages"];
+
+const SKIPPED = [
+	"/node_modules/",
+	"/dist/",
+	"/.turbo/",
+	"/packages/code-samples/",
+	".test.ts",
+];
+
+const LOG_CALL = /(?:\blog|\bconsole)\.[a-z]+\(/g;
+
+const FORBIDDEN_IN_LOG_ARGS: { name: string; pattern: RegExp }[] = [
+	{ name: "interpolated secret", pattern: /\$\{[^}]*\b(otp|privateKey)\b/i },
+	{
+		name: "secret shorthand property",
+		pattern: /[{,]\s*(otp|privateKey)\s*[,}]/,
+	},
+	{ name: "secret property value", pattern: /\b(otp|privateKey)\s*:/i },
+	{ name: "whole event payload", pattern: /[{,]\s*payload\s*[,}]/ },
+	{ name: "whole dns record set", pattern: /[{,]\s*records\s*[,}]/ },
+];
+
+function logCallArguments(source: string): string[] {
+	const calls: string[] = [];
+	for (const match of source.matchAll(LOG_CALL)) {
+		let depth = 1;
+		let i = (match.index ?? 0) + match[0].length;
+		const start = i;
+		while (i < source.length && depth > 0) {
+			const char = source[i];
+			if (char === "(") depth++;
+			else if (char === ")") depth--;
+			i++;
+		}
+		calls.push(source.slice(start, i - 1));
+	}
+	return calls;
+}
+
+function scannedFiles(): string[] {
+	const files: string[] = [];
+	for (const root of SCANNED_ROOTS) {
+		for (const relative of new Glob("**/*.{ts,tsx}").scanSync(
+			`${repoRoot}${root}`,
+		)) {
+			const path = `${root}/${relative}`;
+			if (SKIPPED.some((skip) => `/${path}`.includes(skip))) continue;
+			files.push(path);
+		}
+	}
+	return files;
+}
+
+describe("credentials never reach a log call", () => {
+	const files = scannedFiles();
+
+	test("scans the backend and shared packages", () => {
+		expect(files.length).toBeGreaterThan(100);
+	});
+
+	test("no log or console call receives OTP, DKIM key, or raw event payload", () => {
+		const offenders: string[] = [];
+
+		for (const path of files) {
+			const source = readFileSync(`${repoRoot}${path}`, "utf8");
+			for (const args of logCallArguments(source)) {
+				for (const { name, pattern } of FORBIDDEN_IN_LOG_ARGS) {
+					if (pattern.test(args)) {
+						offenders.push(`${path}: ${name} — ${args.replace(/\s+/g, " ")}`);
+					}
+				}
+			}
+		}
+
+		expect(offenders).toEqual([]);
+	});
+});
+
+describe("DKIM private keys stay out of the verification worker", () => {
+	const handler = readFileSync(
+		`${repoRoot}apps/backend/workflow/src/handlers/domain-verification.handler.ts`,
+		"utf8",
+	);
+
+	test("the dns record query selects an explicit column allowlist", () => {
+		expect(handler).toContain("columns: {");
+		expect(handler).not.toContain("privateKey");
+	});
+});


### PR DESCRIPTION
the auth server logged every OTP in plaintext, the email worker had a leftover `console.log(payload, "OTP PAYLOAD")` debug line, and the domain verification worker logged whole DNS record rows — including the DKIM private key — on every run.

- drop the OTP from the sendVerificationOTP log line
- delete the OTP payload debug dump
- move the OTP out of the redis dedup key and into the value, since RedisCache prints keys on connection errors but never values
- restrict the workflow DNS record query to an explicit column allowlist so the private key never reaches the worker, and log counts and record types instead of full rows
- replace the eleven `...{ error, payload }` error logs in the email subscribers with explicit non-secret fields; two of them carried real credentials (a working invite link and a full rendered email body)

adds a regression test that walks every log and console call in the backend and shared packages and fails on interpolated secrets, secret named properties, or whole payload dumps.

closes #124

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Improved error and diagnostic logging to record only necessary details and reduce exposure of sensitive information.
  * OTP verification logs no longer include the one-time password.
  * OTP request identifiers no longer use the raw OTP.
  * Domain verification diagnostics now use summarized results rather than full record details.

* **Tests**
  * Added automated checks to detect credential and sensitive-data leakage in logs.
  * Expanded log parsing coverage for nested calls and special characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=63468484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=1" align="right"></picture></a>Confidence Score: 4/5</h2>

The PR is not yet safe to merge because stale OTP events can still bypass deduplication and resend an older invalid code.

<h2>Findings</h2>

1. <img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top">&nbsp;**Stale OTPs bypass deduplication** <a href="https://github.com/reloop-labs/reloop/pull/129#discussion_r3997203242">▶</a>
2. <img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top">&nbsp;**Payload dumps escape detection** <a href="https://github.com/reloop-labs/reloop/pull/129#discussion_r3997203244">▶</a>

<h3>Summary</h3>

- Removes plaintext OTPs and secret-bearing payloads from log calls.
- Uses a keyed OTP request identifier and keeps the OTP in the Redis value rather than the logged key.
- Restricts domain-verification queries to an explicit DNS-record allowlist and logs aggregate metadata.
- Adds a static regression test for common secret and payload logging patterns.

<details open><summary><h3>Diagram</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    OTP[Generated OTP] --> HMAC[Keyed request identifier]
    HMAC --> Bus[OTP event]
    Bus --> Cache[OTP stored as Redis value]
    Bus --> Email[Rendered OTP email]
    Cache --> SafeLogs[Secret-free diagnostics]

    DNS[Domain DNS rows] --> Allowlist[Explicit safe columns]
    Allowlist --> Verify[Verification worker]
    Verify --> Summary[Count and record-type logs]
```
</details>

<sub>Reviews (3) · Last reviewed commit: ["fix: stop logging the signed export down..."](https://github.com/reloop-labs/reloop/commit/617a1a4dedd74ba2862f75dc6282e3bb89727cd7)</sub>

<!-- /greptile_comment -->